### PR TITLE
Device info

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -136,6 +136,7 @@ dependencies {
 	androidTestImplementation 'androidx.benchmark:benchmark-junit4:1.0.0'
 	androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 	androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+	androidTestImplementation 'org.mockito:mockito-android:2.17.0'
     implementation "androidx.core:core-ktx:+"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 

--- a/sdk/src/androidTest/java/org/coralibre/android/sdk/internal/DeviceConfidenceLevelTest.java
+++ b/sdk/src/androidTest/java/org/coralibre/android/sdk/internal/DeviceConfidenceLevelTest.java
@@ -1,0 +1,24 @@
+package org.coralibre.android.sdk.internal;
+
+import org.coralibre.android.sdk.internal.device_info.ConfidenceLevel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DeviceConfidenceLevelTest {
+    @Test
+    public void testGetConfidenceLevelFromString() {
+        assertEquals(ConfidenceLevel.NONE, ConfidenceLevel.getConfidenceLevel("NONE"));
+        assertEquals(ConfidenceLevel.LOW, ConfidenceLevel.getConfidenceLevel("LOW"));
+        assertEquals(ConfidenceLevel.MEDIUM, ConfidenceLevel.getConfidenceLevel("MEDIUM"));
+        assertEquals(ConfidenceLevel.HIGH, ConfidenceLevel.getConfidenceLevel("HIGH"));
+    }
+
+    @Test
+    public void testGetConfidenceLevelFromInt() {
+        assertEquals(ConfidenceLevel.NONE, ConfidenceLevel.getConfidenceLevel(0));
+        assertEquals(ConfidenceLevel.LOW, ConfidenceLevel.getConfidenceLevel(1));
+        assertEquals(ConfidenceLevel.MEDIUM, ConfidenceLevel.getConfidenceLevel(2));
+        assertEquals(ConfidenceLevel.HIGH, ConfidenceLevel.getConfidenceLevel(3));
+    }
+}

--- a/sdk/src/androidTest/java/org/coralibre/android/sdk/internal/DeviceInfoTest.java
+++ b/sdk/src/androidTest/java/org/coralibre/android/sdk/internal/DeviceInfoTest.java
@@ -1,0 +1,85 @@
+package org.coralibre.android.sdk.internal;
+
+import org.coralibre.android.sdk.internal.device_info.ConfidenceLevel;
+import org.coralibre.android.sdk.internal.device_info.DeviceInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DeviceInfoTest {
+    @Test
+    public void testCompareForDifferentManufacturers() {
+        DeviceInfo device1 = new DeviceInfo("asus", "P024_1", "P024", 1, 1, ConfidenceLevel.LOW);
+        DeviceInfo device2 = new DeviceInfo("blu", "C070", "C4 2019", 1, 1, ConfidenceLevel.LOW);
+        assertTrue("device 1 earlier that device 2", 0 > device1.compareTo(device2));
+        assertTrue("device 1 later that device 2", 0 < device2.compareTo(device1));
+        assertEquals("device equals to itself", device1, device1);
+        assertEquals("device equals to itself by comparison", 0, device1.compareTo(device1));
+    }
+
+    @Test
+    public void testCompareForDifferentManufacturersCaseInsensitive() {
+        DeviceInfo device1 = new DeviceInfo("asus", "P024_1", "P024", 1, 1, ConfidenceLevel.LOW);
+        DeviceInfo device2 = new DeviceInfo("BLU", "C070", "C4 2019", 1, 1, ConfidenceLevel.LOW);
+        assertTrue("device 1 earlier that device 2", 0 > device1.compareTo(device2));
+        assertTrue("device 1 later that device 2", 0 < device2.compareTo(device1));
+        assertEquals("device equals to itself", device1, device1);
+        assertEquals("device equals to itself by comparison", 0, device1.compareTo(device1));
+    }
+
+    @Test
+    public void testCompareForDifferentModels() {
+        DeviceInfo device1 = new DeviceInfo("asus", "K019_2", "K019", 1, 1, ConfidenceLevel.LOW);
+        DeviceInfo device2 = new DeviceInfo("asus", "P024_2", "P024", 1, 1, ConfidenceLevel.LOW);
+        assertTrue("device 1 earlier that device 2", 0 > device1.compareTo(device2));
+        assertTrue("device 1 later that device 2", 0 < device2.compareTo(device1));
+        assertEquals("device equals to itself", device1, device1);
+        assertEquals("device equals to itself by comparison", 0, device1.compareTo(device1));
+    }
+
+    @Test
+    public void testCompareForDifferentModelsCaseInsensitive() {
+        DeviceInfo device1 = new DeviceInfo("asus", "K019_2", "K019", 1, 1, ConfidenceLevel.LOW);
+        DeviceInfo device2 = new DeviceInfo("asus", "P024_2", "p024", 1, 1, ConfidenceLevel.LOW);
+        assertTrue("device 1 earlier that device 2", 0 > device1.compareTo(device2));
+        assertTrue("device 1 later that device 2", 0 < device2.compareTo(device1));
+        assertEquals("device equals to itself", device1, device1);
+        assertEquals("device equals to itself by comparison", 0, device1.compareTo(device1));
+    }
+
+    @Test
+    public void testCompareForDifferentDevices() {
+        DeviceInfo device1 = new DeviceInfo("asus", "P024_1", "P024", 1, 1, ConfidenceLevel.LOW);
+        DeviceInfo device2 = new DeviceInfo("asus", "P024_2", "P024", 1, 1, ConfidenceLevel.LOW);
+        assertTrue("device 1 earlier that device 2", 0 > device1.compareTo(device2));
+        assertTrue("device 1 later that device 2", 0 < device2.compareTo(device1));
+        assertEquals("device equals to itself", device1, device1);
+        assertEquals("device equals to itself by comparison", 0, device1.compareTo(device1));
+    }
+
+    @Test
+    public void testCompareForDifferentDevicesCaseInsensitive() {
+        DeviceInfo device1 = new DeviceInfo("asus", "P024_1", "P024", 1, 1, ConfidenceLevel.LOW);
+        DeviceInfo device2 = new DeviceInfo("asus", "p024_2", "P024", 1, 1, ConfidenceLevel.LOW);
+        assertTrue("device 1 earlier that device 2", 0 > device1.compareTo(device2));
+        assertTrue("device 1 later that device 2", 0 < device2.compareTo(device1));
+        assertEquals("device equals to itself", device1, device1);
+        assertEquals("device equals to itself by comparison", 0, device1.compareTo(device1));
+    }
+
+    @Test
+    public void testCaseInsensitivityForEquals() {
+        DeviceInfo device1 = new DeviceInfo("AsUs", "p024_1", "P024", 1, 1, ConfidenceLevel.LOW);
+        DeviceInfo device2 = new DeviceInfo("asuS", "P024_1", "p024", 1, 1, ConfidenceLevel.LOW);
+        assertEquals("device equals to itself", device1, device2);
+    }
+
+    @Test
+    public void testCaseInsensitivityForComparison() {
+        DeviceInfo device1 = new DeviceInfo("AsUs", "p024_1", "P024", 1, 1, ConfidenceLevel.LOW);
+        DeviceInfo device2 = new DeviceInfo("asuS", "P024_1", "p024", 1, 1, ConfidenceLevel.LOW);
+        assertEquals("device equals to itself", device1, device2);
+        assertEquals("device equals to itself by comparison", 0, device1.compareTo(device2));
+    }
+}

--- a/sdk/src/androidTest/java/org/coralibre/android/sdk/internal/DeviceListTest.java
+++ b/sdk/src/androidTest/java/org/coralibre/android/sdk/internal/DeviceListTest.java
@@ -1,0 +1,254 @@
+package org.coralibre.android.sdk.internal;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.coralibre.android.sdk.internal.device_info.ConfidenceLevel;
+import org.coralibre.android.sdk.internal.device_info.DeviceInfo;
+import org.coralibre.android.sdk.internal.device_info.DeviceList;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.coralibre.android.sdk.internal.device_info.ConfidenceLevel.HIGH;
+import static org.coralibre.android.sdk.internal.device_info.ConfidenceLevel.LOW;
+import static org.coralibre.android.sdk.internal.device_info.ConfidenceLevel.NONE;
+import static org.coralibre.android.sdk.internal.device_info.DeviceList.DEFAULT_INFO;
+import static org.coralibre.android.sdk.internal.device_info.DeviceList.DEVICE_INFO_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DeviceListTest {
+    private static final DeviceInfo TEST_DEVICE = new DeviceInfo(
+            "a", "b", "c", 1, -2, HIGH);
+
+    private static final DeviceInfo TEST_DEVICE_GETTING_LIST_VALUES = new DeviceInfo(
+            "a", "b", "c", DEFAULT_INFO.getRssiCorrection(), DEFAULT_INFO.getTx(), NONE);
+
+    private Context context;
+    private DeviceList deviceList;
+
+    private DeviceList.FindingsResult runFindingsInList(final DeviceList deviceList,
+                                                        final String manufacturer,
+                                                        final String device,
+                                                        final String model) throws Exception {
+        Method findingsInListMethod = DeviceList.class.getDeclaredMethod("findingsInList",
+                String.class, String.class, String.class);
+        findingsInListMethod.setAccessible(true);
+        return (DeviceList.FindingsResult) findingsInListMethod.invoke(
+                deviceList, manufacturer, device, model);
+    }
+
+    private DeviceInfo runGetAverageOfFindings(DeviceList deviceList, List<DeviceInfo> findings) throws Exception {
+        Method getAverageOfFindingsMethod = DeviceList.class.getDeclaredMethod(
+                "getAverageOfFindings", List.class);
+        getAverageOfFindingsMethod.setAccessible(true);
+        return (DeviceInfo) getAverageOfFindingsMethod.invoke(deviceList, findings);
+    }
+
+    private DeviceInfo runGetBestFittingInfoFormList(DeviceList deviceList,
+                                                     String oem,
+                                                     String device,
+                                                     String model) throws Exception {
+        Method getBestFittingInfoFromListMethod = DeviceList.class.getDeclaredMethod(
+                "getBestFittingInfoFromList", String.class, String.class, String.class);
+        getBestFittingInfoFromListMethod.setAccessible(true);
+        return (DeviceInfo) getBestFittingInfoFromListMethod.invoke(deviceList, oem, device, model);
+    }
+
+    private DeviceInfo runGetOwnDeviceInfo(DeviceList deviceList,
+                                           String oem,
+                                           String device,
+                                           String model) throws Exception {
+        Method getOwnDeviceInfoMethod = DeviceList.class.getDeclaredMethod(
+                "getOwnDeviceInfo", String.class, String.class, String.class);
+        getOwnDeviceInfoMethod.setAccessible(true);
+        return (DeviceInfo) getOwnDeviceInfoMethod.invoke(deviceList, oem, device, model);
+    }
+
+
+    @Before
+    public void setup() throws Exception {
+        context = InstrumentationRegistry.getInstrumentation().getContext();
+        SharedPreferences sharedPreferences = Mockito.mock(SharedPreferences.class);
+        SharedPreferences.Editor editor = Mockito.mock(SharedPreferences.Editor.class);
+        when(sharedPreferences.edit()).thenReturn(editor);
+        when(editor.putString(any(), any())).thenReturn(editor);
+        deviceList = new DeviceList(context, sharedPreferences);
+    }
+
+
+    private static void assertDevice(DeviceInfo info,
+                                     String manu,
+                                     String device,
+                                     String model,
+                                     int rssi,
+                                     int tx,
+                                     ConfidenceLevel clevel) {
+        assertEquals(manu, info.getManufacturer());
+        assertEquals(device, info.getDevice());
+        assertEquals(model, info.getModel());
+        assertEquals(rssi, info.getRssiCorrection());
+        assertEquals(tx, info.getTx());
+        assertEquals(clevel, info.getCalibrationConfidence());
+    }
+
+    @Test
+    public void testLoadDeviceList() throws Exception {
+        DeviceInfo[] deviceList = DeviceList.loadDeviceInfoTable(context);
+        for (DeviceInfo i : deviceList) {
+            System.out.println(i);
+            assertTrue("manufacturer seems to be empty", i.getManufacturer().length() > 0);
+            assertFalse("confidence may not be NONE", i.getCalibrationConfidence() == NONE);
+        }
+    }
+
+    @Test
+    public void testLoadDeviceListLength() throws Exception {
+        DeviceInfo[] deviceList = DeviceList.loadDeviceInfoTable(context);
+        assertEquals(11809, deviceList.length);
+    }
+
+    @Test
+    public void testGetInfoForKnownDevice() throws Exception {
+        DeviceInfo info = deviceList.getExactInfo("asus", "P024_1", "P024");
+        assertDevice(info, "asus", "P024_1", "P024", 3, -22, LOW);
+    }
+
+    @Test
+    public void testGetInfoForUnknownDevice() throws Exception {
+        DeviceInfo info = deviceList.getExactInfo("testphone", "versionone", "modelone");
+        assertDevice(info, "testphone", "versionone", "modelone", 4, -25, NONE);
+    }
+
+    @Test
+    public void testFindingsInListForUnknownSamsungZaninDevice() throws Exception {
+        DeviceList.FindingsResult result =
+                runFindingsInList(deviceList, "samsung", "zanin", "unknown");
+        assertEquals(2340, result.manufacturerFindings.size());
+        assertEquals(3, result.oemDeviceFindings.size());
+        assertEquals(0, result.oemModelFindings.size());
+    }
+
+    @Test
+    public void testFindingsInListForUnknownAsusA001dModel() throws Exception {
+        DeviceList.FindingsResult result =
+                runFindingsInList(deviceList, "asus", "unknown", "ASUS_A001D");
+        assertEquals(347, result.manufacturerFindings.size());
+        assertEquals(0, result.oemDeviceFindings.size());
+        assertEquals(2, result.oemModelFindings.size());
+    }
+
+    @Test
+    public void testGetAverageOfSamsungZaninDevice() throws Exception {
+        DeviceList.FindingsResult findings =
+                runFindingsInList(deviceList, "samsung", "zanin", "unknown");
+        DeviceInfo oemAverage = runGetAverageOfFindings(deviceList, findings.manufacturerFindings);
+        DeviceInfo deviceAverage = runGetAverageOfFindings(deviceList, findings.oemDeviceFindings);
+        DeviceInfo modelAverage = runGetAverageOfFindings(deviceList, findings.oemModelFindings);
+
+        assertEquals(5, oemAverage.getRssiCorrection());
+        assertEquals(-23, oemAverage.getTx());
+        assertEquals(NONE, oemAverage.getCalibrationConfidence());
+
+        assertEquals(5, deviceAverage.getRssiCorrection());
+        assertEquals(-24, deviceAverage.getTx());
+        assertEquals(NONE, deviceAverage.getCalibrationConfidence());
+
+        assertEquals(0, modelAverage.getRssiCorrection());
+        assertEquals(0, modelAverage.getTx());
+        assertEquals(NONE, modelAverage.getCalibrationConfidence());
+    }
+
+    @Test
+    public void testBestFittingForOneDeviceMatch() throws Exception {
+        DeviceInfo info = runGetBestFittingInfoFormList(deviceList, "google", "blueline", "unknown");
+        assertEquals(5, info.getRssiCorrection());
+        assertEquals(-33, info.getTx());
+        assertEquals(HIGH, info.getCalibrationConfidence());
+    }
+
+    @Test
+    public void testBestFittingForOneModelMatch() throws Exception {
+        DeviceInfo info = runGetBestFittingInfoFormList(deviceList, "google", "unknown", "Pixel 3");
+        assertEquals(5, info.getRssiCorrection());
+        assertEquals(-33, info.getTx());
+        assertEquals(HIGH, info.getCalibrationConfidence());
+    }
+
+    @Test
+    public void testBestFittingForKnownVendor() throws Exception {
+        DeviceInfo info = runGetBestFittingInfoFormList(deviceList, "samsung", "unknown", "unknown");
+        assertEquals(5, info.getRssiCorrection());
+        assertEquals(-23, info.getTx());
+        assertEquals(NONE, info.getCalibrationConfidence());
+    }
+
+    @Test
+    public void testGetOwnInfoForKnownDevice() throws Exception {
+        DeviceInfo info = runGetOwnDeviceInfo(deviceList, "google", "blueline", "Pixel 3");
+        assertEquals(5, info.getRssiCorrection());
+        assertEquals(-33, info.getTx());
+        assertEquals(HIGH, info.getCalibrationConfidence());
+    }
+
+    @Test
+    public void testGetOwnInfoForUnknownDevice() throws Exception {
+        DeviceInfo info = runGetOwnDeviceInfo(deviceList, "unknown", "unknown", "unknown");
+        assertEquals(4, info.getRssiCorrection());
+        assertEquals(-25, info.getTx());
+        assertEquals(NONE, info.getCalibrationConfidence());
+    }
+
+    @Test
+    public void testGetOwnInfoFromSharedPreferences() throws Exception {
+        final SharedPreferences prefs = Mockito.mock(SharedPreferences.class);
+        when(prefs.contains(DEVICE_INFO_KEY)).thenReturn(true);
+        when(prefs.getString(DEVICE_INFO_KEY, DEFAULT_INFO.toString()))
+                .thenReturn(TEST_DEVICE.toString());
+
+        DeviceList deviceList = new DeviceList(context, prefs);
+        DeviceInfo info = runGetOwnDeviceInfo(deviceList,
+                TEST_DEVICE.getManufacturer(),
+                TEST_DEVICE.getDevice(),
+                TEST_DEVICE.getModel());
+
+        assertEquals(TEST_DEVICE.getManufacturer(), info.getManufacturer());
+        assertEquals(TEST_DEVICE.getDevice(), info.getDevice());
+        assertEquals(TEST_DEVICE.getModel(), info.getModel());
+        assertEquals(TEST_DEVICE.getRssiCorrection(), info.getRssiCorrection());
+        assertEquals(TEST_DEVICE.getTx(), info.getTx());
+        assertEquals(TEST_DEVICE.getCalibrationConfidence(), info.getCalibrationConfidence());
+    }
+
+    @Test
+    public void testGetOwnInfoFromListAndSaveItInPreferences() throws Exception {
+        final SharedPreferences prefs = Mockito.mock(SharedPreferences.class);
+        final SharedPreferences.Editor editor = Mockito.mock(SharedPreferences.Editor.class);
+        when(prefs.contains(DEVICE_INFO_KEY)).thenReturn(false);
+        when(prefs.edit()).thenReturn(editor);
+        when(editor.putString(any(), any())).thenReturn(editor);
+
+        DeviceList deviceList = new DeviceList(context, prefs);
+        DeviceInfo info = runGetOwnDeviceInfo(deviceList,
+                TEST_DEVICE.getManufacturer(),
+                TEST_DEVICE.getDevice(),
+                TEST_DEVICE.getModel());
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
+        verify(editor).putString(keyCaptor.capture(), valueCaptor.capture());
+        assertEquals(DEVICE_INFO_KEY, keyCaptor.getValue());
+        assertEquals(TEST_DEVICE_GETTING_LIST_VALUES.toString(), valueCaptor.getValue());
+    }
+}

--- a/sdk/src/main/java/org/coralibre/android/sdk/internal/device_info/ConfidenceLevel.java
+++ b/sdk/src/main/java/org/coralibre/android/sdk/internal/device_info/ConfidenceLevel.java
@@ -1,0 +1,58 @@
+package org.coralibre.android.sdk.internal.device_info;
+
+public enum ConfidenceLevel {
+    NONE,
+    LOW,
+    MEDIUM,
+    HIGH;
+
+    private static final int LOW_INT = 1;
+    private static final int MEDIUM_INT = 2;
+    private static final int HIGH_INT = 3;
+    private static final String LOW_STR = "LOW";
+    private static final String MEDIUM_STR = "MEDIUM";
+    private static final String HIGH_STR = "HIGH";
+    private static final String NONE_STR = "NONE";
+
+    public static ConfidenceLevel getConfidenceLevel(int raw) {
+        switch (raw) {
+            case LOW_INT:
+                return ConfidenceLevel.LOW;
+            case MEDIUM_INT:
+                return ConfidenceLevel.MEDIUM;
+            case HIGH_INT:
+                return ConfidenceLevel.HIGH;
+            default:
+                return ConfidenceLevel.NONE;
+        }
+    }
+
+    public static ConfidenceLevel getConfidenceLevel(String raw) throws RuntimeException {
+        switch (raw) {
+            case NONE_STR:
+                return ConfidenceLevel.NONE;
+            case LOW_STR:
+                return ConfidenceLevel.LOW;
+            case MEDIUM_STR:
+                return ConfidenceLevel.MEDIUM;
+            case HIGH_STR:
+                return ConfidenceLevel.HIGH;
+            default:
+                throw new RuntimeException("Unknown option: " + raw);
+        }
+    }
+
+    @Override
+    public String toString() {
+        switch (this) {
+            case LOW:
+                return LOW_STR;
+            case MEDIUM:
+                return MEDIUM_STR;
+            case HIGH:
+                return HIGH_STR;
+            default:
+                return NONE_STR;
+        }
+    }
+}

--- a/sdk/src/main/java/org/coralibre/android/sdk/internal/device_info/DeviceInfo.java
+++ b/sdk/src/main/java/org/coralibre/android/sdk/internal/device_info/DeviceInfo.java
@@ -1,0 +1,97 @@
+package org.coralibre.android.sdk.internal.device_info;
+
+import static org.coralibre.android.sdk.internal.device_info.ConfidenceLevel.getConfidenceLevel;
+
+public class DeviceInfo implements Comparable<DeviceInfo> {
+
+    private String manufacturer;
+    private String device;
+    private String model;
+    private int rssiCorrection;
+    private int tx;
+    private ConfidenceLevel calibrationConfidence;
+
+    public DeviceInfo(String manufacturer,
+                      String device,
+                      String model,
+                      int rssiCorrection,
+                      int tx,
+                      ConfidenceLevel calibrationConfidence) {
+        this.manufacturer = manufacturer;
+        this.device = device;
+        this.model = model;
+        this.rssiCorrection = rssiCorrection;
+        this.tx = tx;
+        this.calibrationConfidence = calibrationConfidence;
+    }
+
+    public DeviceInfo(String rawString) {
+        String[] row = rawString.split(",");
+        this.manufacturer = row[0];
+        this.device = row[1];
+        this.model = row[2];
+        this.rssiCorrection = Integer.parseInt(row[3]);
+        this.tx = Integer.parseInt(row[4]);
+        try {
+            this.calibrationConfidence = getConfidenceLevel(Integer.parseInt(row[5]));
+        } catch (NumberFormatException e) {
+            this.calibrationConfidence = getConfidenceLevel(row[5]);
+        }
+    }
+
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    public String getDevice() {
+        return device;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public int getRssiCorrection() {
+        return rssiCorrection;
+    }
+
+    public int getTx() {
+        return tx;
+    }
+
+    public ConfidenceLevel getCalibrationConfidence() {
+        return calibrationConfidence;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s,%s,%s,%d,%d,%s",
+                manufacturer, device, model, rssiCorrection, tx, calibrationConfidence);
+    }
+
+    @Override
+    public boolean equals(Object otherInfo) {
+        if (otherInfo.getClass() != getClass()) return false;
+        DeviceInfo otherDeviceInfo = (DeviceInfo) otherInfo;
+        return otherDeviceInfo.getManufacturer().equalsIgnoreCase(manufacturer)
+                && otherDeviceInfo.getDevice().equalsIgnoreCase(device)
+                && otherDeviceInfo.getModel().equalsIgnoreCase(model)
+                && otherDeviceInfo.getRssiCorrection() == rssiCorrection
+                && otherDeviceInfo.getTx() == tx
+                && otherDeviceInfo.getCalibrationConfidence() == calibrationConfidence;
+    }
+
+    @Override
+    public int compareTo(DeviceInfo otherInfo) {
+        if (manufacturer.compareToIgnoreCase(otherInfo.manufacturer) != 0) {
+            return manufacturer.compareToIgnoreCase(otherInfo.manufacturer);
+        }
+        if (model.compareToIgnoreCase(otherInfo.model) != 0) {
+            return model.compareToIgnoreCase(otherInfo.model);
+        }
+        if (device.compareToIgnoreCase(otherInfo.device) != 0) {
+            return device.compareToIgnoreCase(otherInfo.device);
+        }
+        return 0;
+    }
+}

--- a/sdk/src/main/java/org/coralibre/android/sdk/internal/device_info/DeviceList.java
+++ b/sdk/src/main/java/org/coralibre/android/sdk/internal/device_info/DeviceList.java
@@ -1,0 +1,204 @@
+package org.coralibre.android.sdk.internal.device_info;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.preference.PreferenceManager;
+import android.util.Log;
+
+import org.coralibre.android.sdk.BuildConfig;
+import org.coralibre.android.sdk.R;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.coralibre.android.sdk.internal.device_info.ConfidenceLevel.LOW;
+import static org.coralibre.android.sdk.internal.device_info.ConfidenceLevel.NONE;
+
+public class DeviceList {
+    private static final String TAG = DeviceInfo.class.toString();
+
+    public static final String DEVICE_INFO_KEY = "DeviceList_device_info_key";
+
+    private static final int LIST_FILE_ID = R.raw.en_calibration_2020_08_12;
+    private static final int LIST_LINE_COUNT = 11810;
+    public static final DeviceInfo DEFAULT_INFO = new DeviceInfo(
+            "unknown", "unknown", "unknown", 4, -25, NONE);
+
+    final DeviceInfo[] deviceList;
+    final SharedPreferences sharedPreferences;
+
+    public class FindingsResult {
+        public final List<DeviceInfo> manufacturerFindings;
+        public final List<DeviceInfo> oemDeviceFindings;
+        public final List<DeviceInfo> oemModelFindings;
+
+        public FindingsResult(List<DeviceInfo> manufacturerFindings,
+                              List<DeviceInfo> oemDeviceFindings,
+                              List<DeviceInfo> oemModelFindings) {
+            this.manufacturerFindings = Collections.unmodifiableList(manufacturerFindings);
+            this.oemDeviceFindings = Collections.unmodifiableList(oemDeviceFindings);
+            this.oemModelFindings = Collections.unmodifiableList(oemModelFindings);
+        }
+    }
+
+    public DeviceList(Context context, SharedPreferences sharedPrefs) throws IOException {
+        deviceList = loadDeviceInfoTable(context);
+        sharedPreferences = sharedPrefs;
+    }
+
+    public static DeviceInfo[] loadDeviceInfoTable(Context context) throws IOException {
+        BufferedReader infoCVS = new BufferedReader(new InputStreamReader(
+                context.getResources().openRawResource(LIST_FILE_ID)));
+        DeviceInfo[] deviceList = new DeviceInfo[LIST_LINE_COUNT - 1];
+        String line = infoCVS.readLine(); // discard the first line as it just contains the header
+        int i = 0;
+        while ((line = infoCVS.readLine()) != null) {
+            deviceList[i] = new DeviceInfo(line);
+            i++;
+        }
+        infoCVS.close();
+        return deviceList;
+    }
+
+    /**
+     * Tries to find the exact device in the list based on the given parameters. If the device
+     * can not be found it will return the default device info, which is an average over the whole list.
+     * @param manufacturer oem/manufacturer of the device
+     * @param device name of the device
+     * @param model name of the specific model
+     * @return the exact device info from the list or the default device info
+     */
+    public DeviceInfo getExactInfo(final String manufacturer, final String device, final String model) {
+        int index = Arrays.binarySearch(deviceList, new DeviceInfo(manufacturer, device, model, 0, 0, NONE));
+        if (0 < index && deviceList[index].getModel().equals(model)) {
+            return deviceList[index];
+        } else {
+            return new DeviceInfo(manufacturer, device, model,
+                    DEFAULT_INFO.getRssiCorrection(),
+                    DEFAULT_INFO.getTx(),
+                    DEFAULT_INFO.getCalibrationConfidence());
+        }
+    }
+
+    private FindingsResult findingsInList(final String manufacturer, final String device, final String model) {
+        ArrayList<DeviceInfo> manufacturerFindings = new ArrayList<>();
+        ArrayList<DeviceInfo> oemDeviceFindings = new ArrayList<>();
+        ArrayList<DeviceInfo> oemModelFindings = new ArrayList<>();
+
+        for (DeviceInfo i : deviceList) {
+            if (manufacturer.toLowerCase().equals(i.getManufacturer().toLowerCase())) {
+                manufacturerFindings.add(i);
+
+                if (device.toLowerCase().equals(i.getDevice().toLowerCase())) {
+                    oemDeviceFindings.add(i);
+                }
+                if (model.toLowerCase().equals(i.getModel().toLowerCase())) {
+                    oemModelFindings.add(i);
+                }
+            }
+        }
+        return new FindingsResult(manufacturerFindings, oemDeviceFindings, oemModelFindings);
+    }
+
+    private static DeviceInfo getAverageOfFindings(List<DeviceInfo> findings) {
+        boolean allConfidenceGreaterLow = true;
+        int rssiSum = 0;
+        int txSum = 0;
+        for (DeviceInfo i : findings) {
+            rssiSum += i.getRssiCorrection();
+            txSum += i.getTx();
+            if (i.getCalibrationConfidence() == LOW) allConfidenceGreaterLow = false;
+        }
+
+        return findings.size() == 0
+                ? new DeviceInfo(Build.MANUFACTURER, Build.DEVICE, Build.MODEL, 0, 0, NONE)
+                : new DeviceInfo(Build.MANUFACTURER, Build.DEVICE, Build.MODEL,
+                rssiSum / findings.size(),
+                txSum / findings.size(),
+                allConfidenceGreaterLow ? LOW : NONE);
+    }
+
+    /**
+     * Tries to calculate an accurate average based on similar manufacturer device or model.
+     * This method tries to accomplish this by going through several steps. If one step
+     * did not yield useful information the next step will be taken. The further down these
+     * steps go the less accurate the result will be:
+     * - If there is a full match on oem/device/model, take that
+     * - If there is exactly one match with same oem/device or same oem/model, take that
+     * - If there matches with same oem/device or same oem/model and confidence > LOW, take the average of them and set confidence to LOW
+     * - If there are matches with same oem and confidence > LOW, take the average of them and set confidence to LOW
+     * - Fallback should better not be zero, but more like industry average: RSSI: -3, TX: -25 (and confidence to LOWEST)
+     *
+     * Before using this method the getExactDevice() method should be called.
+     * @param manufacturer oem/manufacturer of the device
+     * @param device name of the device
+     * @param model name of the specific model
+     * @return a DeviceInfo calculated by the steps described earlier
+     */
+    private DeviceInfo getBestFittingInfoFromList(String manufacturer,
+                                                  String device,
+                                                  String model) {
+        //try to find oem/device oem/model match
+
+        FindingsResult findings = findingsInList(manufacturer, device, model);
+        if (findings.oemDeviceFindings.size() == 1) {
+            return findings.oemDeviceFindings.get(0);
+        }
+        if (findings.oemModelFindings.size() == 1) {
+            return findings.oemModelFindings.get(0);
+        }
+
+        if (findings.oemDeviceFindings.size() > 1) {
+            DeviceInfo info = getAverageOfFindings(findings.oemDeviceFindings);
+            if (info.getCalibrationConfidence() == LOW) {
+                return info;
+            }
+        }
+
+        if (findings.oemModelFindings.size() > 1) {
+            DeviceInfo info = getAverageOfFindings(findings.oemModelFindings);
+            if (info.getCalibrationConfidence() == LOW) {
+                return info;
+            }
+        }
+
+        if (findings.manufacturerFindings.size() > 1) {
+            return getAverageOfFindings(findings.manufacturerFindings);
+        }
+
+        return new DeviceInfo(manufacturer, device, model,
+                DEFAULT_INFO.getRssiCorrection(), DEFAULT_INFO.getTx(), NONE);
+    }
+
+    private DeviceInfo getOwnDeviceInfo(String manufacturer,
+                                        String device,
+                                        String model) {
+        if (sharedPreferences.contains(DEVICE_INFO_KEY)) {
+            final DeviceInfo deviceInfo = new DeviceInfo(sharedPreferences.getString(DEVICE_INFO_KEY, DEFAULT_INFO.toString()));
+            if (BuildConfig.DEBUG)
+                Log.d(TAG, "get from shared prefs: " +
+                        deviceInfo.toString());
+            return deviceInfo;
+        }
+        //
+        DeviceInfo deviceInfo = getExactInfo(manufacturer, device, model);
+        if (deviceInfo.getCalibrationConfidence() == NONE) {
+            deviceInfo = getBestFittingInfoFromList(manufacturer, device, model);
+        }
+
+        sharedPreferences.edit().putString(DEVICE_INFO_KEY, deviceInfo.toString()).apply();
+        if (BuildConfig.DEBUG) Log.d(TAG, "get from list: " + deviceInfo.toString());
+        return deviceInfo;
+    }
+
+    public static DeviceInfo getOwnDeviceInfo(Context context) throws IOException {
+        return new DeviceList(context, PreferenceManager.getDefaultSharedPreferences(context))
+                .getOwnDeviceInfo(Build.MANUFACTURER, Build.DEVICE, Build.MODEL);
+    }
+}

--- a/sdk/src/main/res/raw/en_calibration_2020_08_12.csv
+++ b/sdk/src/main/res/raw/en_calibration_2020_08_12.csv
@@ -1,0 +1,11810 @@
+oem,device, model,rssi correction,tx,calibration confidence
+asus,K015,AST21,3,-22,1
+asus,terra_cheets,ASUS Chromebook C202SA,3,-22,1
+asus,minnie_cheets,ASUS Chromebook Flip C100PA,3,-22,1
+asus,bob_cheets,ASUS Chromebook Flip C101PA,3,-22,1
+asus,cave_cheets,ASUS Chromebook Flip C302,3,-22,1
+asus,ASUS-K00S,ASUS K00S,3,-22,1
+asus,K00X,ASUS MeMO Pad 7,3,-22,1
+asus,TF300T,ASUS Pad TF300T,3,-22,1
+asus,TF700T,ASUS Pad TF700T,3,-22,1
+asus,ASUS-T00D,ASUS PadFone X,3,-22,1
+asus,ASUS-T00S,ASUS PadFone X mini,3,-22,1
+asus,P1801-T,ASUS Tablet P1801-T,3,-22,1
+asus,P1802-T,ASUS Tablet P1802-T,3,-22,1
+asus,TF300T,ASUS Transformer 300,3,-22,1
+asus,TF300T,ASUS Transformer Pad TF300T,3,-22,1
+asus,TF300TG,ASUS Transformer Pad TF300TG,3,-22,1
+asus,TF300TL,ASUS Transformer Pad TF300TL,3,-22,1
+asus,TF502T,ASUS Transformer Pad TF502T,3,-22,1
+asus,TF600T,ASUS Transformer Pad TF600T,3,-22,1
+asus,TF700KL,ASUS Transformer Pad TF700KL,3,-22,1
+asus,TF700T,ASUS Transformer Pad TF700T,3,-22,1
+asus,ASUS_Z00D,ASUS ZenFone 2,3,-22,1
+asus,ASUS_Z00D,ASUS ZenFone 2E,3,-22,1
+asus,anthias,ASUS ZenWatch,3,-22,1
+asus,wren,ASUS ZenWatch 2,3,-22,1
+asus,sparrow,ASUS ZenWatch 2,3,-22,1
+asus,swift,ASUS ZenWatch 3,3,-22,1
+asus,ASUS_A001,ASUS_A001,9,-25,3
+asus,ASUS_A001D_2,ASUS_A001D,3,-22,1
+asus,ASUS_A001D_1,ASUS_A001D,3,-22,1
+asus,ASUS_A002_2,ASUS_A002,3,-22,1
+asus,ASUS_A002,ASUS_A002,3,-22,1
+asus,ASUS_A002_1,ASUS_A002A,3,-22,1
+asus,ASUS_A006,ASUS_A006,3,-22,1
+asus,ASUS_A007,ASUS_A007,3,-22,1
+asus,ASUS_A009,ASUS_A009,3,-22,1
+asus,ASUS_I001_1,ASUS_I001D,3,-22,1
+asus,ASUS_I01WD,ASUS_I01WD,3,-22,1
+asus,ASUS_L001_2,ASUS_L001,3,-22,1
+asus,ASUS_L001_1,ASUS_L001,3,-22,1
+asus,ASUS_P00I,ASUS_P00I,3,-22,1
+asus,ASUS_P00J,ASUS_P00J,3,-22,1
+asus,ASUS_T00E,ASUS_T00E,3,-22,1
+asus,ASUS_T00F,ASUS_T00F,3,-22,1
+asus,ASUS_T00F1,ASUS_T00F,3,-22,1
+asus,ASUS_T00G,ASUS_T00G,3,-22,1
+asus,ASUS_T00I,ASUS_T00I,3,-22,1
+asus,ASUS_T00I,ASUS_T00I-D,3,-22,1
+asus,ASUS_T00J1,ASUS_T00J,3,-22,1
+asus,ASUS_T00J,ASUS_T00J,3,-22,1
+asus,ASUS_T00K,ASUS_T00K,3,-22,1
+asus,ASUS_T00N,ASUS_T00N,3,-22,1
+asus,ASUS_T00P,ASUS_T00P,3,-22,1
+asus,ASUS_T00Q,ASUS_T00Q,3,-22,1
+asus,ASUS-T00S,ASUS_T00T,3,-22,1
+asus,ASUS_X002,ASUS_X002,3,-22,1
+asus,ASUS_X003,ASUS_X003,3,-22,1
+asus,ASUS_X005,ASUS_X005,3,-22,1
+asus,ASUS_X007D,ASUS_X007D,3,-22,1
+asus,ASUS_X008,ASUS_X008D,0,-21,1
+asus,ASUS_X008_1,ASUS_X008D,0,-21,1
+asus,ASUS_X008,ASUS_X008DA,0,-21,1
+asus,ASUS_X008_1,ASUS_X008DA,0,-21,1
+asus,ASUS_X008_1,ASUS_X008DB,0,-21,1
+asus,ASUS_X008,ASUS_X008DB,0,-21,1
+asus,ASUS_X008_1,ASUS_X008DC,0,-21,3
+asus,ASUS_X009D_2,ASUS_X009DB,3,-22,1
+asus,ASUS_X00AD_2,ASUS_X00AD,3,-22,1
+asus,ASUS_X00BD_1,ASUS_X00BD,3,-22,1
+asus,ASUS_X00DD,ASUS_X00DD,3,-22,1
+asus,ASUS_X00DD,ASUS_X00DDA,3,-22,1
+asus,ASUS_X00G_1,ASUS_X00GD,3,-22,1
+asus,ASUS_X00HD_4,ASUS_X00HD,3,-22,1
+asus,ASUS_X00HD_5,ASUS_X00HD,3,-22,1
+asus,ASUS_X00HD_1,ASUS_X00HD,3,-22,1
+asus,ASUS_X00HD_3,ASUS_X00HD,3,-22,1
+asus,ASUS_X00HD_2,ASUS_X00HD,3,-22,1
+asus,ASUS_X00HD_3,ASUS_X00HDA,3,-22,1
+asus,ASUS_X00IDC,ASUS_X00ID,3,-22,1
+asus,ASUS_X00IDB,ASUS_X00ID,3,-22,1
+asus,ASUS_X00ID,ASUS_X00ID,3,-22,1
+asus,ASUS_X00LD_1,ASUS_X00LD,3,-22,1
+asus,ASUS_X00LD_3,ASUS_X00LDA,3,-22,1
+asus,ASUS_X00LD_2,ASUS_X00LDB,3,-22,1
+asus,ASUS_X00P_4,ASUS_X00PD,3,-22,1
+asus,ASUS_X00P_8,ASUS_X00PD,3,-22,1
+asus,ASUS_X00P_1,ASUS_X00PD,3,-22,1
+asus,ASUS_X00P_3,ASUS_X00PD,3,-22,1
+asus,ASUS_X00P_6,ASUS_X00PD,3,-22,1
+asus,ASUS_X00P_2,ASUS_X00PD,3,-22,1
+asus,ASUS_X00QD,ASUS_X00QD,3,-22,1
+asus,ASUS_X00QD,ASUS_X00QSA,3,-22,1
+asus,ASUS_X00R_3,ASUS_X00RD,3,-22,1
+asus,ASUS_X00R_6,ASUS_X00RD,3,-22,1
+asus,ASUS_X00R_2,ASUS_X00RD,3,-22,1
+asus,ASUS_X00R_5,ASUS_X00RD,3,-22,1
+asus,ASUS_X00R_1,ASUS_X00RD,3,-22,1
+asus,ASUS_X00R_7,ASUS_X00RD,3,-22,1
+asus,ASUS_X00T_4,ASUS_X00TD,2,-26,1
+asus,ASUS_X00T_2,ASUS_X00TD,2,-26,1
+asus,ASUS_X00T_8,ASUS_X00TD,2,-26,1
+asus,ASUS_X00T_3,ASUS_X00TD,2,-26,3
+asus,ASUS_X00T_6,ASUS_X00TD,2,-26,1
+asus,ASUS_X00T_6,ASUS_X00TDB,2,-26,1
+asus,ASUS_X00T_8,ASUS_X00TDB,2,-26,1
+asus,ASUS_X00T_2,ASUS_X00TDB,2,-26,1
+asus,ASUS_X013D_2,ASUS_X013DA,3,-22,1
+asus,ASUS_X013D_1,ASUS_X013DA,3,-22,1
+asus,ASUS_X013D_2,ASUS_X013DB,3,-22,1
+asus,ASUS_X013D_1,ASUS_X013DB,3,-22,1
+asus,ASUS_X014D_1,ASUS_X014D,3,-22,1
+asus,ASUS_X014D_2,ASUS_X014D,3,-22,1
+asus,ASUS_X017D_1,ASUS_X017D,3,-22,1
+asus,ASUS_X017D_2,ASUS_X017DA,3,-22,1
+asus,ASUS_X018_2,ASUS_X018D,2,-22,1
+asus,ASUS_X018_1,ASUS_X018D,2,-22,1
+asus,ASUS_X018_4,ASUS_X018D,2,-22,3
+asus,ASUS_X01A_1,ASUS_X01AD,3,-22,1
+asus,ASUS_X01BD_2,ASUS_X01BDA,2,-25,1
+asus,ASUS_X01BD_1,ASUS_X01BDA,2,-25,3
+asus,ASUS_X550,ASUS_X550,3,-22,1
+asus,ASUS_Z002,ASUS_Z002,3,-22,1
+asus,ASUS_Z007,ASUS_Z007,3,-22,1
+asus,Z008_1,ASUS_Z008D,3,-22,1
+asus,Z00A,ASUS_Z00AD,3,-22,1
+asus,Z00A_3,ASUS_Z00AD,3,-22,1
+asus,Z00A_1,ASUS_Z00AD,3,-22,1
+asus,Z00A,ASUS_Z00ADA,3,-22,1
+asus,Z00A_1,ASUS_Z00ADB,3,-22,1
+asus,ASUS_Z00E_3,ASUS_Z00ED,3,-22,1
+asus,ASUS_Z00E_4,ASUS_Z00ED,3,-22,1
+asus,ASUS_Z00E_2,ASUS_Z00ED,3,-22,1
+asus,ASUS_Z00E_1,ASUS_Z00ED,3,-22,1
+asus,ASUS_Z00E_2,ASUS_Z00EDB,3,-22,1
+asus,ASUS_Z00L_63C,ASUS_Z00LD,3,-22,1
+asus,ASUS_Z00L_63A,ASUS_Z00LD,3,-22,1
+asus,ASUS_Z00L_63,ASUS_Z00LD,3,-22,1
+asus,ASUS_Z00L_93,ASUS_Z00LD,3,-22,1
+asus,ASUS_Z00L_63,ASUS_Z00LDC,3,-22,1
+asus,ASUS_Z00M,ASUS_Z00MD,3,-22,1
+asus,ASUS_Z00RD_7,ASUS_Z00RD,3,-22,1
+asus,ASUS_Z00RD_5,ASUS_Z00RD,3,-22,1
+asus,ASUS_Z00SD,ASUS_Z00SD,3,-22,1
+asus,ASUS_Z00T,ASUS_Z00TD,3,-22,1
+asus,ASUS_Z00U_1,ASUS_Z00UD,3,-22,1
+asus,ASUS_Z00U_2,ASUS_Z00UD,3,-22,1
+asus,ASUS_Z00U_1,ASUS_Z00UDA,3,-22,1
+asus,ASUS_Z00VD,ASUS_Z00VD,3,-22,1
+asus,ASUS_Z00W_63,ASUS_Z00WD,3,-22,1
+asus,Z00X_1,ASUS_Z00XS,3,-22,1
+asus,Z00X,ASUS_Z00XS,3,-22,1
+asus,Z00X_2,ASUS_Z00XS,3,-22,1
+asus,Z00X_1,ASUS_Z00XSA,3,-22,1
+asus,Z00X,ASUS_Z00XSA,3,-22,1
+asus,Z00X,ASUS_Z00XSB,3,-22,1
+asus,ASUS_Z00YD,ASUS_Z00YD,3,-22,1
+asus,ASUS_Z010,ASUS_Z010D,2,-18,1
+asus,ASUS_Z010_CD,ASUS_Z010D,2,-18,3
+asus,ASUS_Z010,ASUS_Z010DA,2,-18,1
+asus,ASUS_Z010_CD,ASUS_Z010DA,2,-18,1
+asus,ASUS_Z010,ASUS_Z010DB,2,-18,1
+asus,ASUS_Z010_2,ASUS_Z010DD,2,-18,1
+asus,ASUS_Z011,ASUS_Z011D,3,-22,1
+asus,ASUS_Z012D,ASUS_Z012D,3,-22,1
+asus,ASUS_Z012D,ASUS_Z012DA,3,-22,1
+asus,ASUS_Z012D,ASUS_Z012DE,3,-22,1
+asus,ASUS_Z012D,ASUS_Z012S,3,-22,1
+asus,Z016,ASUS_Z016D,3,-22,1
+asus,Z016_1,ASUS_Z016D,3,-22,1
+asus,Z016,ASUS_Z016DA,3,-22,1
+asus,Z016,ASUS_Z016S,3,-22,1
+asus,ASUS_Z017D_1,ASUS_Z017D,3,-22,1
+asus,ASUS_Z017D_1,ASUS_Z017DA,3,-22,1
+asus,Z01B_1,ASUS_Z01BD,3,-22,1
+asus,Z01B_1,ASUS_Z01BDA,3,-22,1
+asus,Z01B_1,ASUS_Z01BDC,3,-22,1
+asus,Z01B_1,ASUS_Z01BS,3,-22,1
+asus,ASUS_Z01F_1,ASUS_Z01FD,5,-20,3
+asus,ASUS_Z01GD_1,ASUS_Z01GD,3,-22,1
+asus,ASUS_Z01H_1,ASUS_Z01HD,3,-22,1
+asus,ASUS_Z01H_1,ASUS_Z01HDA,3,-22,1
+asus,ASUS_Z01KD_3,ASUS_Z01KD,3,-22,1
+asus,ASUS_Z01KD_2,ASUS_Z01KD,3,-22,1
+asus,ASUS_Z01KDA,ASUS_Z01KD,3,-22,1
+asus,ASUS_Z01KD_1,ASUS_Z01KDA,3,-22,1
+asus,ASUS_Z01KDA,ASUS_Z01KS,3,-22,1
+asus,ASUS_Z01M_1,ASUS_Z01MD,3,-22,1
+asus,ASUS_Z01M_1,ASUS_Z01MDA,3,-22,1
+asus,ASUS_Z01QD_1,ASUS_Z01QD,3,-22,1
+asus,ASUS_Z01R_1,ASUS_Z01RD,3,-22,1
+asus,a10,Asus A10,3,-22,1
+asus,TF101G,ETBW11AA,3,-22,1
+asus,ETBW11AA,ETBW11AA,3,-22,1
+asus,ASUS_X00R_3,G552KL,3,-22,1
+asus,ASUS_X00R_7,G553KL,3,-22,1
+asus,a10,Garmin-Asus A10,3,-22,1
+asus,a50,Garmin-Asus A50,3,-22,1
+asus,K007,K007,3,-22,1
+asus,K00C,K00C,3,-22,1
+asus,K00E,K00E,3,-22,1
+asus,K00F,K00F,3,-22,1
+asus,K00G,K00G,3,-22,1
+asus,K00L,K00L,3,-22,1
+asus,K00R,K00R,3,-22,1
+asus,K00U,K00U,3,-22,1
+asus,K00X_1,K00X,3,-22,1
+asus,K00Y,K00Y,3,-22,1
+asus,K00Z,K00Z,3,-22,1
+asus,K010_1,K010,3,-22,1
+asus,K010_3,K010,3,-22,1
+asus,K010,K010,3,-22,1
+asus,K010E_1,K010E,3,-22,1
+asus,K010E,K010E,3,-22,1
+asus,K011_1,K011,3,-22,1
+asus,K011,K011,3,-22,1
+asus,K012,K012,3,-22,1
+asus,K012_2,K012_2,3,-22,1
+asus,K013_1,K013,3,-22,1
+asus,K013,K013,3,-22,1
+asus,K013C,K013C,3,-22,1
+asus,K014,K014,3,-22,1
+asus,K015,K015,3,-22,1
+asus,K016_4,K016,3,-22,1
+asus,K016_2,K016,3,-22,1
+asus,K016_1,K016,3,-22,1
+asus,K016_3,K016,3,-22,1
+asus,K017,K017,3,-22,1
+asus,K018,K018,3,-22,1
+asus,K019_4,K019,3,-22,1
+asus,K019_3,K019,3,-22,1
+asus,K019_2,K019,3,-22,1
+asus,K019_1,K019,3,-22,1
+asus,K01A,K01A,3,-22,1
+asus,K01B,K01B,3,-22,1
+asus,K01E_2,K01E,3,-22,1
+asus,K01E_1,K01E,3,-22,1
+asus,K01F,K01F,3,-22,1
+asus,K01H,K01H,3,-22,1
+asus,K01N_1,K01N,3,-22,1
+asus,K01N_2,K01N,3,-22,1
+asus,K01Q,K01Q,3,-22,1
+asus,K01U_2,K01U,3,-22,1
+asus,K01U_1,K01U,3,-22,1
+asus,EP71,ME171,3,-22,1
+asus,me172v,ME172V,3,-22,1
+asus,ME173X,ME173X,3,-22,1
+asus,ME301T,ME301T,3,-22,1
+asus,ME302C,ME302C,3,-22,1
+asus,ME302KL,ME302KL,3,-22,1
+asus,ME371MG,ME371MG,3,-22,1
+asus,deb,Nexus 7,3,-22,1
+asus,tilapia,Nexus 7,3,-22,1
+asus,grouper,Nexus 7,3,-22,1
+asus,flo,Nexus 7,3,-22,1
+asus,fugu,Nexus Player,3,-22,1
+asus,P001,P001,3,-22,1
+asus,P001_2,P001,3,-22,1
+asus,P001_2,P001_2,3,-22,1
+asus,P002_2,P002,3,-22,1
+asus,P002_1,P002,3,-22,1
+asus,P002_M,P002,3,-22,1
+asus,P008_1,P008,3,-22,1
+asus,P008,P008,3,-22,1
+asus,P008_2,P008,3,-22,1
+asus,P00A_1,P00A,3,-22,1
+asus,P00A_M,P00A,3,-22,1
+asus,P00A_2,P00A,3,-22,1
+asus,P00C_2,P00C,3,-22,1
+asus,P00C_1,P00C,3,-22,1
+asus,P00C_M,P00C,3,-22,1
+asus,P00I,P00I,3,-22,1
+asus,ASUS_P00L_M1,P00L,3,-22,1
+asus,ASUS_P00L_M2,P00L,3,-22,1
+asus,ASUS_P00L_2,P00L,3,-22,1
+asus,ASUS_P00L_1,P00L,3,-22,1
+asus,P01M_2,P01M,3,-22,1
+asus,P01M_4,P01M,3,-22,1
+asus,P01M_5,P01MA,3,-22,1
+asus,P01M_3,P01MA,3,-22,1
+asus,P01M_1,P01MA,3,-22,1
+asus,P01T_M,P01T,3,-22,1
+asus,P01T_1,P01T_1,3,-22,1
+asus,P01V_1,P01V,3,-22,1
+asus,P01V_2,P01V,3,-22,1
+asus,P01W,P01W,3,-22,1
+asus,P01W_M,P01W,3,-22,1
+asus,P01Y_2,P01Y,3,-22,1
+asus,P01Y,P01Y,3,-22,1
+asus,P01Y_S,P01Y,3,-22,1
+asus,P01Y_S,P01Y_S,3,-22,1
+asus,P01Z_2,P01Z,3,-22,1
+asus,P01Z,P01Z,3,-22,1
+asus,P021_1,P021,3,-22,1
+asus,P021,P021,3,-22,1
+asus,P022_2,P022,3,-22,1
+asus,P022_1,P022,3,-22,1
+asus,P023_1,P023,3,-22,1
+asus,P023_2,P023,3,-22,1
+asus,P023_M,P023,3,-22,1
+asus,P024_1,P024,3,-22,1
+asus,P024_3,P024,3,-22,1
+asus,P024_4,P024,3,-22,1
+asus,P024_2,P024,3,-22,1
+asus,P027,P027,4,-20,3
+asus,ASUS_P028_1,P028,3,-22,1
+asus,ASUS_P028_2,P028,3,-22,1
+asus,PadFone,PadFone,3,-22,1
+asus,A68,PadFone 2,3,-22,1
+asus,ASUS-A80,PadFone Infinity,3,-22,1
+asus,A80,PadFone Infinity,3,-22,1
+asus,ASUS-A86,PadFone T004,3,-22,1
+asus,ASUS-T008,PadFone T008,3,-22,1
+asus,ASUS-T00C,PadFone T00C,3,-22,1
+asus,RTC-tablet,RTC-tablet,3,-22,1
+asus,SL101,Slider SL101,3,-22,1
+asus,T10xTA,T10xTA,3,-22,1
+asus,TF101,TF101,3,-22,1
+asus,TF101-WiMAX,TF101-WiMAX,3,-22,1
+asus,TF201,TF201,3,-22,1
+asus,TX201LA,TX201LA,3,-22,1
+asus,TX201LAF,TX201LAF,3,-22,1
+asus,TF201,Transformer Prime TF201,3,-22,1
+asus,TF101,Transformer TF101,3,-22,1
+asus,ventana,Transformer TF101,3,-22,1
+asus,EeePad,Transformer TF101,3,-22,1
+asus,EeePad,Transformer TF101G,3,-22,1
+asus,TF101G,Transformer TF101G,3,-22,1
+asus,TF201,Transformer TF201,3,-22,1
+asus,ASUS_Z00D,Z00D,3,-22,1
+asus,ASUS_X00R_3,ZA550KL,3,-22,1
+asus,ASUS_X00R_2,ZA550KL,3,-22,1
+asus,ASUS_X00LD_3,ZB553KL,3,-22,1
+asus,ASUS_X00P_1,ZB555KL,3,-22,1
+asus,ASUS_X00P_3,ZB555KL,3,-22,1
+asus,ASUS_X00P_8,ZB555KL,3,-22,1
+asus,ASUS_X00T_6,ZB602KL,2,-26,1
+asus,ASUS_X01BD_1,ZB631KL,2,-25,1
+asus,ASUS_X01A_1,ZB633KL,3,-22,1
+asus,ASUS_X017D_2,ZC600KL,3,-22,1
+asus,ASUS_X00QD,ZE620KL,3,-22,1
+asus,ASUS_Z01QD_1,ZS600KL,3,-22,1
+asus,ASUS_Z01R_1,ZS620KL,3,-22,1
+asus,ASUS_I01WD,ZS630KL,3,-22,1
+asus,ASUS_I001_1,ZS660KL,3,-22,1
+asus,ASUS_ZENBO,Zenbo,3,-22,1
+asus,asus_google_cube,asus_google_cube,3,-22,1
+asus,bob_cheets,bob,3,-22,1
+blackberry,argon,BBA100-1,6,-26,1
+blackberry,argon,BBA100-2,6,-26,1
+blackberry,bbb100,BBB100-1,6,-26,1
+blackberry,bbb100,BBB100-2,6,-26,1
+blackberry,bbb100,BBB100-3,6,-26,1
+blackberry,bbb100,BBB100-4,6,-26,1
+blackberry,bbb100,BBB100-5,6,-26,1
+blackberry,bbb100,BBB100-6,6,-26,1
+blackberry,bbb100,BBB100-7,6,-26,1
+blackberry,bbc100,BBC100-1,6,-26,1
+blackberry,bbd100,BBD100-1,6,-26,1
+blackberry,bbd100,BBD100-2,6,-26,1
+blackberry,bbd100,BBD100-6,6,-26,1
+blackberry,bbe100,BBE100-1,6,-26,1
+blackberry,bbe100,BBE100-2,6,-26,1
+blackberry,bbe100,BBE100-4,6,-26,3
+blackberry,bbe100,BBE100-5,6,-26,1
+blackberry,bbf100,BBF100-1,6,-26,1
+blackberry,bbf100,BBF100-2,6,-26,1
+blackberry,bbf100,BBF100-4,6,-26,1
+blackberry,bbf100,BBF100-6,6,-26,1
+blackberry,bbf100,BBF100-8,6,-26,1
+blackberry,bbf100,BBF100-9,6,-26,1
+blackberry,bbg100,BBG100-1,6,-26,1
+blackberry,bbh100,BBH100-1,6,-26,1
+blackberry,hamburg,STH100-1,6,-26,1
+blackberry,hamburg,STH100-2,6,-26,1
+blackberry,venice,STV100-1,6,-26,1
+blackberry,venice,STV100-2,6,-26,1
+blackberry,venice,STV100-3,6,-26,1
+blackberry,venice,STV100-4,6,-26,1
+blu,A200,A200,3,-24,1
+blu,A250,A250,3,-24,1
+blu,A30,A30,3,-24,1
+blu,Advance_4_0_L3,Advance 4.0 L3,3,-24,1
+blu,Advance_4_0M,Advance 4.0M,3,-24,1
+blu,Advance_5_0_HD,Advance 5.0 HD,3,-24,1
+blu,A290Q,Advance 5.2,3,-24,1
+blu,A230Q,Advance 5.2,3,-24,1
+blu,Studio_J1,Advance A4,3,-24,1
+blu,Studio_J2,Advance A5,3,-24,1
+blu,A0010WW,Advance A5 LTE,3,-24,1
+blu,A0031WW,Advance A5 Plus LTE,3,-24,1
+blu,A190,Advance A6,3,-24,1
+blu,A210,Advance A7,3,-24,1
+blu,A350,Advance L4,3,-24,1
+blu,A350A,Advance L4,3,-24,1
+blu,A380,Advance L5,3,-24,1
+blu,A390,Advance L5,3,-24,1
+blu,B110DL,B110DL,3,-24,1
+blu,BLU_ADVANCE_4_0_L2,BLU ADVANCE 4.0 L2,3,-24,1
+blu,BLU_DASH_L2,BLU DASH L2,3,-24,1
+blu,BLU_DASH_M2,BLU DASH M2,3,-24,1
+blu,BLU_DASH_X,BLU DASH X,3,-24,1
+blu,DASH_X_LTE,BLU DASH X LTE,3,-24,1
+blu,BLU_DASH_X2,BLU DASH X2,3,-24,1
+blu,BLU_ENERGY_DIAMOND,BLU ENERGY DIAMOND,3,-24,1
+blu,BLU_ENERGY_M,BLU ENERGY M,3,-24,1
+blu,BLU_ENERGY_X_PLUS_2,BLU ENERGY X PLUS 2,3,-24,1
+blu,BLU_GRAND_5_5_HD,BLU GRAND 5.5 HD,3,-24,1
+blu,BLU_Grand_X_LTE,BLU Grand X LTE,3,-24,1
+blu,BLU_LIFE_MARK,BLU LIFE MARK,3,-24,1
+blu,BLU_LIFE_ONE_X,BLU LIFE ONE X,3,-24,1
+blu,BLU_LIFE_XL,BLU LIFE XL,3,-24,1
+blu,BLU_NEO_ENERGY_MINI,BLU NEO ENERGY MINI,3,-24,1
+blu,BLU_NEO_X,BLU NEO X,3,-24,1
+blu,BLU_NEO_X_LTE,BLU NEO X LTE,3,-24,1
+blu,BLU_NEO_X_MINI,BLU NEO X MINI,3,-24,1
+blu,BLU_NEO_X_PLUS,BLU NEO X PLUS,3,-24,1
+blu,BLU_NEO_XL,BLU NEO XL,3,-24,1
+blu,BLU_R1_HD,BLU R1 HD,3,-24,1
+blu,blu_s0010tw,BLU STUDIO 7.0 LTE,3,-24,1
+blu,blu_s0010uu,BLU STUDIO 7.0 LTE,3,-24,1
+blu,BLU_STUDIO_C_8_8,BLU STUDIO C 8+8,3,-24,1
+blu,BLU_STUDIO_C_8_8_LTE,BLU STUDIO C 8+8 LTE,3,-24,1
+blu,BLU_STUDIO_C_HD,BLU STUDIO C HD,3,-24,1
+blu,BLU_STUDIO_G,BLU STUDIO G,3,-24,1
+blu,Studio_G_Plus,BLU STUDIO G PLUS,3,-24,1
+blu,BLU_STUDIO_G2,BLU STUDIO G2,3,-24,1
+blu,BLU_STUDIO_ONE,BLU STUDIO ONE,3,-24,1
+blu,BLU_STUDIO_ONE_PLUS,BLU STUDIO ONE PLUS,3,-24,1
+blu,BLU_STUDIO_SELFIE_2,BLU STUDIO SELFIE 2,3,-24,1
+blu,BLU_STUDIO_SELFIE_LTE,BLU STUDIO SELFIE LTE,3,-24,1
+blu,BLU_STUDIO_X_MINI,BLU STUDIO X MINI,3,-24,1
+blu,BLU_STUDIO_XL_LTE,BLU STUDIO XL LTE,3,-24,1
+blu,Studio_G_HD,BLU Studio G HD,3,-24,1
+blu,BLU_Studio_Touch,BLU Studio Touch,3,-24,1
+blu,BLU_TOUCHBOOK_M7,BLU TOUCHBOOK M7,3,-24,1
+blu,S0320WW,BLU_S1,3,-24,1
+blu,N0030WW,BOLD N1,3,-24,1
+blu,C190,C1,3,-24,1
+blu,C210,C2,3,-24,1
+blu,C050,C4,3,-24,1
+blu,C070,C4 2019,3,-24,1
+blu,C014,C5,3,-24,1
+blu,C004,C5,3,-24,1
+blu,C010Q,C5,3,-24,1
+blu,C110,C5 2019,3,-24,1
+blu,C111,C5 2019,3,-24,1
+blu,C0010UU,C5 LTE,3,-24,1
+blu,C130EQ,C5 Plus,3,-24,1
+blu,C0040LL,C5L,3,-24,1
+blu,C0040,C5L,3,-24,1
+blu,C0051LL,C5L,3,-24,1
+blu,C0050,C5L,3,-24,1
+blu,C0010LL,C5X,3,-24,1
+blu,C0000UU,C5X,3,-24,1
+blu,C031P,C6,3,-24,1
+blu,C090EQ,C6 2019,3,-24,1
+blu,C0030,C6L,3,-24,1
+blu,C090P,C6x,3,-24,1
+blu,D10,D10,3,-24,1
+blu,D500,D500,3,-24,1
+blu,D510,D510,3,-24,1
+blu,D600,D600,3,-24,1
+blu,D701,D701,3,-24,1
+blu,BLU_DASH_X_PLUS_LTE,DASH X PLUS LTE,3,-24,1
+blu,BLU_DIAMOND_M,DIAMOND M,3,-24,1
+blu,D730,Dash 4.5,3,-24,1
+blu,Dash_G,Dash G,3,-24,1
+blu,D931,Dash L3,3,-24,1
+blu,Dash_L3,Dash L3,3,-24,1
+blu,D131,Dash L4,3,-24,1
+blu,D0050,Dash L4 LTE,3,-24,1
+blu,D0040UU,Dash L4X,3,-24,1
+blu,D0090WW,Dash L5 LTE,3,-24,1
+blu,D0070WW,Dash L5X,3,-24,1
+blu,Dash_X2,Dash X2,3,-24,1
+blu,Dash_XL,Dash XL,3,-24,1
+blu,E_100,E100,3,-24,1
+blu,E20,E20,3,-24,1
+blu,BLU_ENERGY_XL,ENERGY XL,3,-24,1
+blu,ENERGY_DIAMOND_MINI,ENERGY_DIAMOND_MINI,3,-24,1
+blu,BLU_Energy_X_2,Energy X 2,3,-24,1
+blu,BLU_Energy_X_LTE,Energy X LTE,3,-24,1
+blu,G0090,G5,3,-24,1
+blu,G0190,G5 Plus,3,-24,1
+blu,G0180LL,G5 Plus,3,-24,1
+blu,G0210,G6,3,-24,1
+blu,G0270WW,G60,3,-24,1
+blu,G0250WW,G70,3,-24,1
+blu,G0170,G8,3,-24,1
+blu,G0290WW,G80,3,-24,1
+blu,G0130WW,G9,3,-24,1
+blu,G0130WW_SR,G9,3,-24,1
+blu,G0231WW,G9 PRO,3,-24,1
+blu,G0230WW,G9 PRO,3,-24,1
+blu,G0310WW,G90,3,-24,1
+blu,G210Q,Grand 5.5 HD II,3,-24,1
+blu,Grand_Energy,Grand Energy,3,-24,1
+blu,Grand_M,Grand M,-1,-21,3
+blu,G190,Grand M2,3,-24,1
+blu,G0050,Grand M2 LTE,3,-24,1
+blu,G0040LL,Grand M2 LTE,3,-24,1
+blu,G0040UU,Grand M2X,3,-24,1
+blu,G0070WW,Grand M3,3,-24,1
+blu,Grand_Max,Grand Max,3,-24,1
+blu,G170Q,Grand Mini,3,-24,1
+blu,Grand_X,Grand X,3,-24,1
+blu,Grand_X_LTE,Grand X LTE,3,-24,1
+blu,Grand_XL,Grand XL,3,-24,1
+blu,G0030,Grand XL LTE,3,-24,1
+blu,J0000LL_ATT_MX,J7,3,-24,1
+blu,Life_Max,Life Max,3,-24,1
+blu,Life_One_X,Life One X,3,-24,1
+blu,Life_One_X2,Life One X2,3,-24,1
+blu,Life_One_X2_Mini,Life One X2 Mini,3,-24,1
+blu,L0150WW,Life One X3,3,-24,1
+blu,M0030TT,M6,3,-24,1
+blu,M030P,M6,3,-24,1
+blu,Neo_X2,Neo X2,3,-24,1
+blu,BLU_PURE_XL,PURE XL,3,-24,1
+blu,P0050WW,Pure View,3,-24,1
+blu,BLU_Pure_XR,Pure XR,3,-24,1
+blu,R1_HD,R1 HD,3,-24,1
+blu,R1_PLUS,R1 PLUS,3,-24,1
+blu,R010P,R2 3G,3,-24,1
+blu,R0170WW,R2 LTE,3,-24,1
+blu,R0150EE,R2 LTE,3,-24,1
+blu,R0190WW,R2 Plus,3,-24,1
+blu,S0480LL,S5,3,-24,1
+blu,S0480LL_ALTAN,S5,3,-24,1
+blu,S150,STUDIO 5.5 HD,3,-24,1
+blu,BLU_STUDIO_ENERGY_2,STUDIO ENERGY 2,3,-24,1
+blu,BLU_STUDIO_M_HD,STUDIO M HD,3,-24,1
+blu,BLU_STUDIO_M_LTE,STUDIO M LTE,3,-24,1
+blu,STUDIO_G_HD,STUDIO_G_HD,3,-24,1
+blu,Studio_C_HD,Studio C HD,3,-24,1
+blu,Studio_G_HD_LTE,Studio G HD LTE,3,-24,1
+blu,Studio_G_Max,Studio G Max,3,-24,1
+blu,S210,Studio G Mini,3,-24,1
+blu,Studio_G_Plus_HD,Studio G Plus HD,3,-24,1
+blu,Studio_G2_HD,Studio G2 HD,3,-24,1
+blu,S770P,Studio G3,3,-24,1
+blu,S870Q,Studio G4,3,-24,1
+blu,Studio_J1,Studio J1,3,-24,1
+blu,Studio_J2,Studio J2,3,-24,1
+blu,Studio_J5,Studio J5,3,-24,1
+blu,Studio_J8,Studio J8,3,-24,1
+blu,Studio_J8_LTE,Studio J8 LTE,3,-24,1
+blu,S0450WW,Studio J8M,3,-24,1
+blu,Advance_4_0M,Studio M4,3,-24,1
+blu,S850U,Studio M4 Plus,3,-24,1
+blu,Studio_J2,Studio M5,3,-24,1
+blu,Dash_XL,Studio M5 Plus,3,-24,1
+blu,S0390WW,Studio M5 Plus LTE,3,-24,1
+blu,S730,Studio M6,3,-24,1
+blu,Studio_XL_2,Studio M6 LTE,3,-24,1
+blu,Studio_Max,Studio Max,3,-24,1
+blu,S910Q,Studio Mega,6,-28,1
+blu,Studio_Mega,Studio Mega,6,-28,3
+blu,S0460WW,Studio Mega LTE,3,-24,1
+blu,S0470WW,Studio Mega LTE,3,-24,1
+blu,S750,Studio Pro,3,-24,1
+blu,S810,Studio View,3,-24,1
+blu,S812P,Studio View,3,-24,1
+blu,S810P,Studio View,3,-24,1
+blu,S790Q,Studio View XL,3,-24,1
+blu,S532,Studio X8 HD,3,-24,1
+blu,S950P,Studio X9 HD,3,-24,1
+blu,Studio_XL_2,Studio XL 2,3,-24,1
+blu,T0050TT,T5,3,-24,1
+blu,T0070TT_TIGO,T5 Plus,3,-24,1
+blu,T0030WW,Tank Xtreme,3,-24,1
+blu,Tank_Xtreme_4_0,Tank Xtreme 4.0,1,-24,3
+blu,Tank_Xtreme_5_0,Tank Xtreme 5.0,3,-24,1
+blu,T0010UU,Tank Xtreme Pro,3,-24,1
+blu,P290,Touchbook M7 Pro,3,-24,1
+blu,B100DL,VIEW 1,3,-24,1
+blu,BLU_VIVO_5,VIVO 5,5,-24,3
+blu,V0390WW,VIVO GO,3,-24,1
+blu,BLU_VIVO_XL,VIVO XL,3,-24,1
+blu,Vivo_5_Mini,Vivo 5 Mini,3,-24,1
+blu,BLU_Vivo_5R,Vivo 5R,3,-24,1
+blu,BLU_Vivo_6,Vivo 6,3,-24,1
+blu,V0150LL,Vivo 8,3,-24,1
+blu,V0150UU,Vivo 8,3,-24,1
+blu,V0190UU,Vivo 8L,3,-24,1
+blu,V0270WW,Vivo ONE,4,-25,3
+blu,V0290WW,Vivo One Plus,3,-24,1
+blu,V0370WW,Vivo One Plus 2019,3,-24,1
+blu,V0160WW,Vivo S,3,-24,1
+blu,V0230WW,Vivo X,3,-24,1
+blu,V0330WW,Vivo XI,3,-24,1
+blu,V0310WW,Vivo XI PLUS,3,-24,1
+blu,V0310WW,Vivo XI+,3,-24,1
+blu,BLU_Vivo_XL2,Vivo XL2,3,-24,1
+blu,V0250WW,Vivo XL3,3,-24,1
+blu,V0210WW,Vivo XL3 Plus,3,-24,1
+blu,V0350WW,Vivo XL4,3,-24,1
+coolpad,Coolpad_1803,1803,0,-20,1
+coolpad,1821,1821,0,-20,1
+coolpad,1825-I01,1825-I01,0,-20,1
+coolpad,Cool_3_Pro,1826,0,-20,1
+coolpad,1826-I01,1826-I01,0,-20,1
+coolpad,1827,1827,0,-20,1
+coolpad,1903,1903,0,-20,1
+coolpad,1904,1904,0,-20,1
+coolpad,1921,1921,0,-20,1
+coolpad,1932,1932,0,-20,1
+coolpad,CP3600I,3600I,0,-20,1
+coolpad,msm7627a_sku3,5110,0,-20,1
+coolpad,5560S,5560S,0,-20,1
+coolpad,CP5832,5832,0,-20,1
+coolpad,msm7627_surf,5860,0,-20,1
+coolpad,msm7627a_sku3,5860A,0,-20,1
+coolpad,CP5860E,5860E,0,-20,1
+coolpad,msm7627a_5860S,5860S,0,-20,1
+coolpad,msm7627a_5870,5870,0,-20,1
+coolpad,CP5880,5880,0,-20,1
+coolpad,msm7627a_cp5910,5910,0,-20,1
+coolpad,msm7627a_7230,7230,0,-20,1
+coolpad,msm7627_surf,7260,0,-20,1
+coolpad,msm7627a_sku3,7260A,0,-20,1
+coolpad,msm7627a_7266,7266,0,-20,1
+coolpad,801E,801E,0,-20,1
+coolpad,801EM,801EM,0,-20,1
+coolpad,801ES,801ES,0,-20,1
+coolpad,dkb,8150,0,-20,1
+coolpad,dkb,8180,0,-20,1
+coolpad,8710,8710,0,-20,1
+coolpad,dkb,8810,0,-20,1
+coolpad,CP8870,8870,0,-20,1
+coolpad,msm8660_CP8950,8950,0,-20,1
+coolpad,msm7627a_9120,9120,0,-20,1
+coolpad,msm8660_9900,9900,0,-20,1
+coolpad,cp8870u,Bs 501,0,-20,1
+coolpad,C103,C1-U02,0,-20,1
+coolpad,C103,C103,0,-20,1
+coolpad,cool_c1,C106,0,-20,1
+coolpad,cool_c1,C106-6,0,-20,1
+coolpad,cool_c1,C106-7,0,-20,1
+coolpad,cool_c1,C106-8,0,-20,1
+coolpad,cool_c1,C106-9,0,-20,1
+coolpad,cool_c1,C107-9,0,-20,1
+coolpad,CK2-01,CK2-01,0,-20,1
+coolpad,CK3-01,CK3-01,0,-20,1
+coolpad,CK3-01,CK3-M1,0,-20,1
+coolpad,Civic,COL-A0,0,-20,1
+coolpad,3700A,CP3700A,0,-20,1
+coolpad,apollo,CP3706AS,0,-20,1
+coolpad,CP8298_M02,CP8298_M02,0,-20,1
+coolpad,CP8676_I03,CP8676_I03,0,-20,1
+coolpad,Civic,CVC-A0,0,-20,1
+coolpad,Civic,CVC-M0,0,-20,1
+coolpad,Coolmini,Coolmini,0,-20,1
+coolpad,3300A,Coolpad 3300A,0,-20,1
+coolpad,ventura,Coolpad 3310A,0,-20,1
+coolpad,cp3320a,Coolpad 3320A,0,-20,1
+coolpad,CP3503I,Coolpad 3503I,0,-20,1
+coolpad,CP3600I,Coolpad 3600I,0,-20,1
+coolpad,cp3622a,Coolpad 3622A,0,-20,1
+coolpad,cp3623a,Coolpad 3623A,0,-20,1
+coolpad,cp3632a,Coolpad 3632A,0,-20,1
+coolpad,msm7627a_ea58,Coolpad 5010,0,-20,1
+coolpad,msm7627a_a8_5108_new,Coolpad 5108,0,-20,1
+coolpad,Coolpad5109,Coolpad 5109,0,-20,1
+coolpad,Coolpad5200,Coolpad 5200,0,-20,1
+coolpad,msm7627a_ea92,Coolpad 5210,0,-20,1
+coolpad,msm7627a_d7_5210a,Coolpad 5210A,0,-20,1
+coolpad,5216D,Coolpad 5216D,0,-20,1
+coolpad,msm8610,Coolpad 5217,0,-20,1
+coolpad,msm8x25q_a5y_5218s,Coolpad 5218S,0,-20,1
+coolpad,5219,Coolpad 5219,0,-20,1
+coolpad,5219_C00,Coolpad 5219_C00,0,-20,1
+coolpad,Coolpad5267,Coolpad 5267,0,-20,1
+coolpad,Coolpad5270,Coolpad 5270,0,-20,1
+coolpad,cp5310,Coolpad 5310,0,-20,1
+coolpad,msm8610_s10_cp5315,Coolpad 5315,0,-20,1
+coolpad,Coolpad5367,Coolpad 5367,0,-20,1
+coolpad,Coolpad5367C,Coolpad 5367C,0,-20,1
+coolpad,Coolpad5370,Coolpad 5370,0,-20,1
+coolpad,Coolpad5380CA,Coolpad 5380CA,0,-20,1
+coolpad,msm7627_5820,Coolpad 5820,0,-20,1
+coolpad,Coolpad5872,Coolpad 5872,0,-20,1
+coolpad,Coolpad5879T,Coolpad 5879T,0,-20,1
+coolpad,Coolpad5891,Coolpad 5891,0,-20,1
+coolpad,Coolpad5891Q,Coolpad 5891Q,0,-20,1
+coolpad,Coolpad5891S,Coolpad 5891S,0,-20,1
+coolpad,Coolpad5892,Coolpad 5892,0,-20,1
+coolpad,Coolpad5950,Coolpad 5950,0,-20,1
+coolpad,Coolpad5950T,Coolpad 5950T,0,-20,1
+coolpad,Coolpad5951,Coolpad 5951,0,-20,1
+coolpad,Coolpad5952,Coolpad 5952,0,-20,1
+coolpad,7019_msm7627a,Coolpad 7019,0,-20,1
+coolpad,CP7061,Coolpad 7061,0,-20,1
+coolpad,Coolpad7230S,Coolpad 7230S,0,-20,1
+coolpad,CP7232,Coolpad 7232,0,-20,1
+coolpad,msm8610_w7_cp7236,Coolpad 7236,0,-20,1
+coolpad,Coolpad7251,Coolpad 7251,0,-20,1
+coolpad,Coolpad7270,Coolpad 7270,0,-20,1
+coolpad,Coolpad7270_W00,Coolpad 7270_W00,0,-20,1
+coolpad,CP7275,Coolpad 7275,0,-20,1
+coolpad,Coolpad7290,Coolpad 7290,0,-20,1
+coolpad,Coolpad7295A,Coolpad 7295+,0,-20,1
+coolpad,Coolpad7295A,Coolpad 7295A,0,-20,1
+coolpad,Coolpad7295C,Coolpad 7295C,0,-20,1
+coolpad,Coolpad7295C_C00,Coolpad 7295C_C00,0,-20,1
+coolpad,Coolpad7295T,Coolpad 7295T,0,-20,1
+coolpad,Coolpad7296,Coolpad 7296,0,-20,1
+coolpad,Coolpad7296S,Coolpad 7296S,0,-20,1
+coolpad,Coolpad7298A,Coolpad 7298A,0,-20,1
+coolpad,Coolpad7298D,Coolpad 7298D,0,-20,1
+coolpad,Coolpad7320,Coolpad 7320,0,-20,1
+coolpad,Coolpad7620L,Coolpad 7620L,0,-20,1
+coolpad,Coolpad8021,Coolpad 8021,0,-20,1
+coolpad,Coolpad8079,Coolpad 8079,0,-20,1
+coolpad,CP8089,Coolpad 8089,0,-20,1
+coolpad,CP8089Q,Coolpad 8089Q,0,-20,1
+coolpad,Coolpad8122,Coolpad 8122,0,-20,1
+coolpad,Coolpad8198W,Coolpad 8198W,0,-20,1
+coolpad,Coolpad8297D,Coolpad 8297D,0,-20,1
+coolpad,Coolpad8297L-I00,Coolpad 8297L-I00,0,-20,1
+coolpad,Coolpad8297W,Coolpad 8297W,0,-20,1
+coolpad,Coolpad8705,Coolpad 8705,0,-20,1
+coolpad,Coolpad8712,Coolpad 8712,0,-20,1
+coolpad,CP8712,Coolpad 8712,0,-20,1
+coolpad,Coolpad8718,Coolpad 8718,0,-20,1
+coolpad,Coolpad8720L,Coolpad 8720L,0,-20,1
+coolpad,CP8722,Coolpad 8722,0,-20,1
+coolpad,CP8722,Coolpad 8722V,0,-20,3
+coolpad,Coolpad8729,Coolpad 8729,0,-20,1
+coolpad,Coolpad8730L,Coolpad 8730L,0,-20,1
+coolpad,8735,Coolpad 8735,0,-20,1
+coolpad,8736,Coolpad 8736,0,-20,1
+coolpad,Coolpad8737A,Coolpad 8737A,0,-20,1
+coolpad,8970L,Coolpad 8970L,0,-20,1
+coolpad,8971,Coolpad 8971,0,-20,1
+coolpad,Coolpad9080W,Coolpad 9080W,0,-20,1
+coolpad,Coolpad9150W,Coolpad 9150W,0,-20,1
+coolpad,Coolpad9190L,Coolpad 9190L,0,-20,1
+coolpad,Coolpad9190_T00,Coolpad 9190_T00,0,-20,1
+coolpad,Coolpad9250L,Coolpad 9250L,0,-20,1
+coolpad,9970,Coolpad 9970,0,-20,1
+coolpad,9970L,Coolpad 9970L,0,-20,1
+coolpad,Coolpad9976A,Coolpad 9976A,0,-20,1
+coolpad,CoolpadA520,Coolpad A520,0,-20,1
+coolpad,A8,Coolpad A8,0,-20,1
+coolpad,A8-831,Coolpad A8-831,0,-20,1
+coolpad,A8-930,Coolpad A8-930,0,-20,1
+coolpad,A8-931,Coolpad A8-931,0,-20,1
+coolpad,A8-931,Coolpad A8-931N,0,-20,1
+coolpad,A8-932,Coolpad A8-932,0,-20,1
+coolpad,B770,Coolpad B770,0,-20,1
+coolpad,CoolpadB770S,Coolpad B770S,0,-20,1
+coolpad,CoolpadCM001,Coolpad CM001,0,-20,1
+coolpad,clover,Coolpad COR-I0,0,-20,1
+coolpad,CP3503I,Coolpad CP3503I,0,-20,1
+coolpad,CPY83_U00,Coolpad E502,0,-20,1
+coolpad,CPY83_S00,Coolpad E502,0,-20,1
+coolpad,CP3505I,Coolpad E503,0,-20,1
+coolpad,CP3505I_U00,Coolpad E503,0,-20,1
+coolpad,E561,Coolpad E561,0,-20,1
+coolpad,E561_EU,Coolpad E561_EU,0,-20,1
+coolpad,CP8722_U00,Coolpad E570,0,-20,1
+coolpad,CP8722_S00,Coolpad E570,0,-20,1
+coolpad,Y72_921,Coolpad E571,0,-20,1
+coolpad,K2L_S00,Coolpad E580,0,-20,1
+coolpad,7560T,Coolpad Flo,0,-20,1
+coolpad,cpy90_g00,Coolpad R106,0,-20,1
+coolpad,R108,Coolpad R108,0,-20,1
+coolpad,C1-S02,Coolpad R116,0,-20,1
+coolpad,CoolpadT1,Coolpad T1,0,-20,1
+coolpad,msm7627_w706T,Coolpad W706+,0,-20,1
+coolpad,msm7627_w706,Coolpad W706+,0,-20,1
+coolpad,msm7627_w708,Coolpad W708,0,-20,1
+coolpad,Y72-921,Coolpad Y72-921,0,-20,1
+coolpad,CPY803_8,Coolpad Y803-8,0,-20,1
+coolpad,CPY803_9,Coolpad Y803-9,0,-20,1
+coolpad,Y83-900,Coolpad Y83-900,0,-20,1
+coolpad,CPY83_I00,Coolpad Y83-I00,0,-20,1
+coolpad,Y91,Coolpad Y891,0,-20,1
+coolpad,Y90,Coolpad Y90,0,-20,1
+coolpad,Y91,Coolpad Y91-921,0,-20,1
+coolpad,Y92-9,Coolpad Y92-9,0,-20,1
+coolpad,CP7728,Coolpad7728,0,-20,1
+coolpad,7920,Coolpad7920,0,-20,1
+coolpad,Coolpad8085Q,Coolpad8085Q,0,-20,1
+coolpad,8198T,Coolpad8198T,0,-20,1
+coolpad,8295M,Coolpad8295M,0,-20,1
+coolpad,8750,Coolpad8750,0,-20,1
+coolpad,8908,Coolpad8908,0,-20,1
+coolpad,msm7627a_a5y_5218d,Coolpad_5218D,0,-20,1
+coolpad,Forward_EVOLVE,Forward_EVOLVE,0,-20,1
+coolpad,GRA,GRA-M0,0,-20,1
+coolpad,Coolpad7295S,Idea ULTRA,0,-20,1
+coolpad,7270I,Idea ULTRA Pro,0,-20,1
+coolpad,Karbonn,Karbonn Titanium S5 Plus,0,-20,1
+coolpad,P5001,MEDION P5001,0,-20,1
+coolpad,MEDION,MEDION P5001,0,-20,1
+coolpad,msm7627_SP150,MTS-SP150,0,-20,1
+coolpad,msm7627a_ea92_mts,Mtag 353,0,-20,1
+coolpad,CP9130,N930,0,-20,1
+coolpad,7560U,Nivo,0,-20,1
+coolpad,msm7627a_PAP4000,PAP4000,0,-20,1
+coolpad,pollux,POL-A0,0,-20,1
+coolpad,SS2-01,SS2-01,0,-20,1
+coolpad,cp8861u,STARADDICT III,0,-20,1
+coolpad,Coolpad7268I,Spice Mi-496,0,-20,1
+coolpad,Coolpad7295I,Spice Mi-515,0,-20,1
+coolpad,victor,VCR-A0,0,-20,1
+coolpad,victor,VCR-I0,0,-20,1
+coolpad,VodafoneSmart4,Vodafone Smart 4,0,-20,1
+coolpad,VodafoneSmart4turbo,Vodafone Smart 4 turbo,0,-20,1
+coolpad,cp8860u,Vodafone Smart 4G,0,-20,1
+coolpad,9960,YL-Coolpad 9960,0,-20,1
+coolpad,CoolpadE2,coolpad E2,0,-20,1
+coolpad,cp3636a,cp3636a,0,-20,1
+coolpad,cp3648a,cp3648A,0,-20,1
+coolpad,cp3648at,cp3648AT,0,-20,1
+coolpad,lithium,cp3705A,0,-20,1
+coolpad,SK5,ivvi SK5,0,-20,1
+coolpad,SK5_S,ivvi SK5_S,0,-20,1
+coolpad,SS1-03,ivvi SS1-03,0,-20,1
+coolpad,SS2-01,ivvi SS2-01,0,-20,1
+coolpad,V1M-S,ivvi V1M-S,0,-20,1
+coolpad,i1,ivvi i1,0,-20,1
+coolpad,i1-01,ivvi i1-01,0,-20,1
+coolpad,V4701_FR1,ivvi i1-S,0,-20,1
+coolpad,i3-01,ivvi i3-01,0,-20,1
+coolpad,i3-M1,ivvi i3-M1,0,-20,1
+coolpad,i3P-02,ivvi i3P-02,0,-20,1
+essential products,Essential,Essential,7,-24,1
+essential products,mata,PH-1,7,-24,3
+google,generic_x86_arm,AOSP on IA Emulator,2,-28,1
+google,reef_cheets,ASUS Chromebook C213NA,2,-28,1
+google,edgar_cheets,Acer Chromebook 14 (CB3-431),2,-28,1
+google,generic_x86,Android SDK built for x86,2,-28,1
+google,generic_x86_64,Android SDK built for x86_64,2,-28,1
+google,generic_x86,Automotive SDK built for x86,2,-28,1
+google,relm_cheets,Braswell Chrome OS Device,2,-28,1
+google,edgar_cheets,Chromebook 14 (CB3-431),2,-28,1
+google,fizz_cheets,Chromebox Reference,2,-28,1
+google,jgedlte,GT-I9505G,2,-28,1
+google,samus_cheets,Google Chromebook Pixel (2015),2,-28,1
+google,nocturne_cheets,Google Pixel Slate,2,-28,1
+google,eve_cheets,Google Pixelbook,2,-28,1
+google,reef_cheets,Intel Apollo Lake Chromebook,2,-28,1
+google,wizpig_cheets,Intel Braswell Chromebook,2,-28,1
+google,relm_cheets,Intel Braswell Chromebook,2,-28,1
+google,hana_cheets,Lenovo N23 Yoga/Flex 11 Chromebook,2,-28,1
+google,hana_cheets,Mediatek MT8173 Chromebook,2,-28,1
+google,hana_cheets,Mediatek MTK8173 Chromebook,2,-28,1
+google,sailfish,Pixel,-3,-26,3
+google,walleye,Pixel 2,2,-28,1
+google,taimen,Pixel 2 XL,2,-28,1
+google,blueline,Pixel 3,5,-33,3
+google,crosshatch,Pixel 3 XL,2,-28,1
+google,sargo,Pixel 3a,2,-29,3
+google,bonito,Pixel 3a XL,2,-28,3
+google,flame,Pixel 4,8,-30,3
+google,coral,Pixel 4 XL,7,-26,3
+google,sunfish,Pixel 4a,1,-30,3
+google,dragon,Pixel C,2,-28,1
+google,nocturne_cheets,Pixel Slate,2,-28,1
+google,marlin,Pixel XL,-2,-26,3
+google,yellowstone,Project Tango Tablet Development Kit,2,-28,1
+google,jerry_cheets,RK3288 Chrome OS Device,2,-28,1
+google,mighty_cheets,RK3288 Chrome OS Device,2,-28,1
+google,mighty_cheets,Rockchip RK3288 Chromebook,2,-28,1
+google,jerry_cheets,Rockchip RK3288 Chromebook,2,-28,1
+google,yellowstone,Yellowstone,2,-28,1
+google,coral_cheets,coral,2,-28,1
+google,fizz_cheets,fizz,2,-28,1
+google,gobo,gobo_512,2,-22,3
+google,grunt_cheets,grunt,2,-28,1
+google,hatch_cheets,hatch,2,-28,1
+google,kukui_cheets,kukui,2,-28,1
+google,nami_cheets,nami,2,-28,1
+google,nocturne_cheets,nocturne,2,-28,1
+google,octopus_cheets,octopus,2,-28,1
+google,rammus_cheets,rammus,2,-28,1
+google,reef_cheets,reef,2,-28,1
+htc,ace,001HT,2,-28,1
+htc,htc_mecwhl,0PAJ5,2,-28,1
+htc,htc_a11chl,0PCV1,2,-28,1
+htc,htc_himauhl,0PJA10,2,-28,1
+htc,htc_himawhl,0PJA2,2,-28,1
+htc,htc_a32ewhl,0PM92,2,-28,1
+htc,htc_hiaewhl,2PQ93,2,-28,1
+htc,htc_pmewhl,2PS64,-1,-31,3
+htc,htc_ocnwhl,2PZC5,2,-21,1
+htc,htc_bre2pdugl,2Q74100,2,-28,1
+htc,htc_zddugl,2Q8L10000,2,-28,1
+htc,htc_ocnuhljapan,601HT,3,-24,1
+htc,htc_a5chl,710C,2,-28,1
+htc,htc_m8whl,831C,2,-28,1
+htc,htc_a37_dugl,A37 DUGL,2,-28,1
+htc,inc,ADR6300,2,-28,1
+htc,lexikon,ADR6325,2,-28,1
+htc,blissc,ADR6330VW,2,-28,1
+htc,vivow,ADR6350,2,-28,1
+htc,mecha,ADR6400L,2,-28,1
+htc,fireball,ADR6410LRA,2,-28,1
+htc,fireball,ADR6410LVW,2,-28,1
+htc,fireball,ADR6410OM,2,-28,1
+htc,vigor,ADR6425LVW,2,-28,1
+htc,k2cl,C525c,2,-28,1
+htc,ace,Desire HD,2,-28,1
+htc,cp2u,Desire L by HTC,2,-28,1
+htc,hero,ERA G2 Touch,2,-28,1
+htc,jewel,EVO,2,-28,1
+htc,htc_exodugl,EXODUS 1,2,-28,1
+htc,htc_exouhl,EXODUS 1,2,-28,1
+htc,desirec,Eris,2,-28,1
+htc,heroc,HERO200,2,-28,1
+htc,htc_melsuhl,HTC 0P6B9,2,-28,1
+htc,htc_melsuhl,HTC 0P6B900,2,-28,1
+htc,htc_a5dwgl,HTC 0P9C8,2,-28,1
+htc,htc_a3qhdcl,HTC 0P9O30,2,-28,1
+htc,htc_mecdwg,HTC 0PAJ4,2,-28,1
+htc,htc_a11ul,HTC 0PCV20,2,-28,1
+htc,htc_a31ul,HTC 0PE64,2,-28,1
+htc,htc_a31mg_dug,HTC 0PE65,2,-28,1
+htc,htc_v01_u,HTC 0PF11,2,-28,1
+htc,htc_v01_u,HTC 0PF120,2,-28,1
+htc,htc_eyeul,HTC 0PFH11,2,-28,1
+htc,htc_eyetuhl,HTC 0PFH2,2,-28,1
+htc,htc_a51ul,HTC 0PFJ4,2,-28,1
+htc,htc_a12ul,HTC 0PGQ1,2,-28,1
+htc,htc_himauhl,HTC 0PJA10,2,-28,1
+htc,htc_hiaur2_ml_tuhl,HTC 0PK71,2,-28,1
+htc,htc_hiau_ml_tuhl,HTC 0PK71,2,-28,1
+htc,htc_hiaur_ml_tuhl,HTC 0PK72,2,-28,1
+htc,htc_a32ul_emea,HTC 0PKX2,2,-28,1
+htc,htc_a53ml_dtul,HTC 0PL31,2,-28,1
+htc,htc_v02_u,HTC 0PL41,2,-28,1
+htc,htc_v02_dug,HTC 0PL41,2,-28,1
+htc,htc_v02_dug,HTC 0PL4100,2,-28,1
+htc,htc_hima_ace_ml_dtul,HTC 0PLA1,2,-28,1
+htc,htc_a32mg_dug,HTC 0PM11,2,-28,1
+htc,htc_a13wl,HTC 0PM31,2,-28,1
+htc,htc_a32eulatt,HTC 0PM912,2,-28,1
+htc,htc_a32ewhl,HTC 0PM92,2,-28,1
+htc,htc_pmec2tuhl,HTC 10,0,-31,1
+htc,htc_pmewl,HTC 10,1,-31,3
+htc,htc_pmeuhl,HTC 10,2,-33,3
+htc,htc_pmec2tuhl,HTC 10 Lifestyle,0,-31,1
+htc,htc_acauhl,HTC 10 evo,2,-28,1
+htc,htc_acawhl,HTC 10 evo,2,-28,1
+htc,htc_v01a_dug,HTC 2PNT1,2,-28,1
+htc,htc_a50cmg_dwg,HTC 2PQ83,2,-28,1
+htc,htc_a50cml_tuhl,HTC 2PQ84,2,-28,1
+htc,htc_hiaeuhl,HTC 2PQ910,2,-28,1
+htc,htc_a51bml_dwgl,HTC 2PRE2,2,-28,1
+htc,htc_a51bml_tuhl,HTC 2PRE4,2,-28,1
+htc,htc_himar2uhl,HTC 2PRG100,2,-28,1
+htc,htc_e56ml_tuhl,HTC 2PS5200,2,-28,1
+htc,htc_pmeuhl,HTC 2PS6200,2,-33,1
+htc,htc_pmec2tuhl,HTC 2PS63,0,-31,1
+htc,htc_a16ul,HTC 2PST1,5,-28,1
+htc,htc_a16ul,HTC 2PST2,5,-28,1
+htc,htc_a16wl,HTC 2PST3,2,-28,1
+htc,htc_a16dwgl,HTC 2PST5,2,-28,1
+htc,htc_a56dugl,HTC 2PUK1,2,-28,1
+htc,htc_a56uhl,HTC 2PUK2,2,-28,1
+htc,htc_a51cml_dtul,HTC 2PVD1,2,-28,1
+htc,htc_v36bml_dugl,HTC 2PVG2,2,-28,1
+htc,htc_e36_ml_uhl,HTC 2PWD1,2,-28,1
+htc,htc_e36_ml_ul,HTC 2PWD2,2,-28,1
+htc,htc_e66_dtwl,HTC 2PXH1,2,-28,1
+htc,htc_e66_dugl,HTC 2PXH2,2,-28,1
+htc,htc_e66_uhl,HTC 2PXH3,2,-28,1
+htc,htc_a56dj_pro_uhl,HTC 2PYA3,2,-28,1
+htc,htc_a17uhl,HTC 2PYR1,2,-28,1
+htc,htc_ocnuhl,HTC 2PZC100,3,-24,1
+htc,htc_oceuhl,HTC 2PZF1,-5,-29,1
+htc,htc_alpine_uhl,HTC 2PZM3,2,-28,1
+htc,htc_a37dj_dugl,HTC 2PZS1,2,-28,1
+htc,htc_ocmdtwl,HTC 2Q4D200,3,-28,1
+htc,htc_haydugl,HTC 2Q4R1,2,-28,1
+htc,htc_haydugl,HTC 2Q4R100,2,-28,1
+htc,htc_haydtwl,HTC 2Q4R300,2,-28,1
+htc,htc_haydtwl,HTC 2Q4R400,2,-28,1
+htc,htc_haydtwla,HTC 2Q4R400,2,-28,1
+htc,htc_imedugl,HTC 2Q551,7,-33,1
+htc,htc_imedugl,HTC 2Q551+,7,-33,1
+htc,htc_imedugl,HTC 2Q55100,7,-33,1
+htc,htc_imeuhl,HTC 2Q552,7,-33,1
+htc,htc_imedtwl,HTC 2Q55300,2,-28,1
+htc,htc_breeze_dugl,HTC 2Q5V1,2,-28,1
+htc,htc_breeze_ul,HTC 2Q5V200,2,-28,1
+htc,htc_brepdugl,HTC 2Q5W1,2,-28,1
+htc,htc_brepdugl,HTC 2Q5W2,2,-28,1
+htc,htc_imldugl,HTC 2Q6E1,2,-23,1
+htc,htc_bre2dugl,HTC 2Q721,2,-28,1
+htc,htc_tetdugl,HTC 2Q7A100,2,-28,1
+htc,g3u,HTC 301e,2,-28,1
+htc,z4dug,HTC 5060,2,-28,1
+htc,z4td,HTC 5088,2,-28,1
+htc,htc_rtxspcs,HTC 5G Hub,2,-28,1
+htc,htc_rtx,HTC 5G Hub,2,-28,1
+htc,m4,HTC 601e,2,-28,1
+htc,cp3dug,HTC 606w,2,-28,1
+htc,cp3dtg,HTC 608t,2,-28,1
+htc,cp3dcg,HTC 609d,2,-28,1
+htc,zaradug,HTC 6160,2,-28,1
+htc,zarawl,HTC 619d,2,-28,1
+htc,cp5dtu,HTC 7088,2,-28,1
+htc,cp5dwg,HTC 709d,2,-28,1
+htc,m7,HTC 801e,2,-28,1
+htc,m7cdwg,HTC 802d,2,-28,1
+htc,m7cdtu,HTC 802t,2,-28,1
+htc,m7cdtu,HTC 802t 16GB,2,-28,1
+htc,m7cdug,HTC 802w,2,-28,1
+htc,t6ul,HTC 803e,2,-28,1
+htc,t6dug,HTC 8060,2,-28,1
+htc,t6tl,HTC 8088,2,-28,1
+htc,t6dwg,HTC 809d,2,-28,1
+htc,t6uhl,HTC 8160,2,-28,1
+htc,dlxpul,HTC 901e,2,-28,1
+htc,dlpdug,HTC 9060,2,-28,1
+htc,dlpdtu,HTC 9088,2,-28,1
+htc,dlpdwg,HTC 919d,2,-28,1
+htc,htc_hiaetuhl,HTC A9w,2,-28,1
+htc,kingdom,HTC Acquire,2,-28,1
+htc,ruby,HTC Amaze 4G,2,-28,1
+htc,liberty,HTC Aria,2,-28,1
+htc,liberty,HTC Aria A6380,2,-28,1
+htc,bee,HTC Bee,2,-28,1
+htc,dlxu,HTC Butterfly,2,-28,1
+htc,dlxub1,HTC Butterfly,2,-28,1
+htc,htc_b2ul,HTC Butterfly 2,2,-28,1
+htc,dlxpul,HTC Butterfly s,2,-28,1
+htc,htc_v2_dug,HTC C2,2,-28,1
+htc,chacha,HTC ChaCha A810b,2,-28,1
+htc,chacha,HTC ChaCha A810e,2,-28,1
+htc,chacha,HTC ChaChaCha A810e,2,-28,1
+htc,htc_a56dj_pro_dtwl,HTC D10w,2,-28,1
+htc,htc_v1_dug,HTC D310w,2,-28,1
+htc,htc_v2_c,HTC D316d,2,-28,1
+htc,htc_v2_dcg,HTC D516d,2,-28,1
+htc,htc_v2_dtg,HTC D516t,2,-28,1
+htc,htc_v2_dug,HTC D516w,2,-28,1
+htc,htc_a3tl,HTC D610t,2,-28,1
+htc,htc_v3_dug,HTC D616w,2,-28,1
+htc,htc_a32dcgl,HTC D626d,2,-28,1
+htc,htc_a32ml_dtul,HTC D626t,2,-28,1
+htc,htc_a32ml_dtul,HTC D626w,2,-28,1
+htc,htc_a50cml_dtul,HTC D728w,2,-28,1
+htc,htc_a5dwg,HTC D816d,2,-28,1
+htc,htc_a5dugl,HTC D816e,2,-28,1
+htc,htc_a5mgp_dug,HTC D816h,2,-28,1
+htc,htc_a5tl,HTC D816t,2,-28,1
+htc,htc_a5dwgl,HTC D816v,2,-28,1
+htc,htc_a5dug,HTC D816w,2,-28,1
+htc,htc_a31dtul,HTC D820mt,2,-28,1
+htc,htc_a31dtul,HTC D820mu,2,-28,1
+htc,htc_a51dtul,HTC D820t,2,-28,1
+htc,htc_a50ml_dtul,HTC D820ts,2,-28,1
+htc,htc_a51dtul,HTC D820u,2,-28,1
+htc,htc_a50ml_dtul,HTC D820us,2,-28,1
+htc,htc_a52dwgl,HTC D826d,2,-28,1
+htc,htc_a50aml,HTC D826sw,2,-28,1
+htc,htc_a52dtul,HTC D826t,2,-28,1
+htc,htc_a52dtul,HTC D826w,2,-28,1
+htc,htc_a51bml_dtul,HTC D828w,2,-28,1
+htc,htc_a51cml_dtul,HTC D830u,2,-28,1
+htc,dlxub1,HTC DLXUB1,2,-28,1
+htc,dlxu,HTC DLX_U,2,-28,1
+htc,bravo,HTC Desire,2,-28,1
+htc,htc_a37dj_dugl,HTC Desire 10 compact,2,-28,1
+htc,htc_a56djuhl,HTC Desire 10 lifestyle,2,-28,1
+htc,htc_a56djdugl,HTC Desire 10 lifestyle,2,-28,1
+htc,htc_a56djul,HTC Desire 10 lifestyle,2,-28,1
+htc,htc_a56dj_pro_dugl,HTC Desire 10 pro,2,-28,1
+htc,htc_a56dj_pro_dtwl,HTC Desire 10 pro,2,-28,1
+htc,htc_a56dj_pro_uhl,HTC Desire 10 pro,2,-28,1
+htc,htc_breeze_dugl,HTC Desire 12,2,-28,1
+htc,htc_breeze_ul,HTC Desire 12 (2Q5V200),2,-28,1
+htc,htc_brepuhl,HTC Desire 12+,2,-28,1
+htc,htc_brepdugl,HTC Desire 12+,2,-28,1
+htc,htc_bre2dugl,HTC Desire 12s,2,-28,1
+htc,htc_bre2pdugl,HTC Desire 19+,2,-28,1
+htc,htc_zddugl,HTC Desire 19s,2,-28,1
+htc,gtou,HTC Desire 200,2,-28,1
+htc,htc_v0_dug,HTC Desire 210 dual sim,2,-28,1
+htc,g3u,HTC Desire 300,2,-28,1
+htc,htc_v1_u,HTC Desire 310,2,-28,1
+htc,htc_v1_dug,HTC Desire 310 dual sim,2,-28,1
+htc,htc_v01_u,HTC Desire 320,2,-28,1
+htc,htc_v01a_dug,HTC Desire 326G dual sim,2,-28,1
+htc,cp2dug,HTC Desire 400 dual sim,2,-28,1
+htc,z4u,HTC Desire 500,2,-28,1
+htc,z4dug,HTC Desire 500 dual sim,2,-28,1
+htc,htc_csnu,HTC Desire 501,2,-28,1
+htc,csndug,HTC Desire 501 dual sim,2,-28,1
+htc,htc_a11ul,HTC Desire 510,2,-28,1
+htc,htc_a11ul8x26,HTC Desire 510,2,-28,1
+htc,htc_a11aul8x26,HTC Desire 512,2,-28,1
+htc,htc_v2_dcg,HTC Desire 516 dual sim,2,-28,1
+htc,htc_v2_dug,HTC Desire 516 dual sim,2,-28,1
+htc,htc_a13wl,HTC Desire 526,2,-28,1
+htc,htc_v02_u,HTC Desire 526G,2,-28,1
+htc,htc_v02_dug,HTC Desire 526G dual sim,2,-28,1
+htc,htc_v02_dug,HTC Desire 526GPLUS dual sim,2,-28,1
+htc,htc_a16ul,HTC Desire 530,5,-28,3
+htc,htc_a16wl,HTC Desire 530,2,-28,1
+htc,htc_a15ul,HTC Desire 550,2,-28,1
+htc,htc_a15ul,HTC Desire 555,2,-28,1
+htc,cp3dug,HTC Desire 600,2,-28,1
+htc,cp3dug,HTC Desire 600 dual sim,2,-28,1
+htc,cp3dcg,HTC Desire 600c dual sim,2,-28,1
+htc,zara,HTC Desire 601,2,-28,1
+htc,zaracl,HTC Desire 601,2,-28,1
+htc,zaradug,HTC Desire 601 dual sim,2,-28,1
+htc,htc_a3ul,HTC Desire 610,2,-28,1
+htc,htc_a3qhdul,HTC Desire 610,2,-28,1
+htc,htc_a3qhdcl,HTC Desire 612,2,-28,1
+htc,htc_v3_dug,HTC Desire 616 dual sim,2,-28,1
+htc,htc_a31ul,HTC Desire 620,2,-28,1
+htc,htc_a31mg_dug,HTC Desire 620G dual sim,2,-28,1
+htc,htc_a32eul,HTC Desire 625,2,-28,1
+htc,htc_a32ul,HTC Desire 626,2,-28,1
+htc,htc_a32eulatt,HTC Desire 626,2,-28,1
+htc,htc_a32ul_emea,HTC Desire 626,2,-28,1
+htc,htc_a32ml_dtul,HTC Desire 626 dual sim,2,-28,1
+htc,htc_a32mg_dug,HTC Desire 626G dual sim,2,-28,1
+htc,htc_a32mg_dug,HTC Desire 626GPLUS dual sim,2,-28,1
+htc,htc_a32ewhl,HTC Desire 626s,2,-28,1
+htc,htc_a32eul,HTC Desire 626s,2,-28,1
+htc,htc_a32eul_la,HTC Desire 626s,2,-28,1
+htc,htc_v36bml_uhl,HTC Desire 628,2,-28,1
+htc,htc_v36bml_dugl,HTC Desire 628 dual sim,2,-28,1
+htc,htc_a16dwgl,HTC Desire 630 dual sim,2,-28,1
+htc,htc_a17uhl,HTC Desire 650,2,-28,1
+htc,htc_a37_dugl,HTC Desire 650 dual sim,2,-28,1
+htc,cp5dug,HTC Desire 700 dual sim,2,-28,1
+htc,cp5dwg,HTC Desire 700 dual sim,2,-28,1
+htc,htc_a50cml_tuhl,HTC Desire 728,2,-28,1
+htc,htc_a50cml_dtul,HTC Desire 728 dual sim,2,-28,1
+htc,htc_a50cmg_dwg,HTC Desire 728G dual sim,2,-28,1
+htc,htc_a5ul,HTC Desire 816,2,-28,1
+htc,htc_a5chl,HTC Desire 816,2,-28,1
+htc,htc_a5dug,HTC Desire 816 dual sim,2,-28,1
+htc,htc_a5dwg,HTC Desire 816 dual sim,2,-28,1
+htc,htc_a5dwgl,HTC Desire 816 dual sim,2,-28,1
+htc,htc_a5mgp_u,HTC Desire 816G,2,-28,1
+htc,htc_a5mgp_dug,HTC Desire 816G dual sim,2,-28,1
+htc,htc_a5mg_dug,HTC Desire 816G dual sim,2,-28,1
+htc,htc_a51ul,HTC Desire 820,2,-28,1
+htc,htc_a51dtul,HTC Desire 820 dual sim,2,-28,1
+htc,htc_a50mgp_dug,HTC Desire 820G PLUS dual sim,2,-28,1
+htc,htc_a50mgp_dug,HTC Desire 820G dual sim,2,-28,1
+htc,htc_a50dtul,HTC Desire 820q dual sim,2,-28,1
+htc,htc_a50ml,HTC Desire 820s dual sim,2,-28,1
+htc,htc_a50ml_dtul,HTC Desire 820s dual sim,2,-28,1
+htc,htc_a56uhl,HTC Desire 825,2,-28,1
+htc,htc_a56dugl,HTC Desire 825 dual sim,2,-28,1
+htc,htc_a52dtul,HTC Desire 826 dual sim,2,-28,1
+htc,htc_a52dwgl,HTC Desire 826 dual sim,2,-28,1
+htc,htc_a51bml_tuhl,HTC Desire 828,2,-28,1
+htc,htc_a51bml_dtul,HTC Desire 828 dual sim,2,-28,1
+htc,htc_a51bml_dwgl,HTC Desire 828 dual sim,2,-28,1
+htc,htc_a51cml_tuhl,HTC Desire 830,2,-28,1
+htc,htc_a51cml_dtul,HTC Desire 830 dual sim,2,-28,1
+htc,golfc,HTC Desire C,2,-28,1
+htc,golfu,HTC Desire C,2,-28,1
+htc,htc_eyeul,HTC Desire EYE,2,-28,1
+htc,htc_eyetuhl,HTC Desire EYE,2,-28,1
+htc,htc_eyeul_att,HTC Desire Eye,2,-28,1
+htc,ace,HTC Desire HD A9191,2,-28,1
+htc,cp2dug,HTC Desire L dual sim,2,-28,1
+htc,magniu,HTC Desire P,2,-28,1
+htc,primods,HTC Desire Q,2,-28,1
+htc,saga,HTC Desire S,2,-28,1
+htc,magnids,HTC Desire SV,2,-28,1
+htc,primods,HTC Desire U,2,-28,1
+htc,primods,HTC Desire U dual sim,2,-28,1
+htc,primods,HTC Desire V,2,-28,1
+htc,primodd,HTC Desire VC,2,-28,1
+htc,primodd,HTC Desire VC T328d,2,-28,1
+htc,protou,HTC Desire X,2,-28,1
+htc,protodug,HTC Desire X dual sim,2,-28,1
+htc,protodcg,HTC Desire XC dual sim,2,-28,1
+htc,dream,HTC Dream,2,-28,1
+htc,htc_a55ml_dtul,HTC E9pt,2,-28,1
+htc,htc_a55ml_dtul,HTC E9pw,2,-28,1
+htc,htc_a53ml_dtul,HTC E9t,2,-28,1
+htc,htc_a53ml_dtul,HTC E9w,2,-28,1
+htc,evitareul,HTC EVARE_UL,2,-28,1
+htc,evitautl,HTC EVA_UTL,2,-28,1
+htc,shooteru,HTC EVO 3D X515a,2,-28,1
+htc,shooteru,HTC EVO 3D X515m,2,-28,1
+htc,kingdom,HTC EVO Design C715e,2,-28,1
+htc,pico,HTC Explorer,2,-28,1
+htc,pico,HTC Explorer A310b,2,-28,1
+htc,pico,HTC Explorer A310e,2,-28,1
+htc,flyer,HTC Flyer,2,-28,1
+htc,express,HTC Flyer,2,-28,1
+htc,flyer,HTC Flyer P510e,2,-28,1
+htc,flyer,HTC Flyer P511e,2,-28,1
+htc,flyer,HTC Flyer P512,2,-28,1
+htc,glacier,HTC Glacier,2,-28,1
+htc,liberty,HTC Gratia A6380,2,-28,1
+htc,hero,HTC Hero,2,-28,1
+htc,kingdom,HTC Hero S,2,-28,1
+htc,tagh,HTC Incredible E S715e,2,-28,1
+htc,vivo,HTC Incredible S,2,-28,1
+htc,vivow,HTC IncredibleS S710d,2,-28,1
+htc,shooteru,HTC Inspire 3D,2,-28,1
+htc,valentewxc9,HTC J Z321e,2,-28,1
+htc,k2u,HTC K2_U,2,-28,1
+htc,k2ul,HTC K2_UL,2,-28,1
+htc,kingdom,HTC Kingdom,2,-28,1
+htc,legend,HTC Legend,2,-28,1
+htc,liberty,HTC Liberty,2,-28,1
+htc,htc_pmeuhl,HTC M10h,2,-33,1
+htc,htc_pmec2tuhl,HTC M10u,0,-31,1
+htc,htc_melstuhl,HTC M8Et,2,-28,1
+htc,htc_melsuhl,HTC M8Ew,2,-28,1
+htc,htc_mecdwg,HTC M8Sd,2,-28,1
+htc,htc_mectl,HTC M8Ss,2,-28,1
+htc,htc_mectl,HTC M8St,2,-28,1
+htc,htc_mecdug,HTC M8Sw,2,-28,1
+htc,htc_m8dwg,HTC M8d,2,-28,1
+htc,htc_m8dug,HTC M8e,2,-28,1
+htc,htc_m8qltuhl,HTC M8si,2,-28,1
+htc,htc_m8tl,HTC M8t,2,-28,1
+htc,htc_m8,HTC M8w,2,-28,1
+htc,htc_himaruhl,HTC M9e,2,-28,1
+htc,htc_hima_ace_ml_dtul,HTC M9et,2,-28,1
+htc,htc_hima_ace_ml_dtul,HTC M9ew,2,-28,1
+htc,htc_hiau_ml_tuhl,HTC M9pt,2,-28,1
+htc,htc_hiau_ml_tuhl,HTC M9pw,2,-28,1
+htc,htc_hiaur_ml_tuhl,HTC M9pw,2,-28,1
+htc,htc_himauhl,HTC M9w,2,-28,1
+htc,sapphire,HTC Magic,2,-28,1
+htc,mecha,HTC Mecha,2,-28,1
+htc,primou,HTC ONE V,2,-28,1
+htc,m7,HTC One,2,-28,1
+htc,m7wls,HTC One,2,-28,1
+htc,m7wlv,HTC One,2,-28,1
+htc,m7,HTC One 801e,2,-28,1
+htc,m7,HTC One 801s,2,-28,1
+htc,htc_hiaeul,HTC One A9,2,-28,1
+htc,htc_hiaeuhl,HTC One A9,2,-28,1
+htc,htc_e36_ml_ul,HTC One A9s,2,-28,1
+htc,htc_e36_ml_uhl,HTC One A9s,2,-28,1
+htc,htc_a53ml_dtul,HTC One E9 dual sim,2,-28,1
+htc,htc_a55ml_dtul,HTC One E9PLUS dual sim,2,-28,1
+htc,htc_a50aml,HTC One E9s dual sim,2,-28,1
+htc,htc_m8qlul,HTC One M8s,2,-28,1
+htc,htc_himauhl,HTC One M9,2,-28,1
+htc,htc_himawhl,HTC One M9,2,-28,1
+htc,htc_himaulatt,HTC One M9,2,-28,1
+htc,htc_himaul,HTC One M9,2,-28,1
+htc,htc_hiau_ml_tuhl,HTC One M9PLUS,2,-28,1
+htc,htc_hiaur_ml_tuhl,HTC One M9PLUS,2,-28,1
+htc,htc_hiaur2_ml_tuhl,HTC One M9PLUS_Prime Camera Edition,2,-28,1
+htc,htc_himaruhl,HTC One M9_Prime Camera Edition,2,-28,1
+htc,htc_himaruhl,HTC One M9s,2,-28,1
+htc,htc_hima_ace_ml_dtul,HTC One ME dual sim,2,-28,1
+htc,ville,HTC One S,2,-28,1
+htc,villec2,HTC One S,2,-28,1
+htc,villeplus,HTC One S Special Edition,2,-28,1
+htc,htc_himar2uhl,HTC One S9,2,-28,1
+htc,cp2dcg,HTC One SC,2,-28,1
+htc,cp2dcg,HTC One SC T528d,2,-28,1
+htc,k2ul,HTC One SV,2,-28,1
+htc,k2u,HTC One SV,2,-28,1
+htc,k2plccl,HTC One SV,2,-28,1
+htc,k2plccl,HTC One SV BLK,2,-28,1
+htc,primoc,HTC One V,2,-28,1
+htc,primou,HTC One V,2,-28,1
+htc,totemc2,HTC One VX,2,-28,1
+htc,evita,HTC One X,2,-28,1
+htc,endeavoru,HTC One X,2,-28,1
+htc,enrc2b,HTC One X+,2,-28,1
+htc,evitareul,HTC One X+,2,-28,1
+htc,htc_e66_dugl,HTC One X10,2,-28,1
+htc,htc_e66_dtwl,HTC One X10,2,-28,1
+htc,htc_e56ml_dtul,HTC One X9 dual sim,2,-28,1
+htc,evita,HTC One XL,2,-28,1
+htc,m7cdwg,HTC One dual 802d,2,-28,1
+htc,m7cdwg,HTC One dual sim,2,-28,1
+htc,m7cdug,HTC One dual sim,2,-28,1
+htc,t6ul,HTC One max,2,-28,1
+htc,htc_m4,HTC One mini,2,-28,1
+htc,m4,HTC One mini,2,-28,1
+htc,htc_memul,HTC One mini 2,2,-28,1
+htc,htc_mecul,HTC One_E8,2,-28,1
+htc,htc_mecul_emea,HTC One_E8,2,-28,1
+htc,htc_mectl,HTC One_E8,2,-28,1
+htc,htc_mecdug,HTC One_E8 dual sim,2,-28,1
+htc,htc_mecdwg,HTC One_E8 dual sim,2,-28,1
+htc,htc_m8wl,HTC One_M8,2,-28,1
+htc,htc_m8,HTC One_M8,2,-28,1
+htc,htc_melsuhl,HTC One_M8 Eye,2,-28,1
+htc,htc_m8dug,HTC One_M8 dual sim,2,-28,1
+htc,puccinilte,HTC PG09410,2,-28,1
+htc,holiday,HTC PH39100,2,-28,1
+htc,csndug,HTC PO091,2,-28,1
+htc,cp3dug,HTC PO49120,2,-28,1
+htc,protou,HTC POO_U,2,-28,1
+htc,primods,HTC PROMIN_U,2,-28,1
+htc,primodd,HTC PRO_DD,2,-28,1
+htc,primods,HTC PRO_DS,2,-28,1
+htc,glacier,HTC Panache,2,-28,1
+htc,holiday,HTC Raider X710e,2,-28,1
+htc,bliss,HTC Rhyme S510b,2,-28,1
+htc,ruby,HTC Ruby,2,-28,1
+htc,endeavoru,HTC S720e,2,-28,1
+htc,icong,HTC Salsa C510b,2,-28,1
+htc,icong,HTC Salsa C510e,2,-28,1
+htc,pyramid,HTC Sensation,2,-28,1
+htc,pyramid,HTC Sensation 4G,2,-28,1
+htc,pyramid,HTC Sensation XE with Beats Audio,2,-28,1
+htc,pyramid,HTC Sensation XE with Beats Audio Z715a,2,-28,1
+htc,pyramid,HTC Sensation XE with Beats Audio Z715e,2,-28,1
+htc,runnymede,HTC Sensation XL with Beats Audio X315b,2,-28,1
+htc,runnymede,HTC Sensation XL with Beats Audio X315e,2,-28,1
+htc,pyramid,HTC Sensation Z710a,2,-28,1
+htc,pyramid,HTC Sensation Z710e,2,-28,1
+htc,chacha,HTC Status,2,-28,1
+htc,primods,HTC T327w,2,-28,1
+htc,primodd,HTC T328d,2,-28,1
+htc,primods,HTC T328w,2,-28,1
+htc,protodcg,HTC T329d,2,-28,1
+htc,htc_alpine_uhl,HTC U Play,2,-28,1
+htc,htc_alpine_dugl,HTC U Play,2,-28,1
+htc,htc_ocedugl,HTC U Ultra,-5,-29,1
+htc,htc_oceuhl,HTC U Ultra,-5,-29,1
+htc,htc_ocedtwl,HTC U-1w,-5,-29,1
+htc,htc_ocndtwl,HTC U-3w,3,-24,1
+htc,htc_ocnwhl,HTC U11,2,-21,3
+htc,htc_ocnuhljapan,HTC U11,3,-24,1
+htc,htc_ocndugl,HTC U11,2,-27,3
+htc,htc_ocnuhl,HTC U11,3,-24,1
+htc,htc_haydugl,HTC U11 EYEs,2,-28,1
+htc,htc_oclul,HTC U11 Life,2,-28,1
+htc,htc_ocluhljapan,HTC U11 Life,2,-28,1
+htc,htc_ocla1_sprout,HTC U11 life,2,-28,1
+htc,htc_ocluhljapan,HTC U11 life,2,-28,1
+htc,htc_oclul,HTC U11 life,2,-28,1
+htc,htc_ocmdugl,HTC U11 plus,3,-28,3
+htc,htc_imldugl,HTC U12 life,2,-23,3
+htc,htc_imeuhl,HTC U12+,7,-33,1
+htc,htc_imeuhljp,HTC U12+,7,-33,1
+htc,htc_imedugl,HTC U12+,7,-33,3
+htc,htc_v2_dug,HTC V2,2,-28,1
+htc,htc_v3_dug,HTC V3,2,-28,1
+htc,ville,HTC VLE_U,2,-28,1
+htc,holiday,HTC Velocity 4G,2,-28,1
+htc,holiday,HTC Velocity 4G X710s,2,-28,1
+htc,vision,HTC Vision,2,-28,1
+htc,htc_a50bml,HTC WF5w,2,-28,1
+htc,buzz,HTC Wildfire,2,-28,1
+htc,bee,HTC Wildfire,2,-28,1
+htc,marvel,HTC Wildfire S,2,-28,1
+htc,marvel,HTC Wildfire S A510b,2,-28,1
+htc,marvel,HTC Wildfire S A510e,2,-28,1
+htc,marvelc,HTC Wildfire S A515c,2,-28,1
+htc,htc_h11dugl,HTC Wildfire X,2,-28,1
+htc,dlxu,HTC X920e,2,-28,1
+htc,htc_e56ml_dtul,HTC X9u,2,-28,1
+htc,villec2,HTC Z560e,2,-28,1
+htc,htc_brepdugl,HTC ZQ5W10000,2,-28,1
+htc,mystul,HTC first,2,-28,1
+htc,marvel,HTC-A510a,2,-28,1
+htc,puccinilte,HTC-P715a,2,-28,1
+htc,marvelc,HTC-PG762,2,-28,1
+htc,runnymede,HTC-X315E,2,-28,1
+htc,holiday,HTC-X710a,2,-28,1
+htc,pyramid,HTC-Z710a,2,-28,1
+htc,t6whl,HTC0P3P7,2,-28,1
+htc,zaracl,HTC0P4E1,2,-28,1
+htc,htc_a3qhdcl,HTC331ZLVW,2,-28,1
+htc,htc_a3qhdcl,HTC331ZLVWPP,2,-28,1
+htc,dlx,HTC6435LRA,2,-28,1
+htc,dlx,HTC6435LVW,2,-28,1
+htc,m7wlv,HTC6500LVW,2,-28,1
+htc,htc_memwl,HTC6515LVW,2,-28,1
+htc,htc_m8wl,HTC6525LVW,2,-28,1
+htc,htc_himawl,HTC6535LRA,2,-28,1
+htc,htc_himawl,HTC6535LVW,2,-28,1
+htc,htc_pmewl,HTC6545LVW,1,-31,1
+htc,t6wl,HTC6600LVW,2,-28,1
+htc,htc_a13wl,HTCD100LVW,2,-28,1
+htc,htc_a13wlpp,HTCD100LVWPP,2,-28,1
+htc,htc_a16wl,HTCD160LVW,2,-28,1
+htc,htc_a16wl,HTCD160LVWPP,2,-28,1
+htc,htc_a32ewl,HTCD200LVW,2,-28,1
+htc,htc_a32ewlpp,HTCD200LVWPP,2,-28,1
+htc,kingdom,HTCEVODesign4G,2,-28,1
+htc,shooter,HTCEVOV4G,2,-28,1
+htc,m7wls,HTCONE,2,-28,1
+htc,t6ul,HTC_0P3P5,2,-28,1
+htc,zara,HTC_0P4E2,2,-28,1
+htc,g3u,HTC_0P6A1,2,-28,1
+htc,htc_m8,HTC_0P6B,2,-28,1
+htc,htc_m8,HTC_0P6B6,2,-28,1
+htc,htc_a5ul,HTC_0P9C2,2,-28,1
+htc,htc_a3qhdul,HTC_0P9O2,2,-28,1
+htc,htc_a11ul,HTC_0PCV2,2,-28,1
+htc,htc_a51tuhl,HTC_0PFJ50,2,-28,1
+htc,htc_himauhl,HTC_0PJA10,2,-28,1
+htc,htc_m8qlul,HTC_0PKV1,2,-28,1
+htc,htc_a32ul_emea,HTC_0PKX2,2,-28,1
+htc,htc_ocmdugl,HTC_2Q4D100,3,-28,1
+htc,htc_csnu,HTC_603h,2,-28,1
+htc,cp5dug,HTC_7060,2,-28,1
+htc,cp5dwg,HTC_709d,2,-28,1
+htc,marvelc,HTC_A510c,2,-28,1
+htc,htc_e36_ml_uhl,HTC_A9sx,2,-28,1
+htc,htc_hiaeuhl,HTC_A9u,2,-28,1
+htc,ruby,HTC_Amaze_4G,2,-28,1
+htc,htc_b2ul,HTC_B810x,2,-28,1
+htc,htc_b3tuhl,HTC_B830x,2,-28,1
+htc,dlxpul,HTC_Butterfly_s_901s,2,-28,1
+htc,htc_a56dj_pro_dugl,HTC_D10i,2,-28,1
+htc,htc_a56djuhl,HTC_D10u,2,-28,1
+htc,htc_v1_u,HTC_D310n,2,-28,1
+htc,htc_v02_dug,HTC_D526h,2,-28,1
+htc,htc_a16ul,HTC_D530u,5,-28,1
+htc,htc_a3qhdul,HTC_D610x,2,-28,1
+htc,htc_a31mg_dug,HTC_D620h,2,-28,1
+htc,htc_a31dtul,HTC_D620u,2,-28,1
+htc,htc_a32mg_dug,HTC_D626ph,2,-28,1
+htc,htc_a32ml_dtul,HTC_D626q,2,-28,1
+htc,htc_a32ul,HTC_D626x,2,-28,1
+htc,htc_v36bml_uhl,HTC_D628u,2,-28,1
+htc,htc_a32ul,HTC_D630x,2,-28,1
+htc,htc_a17uhl,HTC_D650h,2,-28,1
+htc,htc_a50cml_dtul,HTC_D728x,2,-28,1
+htc,htc_a5dwg,HTC_D816d,2,-28,1
+htc,htc_a5ul,HTC_D816x,2,-28,1
+htc,htc_a51tuhl,HTC_D820f,2,-28,1
+htc,htc_a50mgp_dug,HTC_D820pi,2,-28,1
+htc,htc_a50ml,HTC_D820ts,2,-28,1
+htc,htc_a51dtul,HTC_D820u,2,-28,1
+htc,htc_a50ml,HTC_D820ys,2,-28,1
+htc,htc_a50ml_dtul,HTC_D820ys,2,-28,1
+htc,htc_a56uhl,HTC_D825u,2,-28,1
+htc,htc_a52tuhl,HTC_D826y,2,-28,1
+htc,htc_a51bml_tuhl,HTC_D828g,2,-28,1
+htc,htc_a51bml_dtul,HTC_D828x,2,-28,1
+htc,htc_a51cml_tuhl,HTC_D830x,2,-28,1
+htc,gtou,HTC_Desire_200,2,-28,1
+htc,g3u,HTC_Desire_300,2,-28,1
+htc,htc_v01_u,HTC_Desire_320,2,-28,1
+htc,z4u,HTC_Desire_500,2,-28,1
+htc,htc_a55ml_dtul,HTC_E9pw,2,-28,1
+htc,htc_a50aml,HTC_E9sx,2,-28,1
+htc,htc_a53ml_dtul,HTC_E9x,2,-28,1
+htc,flyer,HTC_Flyer_P512_NA,2,-28,1
+htc,htc_acauhl,HTC_M10f,2,-28,1
+htc,htc_pmeuhl,HTC_M10h,2,-33,1
+htc,htc_memul,HTC_M8MINx,2,-28,1
+htc,htc_mecdwg,HTC_M8Sd,2,-28,1
+htc,htc_mecul,HTC_M8Sx,2,-28,1
+htc,htc_mecdug,HTC_M8Sy,2,-28,1
+htc,htc_m8,HTC_M8x,2,-28,1
+htc,htc_eyetuhl,HTC_M910x,2,-28,1
+htc,htc_himaruhl,HTC_M9e,2,-28,1
+htc,htc_hima_ace_ml_dtul,HTC_M9ew,2,-28,1
+htc,htc_hiau_ml_tuhl,HTC_M9pw,2,-28,1
+htc,htc_hiaur_ml_tuhl,HTC_M9px,2,-28,1
+htc,htc_himauhl,HTC_M9u,2,-28,1
+htc,evita,HTC_One_XL,2,-28,1
+htc,t6ul,HTC_One_max,2,-28,1
+htc,htc_memul,HTC_One_mini_2,2,-28,1
+htc,m4,HTC_One_mini_601e,2,-28,1
+htc,expresskt,HTC_P515E,2,-28,1
+htc,m7,HTC_PN071,2,-28,1
+htc,m4,HTC_PO582,2,-28,1
+htc,vivo,HTC_S710E,2,-28,1
+htc,htc_himar2uhl,HTC_S9u,2,-28,1
+htc,htc_ocedugl,HTC_U-1u,-5,-29,3
+htc,htc_alpine_dugl,HTC_U-2u,2,-28,1
+htc,htc_ocndugl,HTC_U-3u,5,-23,3
+htc,htc_v1_u,HTC_V1,2,-28,1
+htc,htc_e66_dugl,HTC_X10u,2,-28,1
+htc,rider,HTC_X515E,2,-28,1
+htc,htc_e56ml_dtul,HTC_X9u,2,-28,1
+htc,dlxj,HTL21,2,-28,1
+htc,m7wlj,HTL22,2,-28,1
+htc,htc_b2wlj,HTL23,2,-28,1
+htc,htc_b3uhl,HTV31,2,-28,1
+htc,htc_pmeuhljapan,HTV32,0,-31,1
+htc,htc_ocnuhljapan,HTV33,3,-24,1
+htc,imnj,HTX21,2,-28,1
+htc,shooterk,ISW12HT,2,-28,1
+htc,valentewx,ISW13HT,2,-28,1
+htc,ace,Inspire HD,2,-28,1
+htc,htc_pmewl,MSM8996 for arm64,1,-31,1
+htc,flounder_lte,Nexus 9,2,-28,1
+htc,flounder,Nexus 9,2,-28,1
+htc,passion,Nexus One,2,-28,1
+htc,bravoc,PB99400,2,-28,1
+htc,supersonic,PC36100,2,-28,1
+htc,speedy,PG06100,2,-28,1
+htc,express,PG41200,2,-28,1
+htc,shooter,PG86100,2,-28,1
+htc,kingdom,PH44100,2,-28,1
+htc,desirec,Pulse,2,-28,1
+htc,runnymede,Sensation XL with Beats Audio,2,-28,1
+htc,vision,T-Mobile G2,2,-28,1
+htc,hero,T-Mobile G2 Touch,2,-28,1
+htc,sapphire,T-Mobile myTouch 3G,2,-28,1
+htc,espresso,T-Mobile myTouch 3G Slide,2,-28,1
+htc,hero,T-Mobile_G2_Touch,2,-28,1
+htc,marvelc,USCCADR6230US,2,-28,1
+htc,Wildfire_E,Wildfire E,2,-28,1
+htc,Wildfire-E1,Wildfire E1,2,-28,1
+htc,Wildfire_E1_Plus,Wildfire E1 Plus,2,-28,1
+htc,bravo,X06HT,2,-28,1
+htc,htc_ocla1_sprout,X2-HT,2,-28,1
+htc,htc_a37dj_dugl,a37dj dugl,2,-28,1
+htc,hero,dopod A6288,2,-28,1
+htc,doubleshot,myTouch_4G_Slide,2,-28,1
+huawei,msm7227,004HW,2,-17,1
+huawei,hwu8850,007HW,2,-17,1
+huawei,hwu9201L,201HW,2,-17,1
+huawei,hw204HW,204HW,2,-17,1
+huawei,hwp6s-l04,302HW,2,-17,1
+huawei,hws10231l,402HW,2,-17,1
+huawei,hws8301l,403HW,2,-17,1
+huawei,hwALE-H,503HW,2,-17,1
+huawei,hwfdr,605HW,2,-17,1
+huawei,hwfdr,606HW,2,-17,1
+huawei,HWPRA-H,608HW,1,-3,1
+huawei,HWCPN-Q,701HW,2,-17,1
+huawei,HWCPN-Q,702HW,2,-17,1
+huawei,HWFIG-H,704HW,2,-17,1
+huawei,hw7d501l,7D-501u,2,-17,1
+huawei,hwS7-901w,A01HW,2,-17,1
+huawei,HWAGS-Q,AGS-L03,2,-17,1
+huawei,HWAGS-Q,AGS-L09,2,-17,1
+huawei,HWAGS-Q,AGS-W09,2,-17,1
+huawei,HWAGS2,AGS2-AL00,2,-17,1
+huawei,HWAGS2,AGS2-AL00HN,2,-17,1
+huawei,HWAGS2,AGS2-L03,2,-17,1
+huawei,HWAGS2,AGS2-L09,2,-17,1
+huawei,HWAGS2,AGS2-W09,2,-17,1
+huawei,HWAGS2,AGS2-W09HN,2,-17,1
+huawei,HWAGS2,AGS2-W19,2,-17,1
+huawei,hwALE-H,ALE-L02,2,-17,1
+huawei,hwALE-H,ALE-L21,2,-17,1
+huawei,hwALE-H,ALE-L23,2,-17,1
+huawei,hwALE-H,ALE-TL00,2,-17,1
+huawei,hwALE-H,ALE-UL00,2,-17,1
+huawei,HWALP,ALP-AL00,2,-17,1
+huawei,HWALP,ALP-L09,2,-17,1
+huawei,HWALP,ALP-L29,2,-17,1
+huawei,HWALP,ALP-TL00,2,-17,1
+huawei,HWAMN-M,AMN-LX1,2,-17,1
+huawei,HWAMN-M,AMN-LX2,2,-17,1
+huawei,HWAMN-M,AMN-LX3,2,-17,1
+huawei,HWAMN-M,AMN-LX9,2,-17,1
+huawei,HWANE,ANE-AL00,3,-3,1
+huawei,HWANE,ANE-LX1,3,-3,1
+huawei,HWANE,ANE-LX2,3,-3,1
+huawei,HWANE,ANE-LX2J,3,-3,1
+huawei,HWANE,ANE-LX3,3,-3,3
+huawei,HWANE,ANE-TL00,3,-3,1
+huawei,HWARE-Q,ARE-AL00,2,-17,1
+huawei,HWARE-QC,ARE-AL10,2,-17,1
+huawei,HWARE-QC,ARE-L22HN,2,-17,1
+huawei,HWARE-Q,ARE-TL00,2,-17,1
+huawei,HWARS-Q,ARS-AL00,2,-17,1
+huawei,HWARS-Q,ARS-L22,2,-17,1
+huawei,HWARS-Q,ARS-TL00,2,-17,1
+huawei,HWATH,ATH-AL00,2,-17,1
+huawei,HWATH,ATH-CL00,2,-17,1
+huawei,HWATH,ATH-TL00,2,-17,1
+huawei,HWATH,ATH-TL00H,2,-17,1
+huawei,HWATH,ATH-UL00,2,-17,1
+huawei,HWATU-QC,ATU-AL10,2,-17,1
+huawei,HWATU-QG,ATU-L11,2,-17,1
+huawei,HWATU-QG,ATU-L21,2,-17,1
+huawei,HWATU-QG,ATU-L22,2,-17,1
+huawei,HWATU-QG,ATU-L31,2,-17,1
+huawei,HWATU-QG,ATU-L42,2,-17,1
+huawei,HWATU-QG,ATU-LX3,2,-17,1
+huawei,HWATU-QC,ATU-TL10,2,-17,1
+huawei,HWAUM-Q,AUM-AL00,2,-17,1
+huawei,HWAUM-Q,AUM-AL20,2,-17,1
+huawei,HWAUM-Q,AUM-L29,2,-17,1
+huawei,HWAUM-Q,AUM-L33,2,-17,1
+huawei,HWAUM-Q,AUM-L41,2,-17,1
+huawei,HWAUM-Q,AUM-TL00,2,-17,1
+huawei,HWAUM-Q,AUM-TL20,2,-17,1
+huawei,hwu8651,Astro,2,-17,1
+huawei,hwALE-H,Autana LTE,2,-17,1
+huawei,HWBAC,BAC-AL00,2,-17,1
+huawei,HWBAC,BAC-L01,2,-17,1
+huawei,HWBAC,BAC-L03,2,-17,1
+huawei,HWBAC,BAC-L21,2,-17,1
+huawei,HWBAC,BAC-L22,2,-17,1
+huawei,HWBAC,BAC-L23,2,-17,1
+huawei,HWBAC,BAC-TL00,2,-17,1
+huawei,HWBAH-Q,BAH-AL00,2,-17,1
+huawei,HWBAH-Q,BAH-L09,2,-17,1
+huawei,HWBAH-Q,BAH-W09,2,-17,1
+huawei,HWBAH2,BAH2-AL00,2,-17,1
+huawei,HWBAH2,BAH2-AL10,2,-17,1
+huawei,HWBAH2,BAH2-L09,2,-17,1
+huawei,HWBAH2,BAH2-W09,2,-17,1
+huawei,HWBAH2,BAH2-W19,2,-17,1
+huawei,HWBG2,BG2-U01,2,-17,1
+huawei,HWBG2,BG2-U03,2,-17,1
+huawei,hwbg2,BG2-W09,2,-17,1
+huawei,hwbgo,BGO-DL09,2,-17,1
+huawei,hwbgo,BGO-L03,2,-17,1
+huawei,HWBKK-Q,BKK-AL00,2,-17,1
+huawei,HWBKK-Q,BKK-AL10,2,-17,1
+huawei,HWBKK-Q,BKK-L21,2,-17,1
+huawei,HWBKK-Q,BKK-L22,2,-17,1
+huawei,HWBKK-Q,BKK-LX2,2,-17,1
+huawei,HWBKK-Q,BKK-TL00,2,-17,1
+huawei,HWBKL,BKL-AL00,2,-17,1
+huawei,HWBKL,BKL-AL20,2,-17,1
+huawei,HWBKL,BKL-L04,2,-17,1
+huawei,HWBKL,BKL-L09,2,-17,1
+huawei,HWBKL,BKL-TL10,2,-17,1
+huawei,HWBLA,BLA-A09,2,-17,1
+huawei,HWBLA,BLA-AL00,2,-17,1
+huawei,HWBLA,BLA-L09,2,-17,1
+huawei,HWBLA,BLA-L29,2,-17,1
+huawei,HWBLA,BLA-TL00,2,-17,1
+huawei,HWBLN-H,BLL-L21,2,-17,1
+huawei,HWBLN-H,BLL-L22,2,-17,1
+huawei,HWBLN-H,BLL-L23,2,-17,1
+huawei,HWBLN-H,BLN-AL10,2,-17,1
+huawei,HWBLN-H,BLN-AL20,2,-17,1
+huawei,HWBLN-H,BLN-AL30,2,-17,1
+huawei,HWBLN-H,BLN-AL40,2,-17,1
+huawei,HWBLN-H,BLN-L21,2,-17,1
+huawei,HWBLN-H,BLN-L22,2,-17,1
+huawei,HWBLN-H,BLN-L24,2,-17,1
+huawei,HWBLN-H,BLN-TL00,2,-17,1
+huawei,HWBLN-H,BLN-TL10,2,-17,1
+huawei,HWBND-H,BND-AL00,2,-17,1
+huawei,HWBND-H,BND-AL10,2,-17,1
+huawei,HWBND-H,BND-L21,2,-17,1
+huawei,HWBND-H,BND-L24,2,-17,1
+huawei,HWBND-H,BND-L31,2,-17,1
+huawei,HWBND-H,BND-L34,2,-17,1
+huawei,HWBND-H,BND-TL10,2,-17,1
+huawei,hwbeethoven,BTV-DL09,2,-17,1
+huawei,hwbeethoven,BTV-W09,2,-17,1
+huawei,HWBZA-Q,BZA-L00,2,-17,1
+huawei,HWBZA-Q,BZA-W00,2,-17,1
+huawei,HWBZK-Q,BZK-L00,2,-17,1
+huawei,HWBZK-Q,BZK-W00,2,-17,1
+huawei,HWBZT,BZT-AL00,2,-17,1
+huawei,HWBZT,BZT-AL10,2,-17,1
+huawei,HWBZT,BZT-W09,2,-17,1
+huawei,HWHDL,BZW-AL00,2,-17,1
+huawei,HWHDL,BZW-AL10,2,-17,1
+huawei,hwu8350,Barcelona,2,-17,1
+huawei,msm7225,Beeline_E300,2,-17,1
+huawei,hwu8510,Beeline_E500,2,-17,1
+huawei,hwu8825-1,Bs 401,2,-17,1
+huawei,hwY330-U05,Bucare Y330-U05,2,-17,1
+huawei,hwc8500,C8500,2,-17,1
+huawei,hwc8511,C8511,2,-17,1
+huawei,hwc8512,C8512,2,-17,1
+huawei,C8600,C8600,2,-17,1
+huawei,msm7625,C8600,2,-17,1
+huawei,hwc8600,C8600,2,-17,1
+huawei,hwc8650,C8650,2,-17,1
+huawei,hwc8800,C8800,2,-17,1
+huawei,hwC8817D,C8817D,2,-17,1
+huawei,hwc8860V,C8860V,2,-17,1
+huawei,HWCAG-L6737M,CAG-L02,2,-17,1
+huawei,HWCAG-L6737M,CAG-L03,2,-17,1
+huawei,HWCAG-L6737M,CAG-L22,2,-17,1
+huawei,HWCAG-L6737M,CAG-L23,2,-17,1
+huawei,HWCAM-Q,CAM-AL00,2,-17,1
+huawei,HNCAM-Q,CAM-AL00,2,-17,1
+huawei,HNCAM-Q,CAM-CL00,2,-17,1
+huawei,HWCAM-H,CAM-L03,2,-17,1
+huawei,HWCAM-H,CAM-L21,2,-17,1
+huawei,HWCAM-H,CAM-L23,2,-17,1
+huawei,HWCAM-Q,CAM-L32,2,-17,1
+huawei,HNCAM-H,CAM-TL00,2,-17,1
+huawei,HWCAM-H,CAM-TL00,2,-17,1
+huawei,HNCAM-H,CAM-TL00H,2,-17,1
+huawei,HWCAM-H,CAM-TL00H,2,-17,1
+huawei,HWCAM-H,CAM-U22,2,-17,1
+huawei,HWCAM-H,CAM-UL00,2,-17,1
+huawei,HNCAM-H,CAM-UL00,2,-17,1
+huawei,hwCHC-H,CHC-U01,2,-17,1
+huawei,hwCHC-H,CHC-U03,2,-17,1
+huawei,hwCHC-H,CHC-U23,2,-17,1
+huawei,hnCHE-H,CHE-TL00,2,-17,1
+huawei,hnCHE-H,CHE-TL00H,2,-17,1
+huawei,hwCHM-Q,CHM-CL00,2,-17,1
+huawei,hwCHM-H,CHM-TL00,2,-17,1
+huawei,hwCHM-H,CHM-TL00H,2,-17,1
+huawei,hwCHM-H,CHM-U01,2,-17,1
+huawei,hwCHM-H,CHM-UL00,2,-17,1
+huawei,CHT8000,CHT8000,2,-17,1
+huawei,HWCLT,CLT-AL00,-1,-30,1
+huawei,HWCLT,CLT-AL00l,-1,-30,1
+huawei,HWCLT,CLT-AL01,-1,-30,1
+huawei,HWCLT,CLT-L04,-1,-30,1
+huawei,HWCLT,CLT-L09,-1,-30,3
+huawei,HWCLT,CLT-L29,-1,-30,1
+huawei,HWCLT,CLT-TL00,-1,-30,1
+huawei,HWCLT,CLT-TL01,-1,-30,1
+huawei,hwcm980,CM980,2,-17,1
+huawei,hwCM990,CM990,2,-17,1
+huawei,HWCMR09,CMR-AL09,2,-17,1
+huawei,HWCMR,CMR-AL19,2,-17,1
+huawei,HWCMR09,CMR-W09,2,-17,1
+huawei,HWCMR,CMR-W19,2,-17,1
+huawei,hws8301l,CNPC Security Pad S1,2,-17,1
+huawei,HWCOL,COL-AL00,2,-17,1
+huawei,HWCOL,COL-AL10,2,-17,1
+huawei,HWCOL,COL-L29,2,-17,1
+huawei,HWCOL,COL-TL10,2,-17,1
+huawei,HWCOR,COR-AL00,2,-5,1
+huawei,HWCOR,COR-AL10,2,-5,1
+huawei,HWCOR,COR-L29,2,-5,3
+huawei,HWCOR,COR-TL10,2,-5,1
+huawei,HWCPN-Q,CPN-AL00,2,-17,1
+huawei,HWCPN-Q,CPN-L09,2,-17,1
+huawei,HWCPN-Q,CPN-W09,2,-17,1
+huawei,HWCRO-L6737M,CRO-L02,2,-17,1
+huawei,HWCRO-L6737M,CRO-L03,2,-17,1
+huawei,HWCRO-L6737M,CRO-L22,2,-17,1
+huawei,HWCRO-L6737M,CRO-L23,2,-17,1
+huawei,HWCRO-U6580M,CRO-U00,2,-17,1
+huawei,HWCRO-U6580M,CRO-U23,2,-17,1
+huawei,HWCUN-L6735,CUN-AL00,2,-17,1
+huawei,HWCUN-L6735,CUN-L22,2,-17,1
+huawei,HWCUN-L6735,CUN-TL00,2,-17,1
+huawei,Che1,Che1-CL10,2,-17,1
+huawei,Che1,Che1-CL20,2,-17,1
+huawei,Che1,Che1-L04,2,-17,1
+huawei,hwChe2,Che2-L11,2,-17,1
+huawei,hwChe2,Che2-L12,2,-17,1
+huawei,hwChe2,Che2-L23,2,-17,1
+huawei,hwChe2,Che2-TL00,2,-17,1
+huawei,hwChe2,Che2-TL00H,2,-17,1
+huawei,hwChe2,Che2-TL00M,2,-17,1
+huawei,hwChe2,Che2-UL00,2,-17,1
+huawei,U8150,Comet,2,-17,1
+huawei,HWDIG-L8940,DIG-AL00,2,-17,1
+huawei,HWDIG-L8940,DIG-L01,2,-17,1
+huawei,HWDIG-L8940,DIG-L03,2,-17,1
+huawei,HWDIG-L8940,DIG-L21,2,-17,1
+huawei,HWDIG-L8940,DIG-L21HN,2,-17,1
+huawei,HWDIG-L8940,DIG-L22,2,-17,1
+huawei,HWDIG-L8940,DIG-L23,2,-17,1
+huawei,HWDIG-L8940,DIG-TL10,2,-17,1
+huawei,HWDLI-Q,DLI-AL10,2,-17,1
+huawei,HWDLI-Q,DLI-L22,2,-17,1
+huawei,HWDLI-Q,DLI-L42,2,-17,1
+huawei,HWDLI-Q,DLI-TL20,2,-17,1
+huawei,HWDRA-M,DRA-AL00,2,-17,1
+huawei,HWDRA-M,DRA-L01,4,-24,1
+huawei,HWDRA-M,DRA-L21,4,-24,1
+huawei,HWDRA-M,DRA-LX2,2,-17,1
+huawei,HWDRA-MG,DRA-LX3,4,-24,3
+huawei,HWDRA-MG,DRA-LX5,4,-24,1
+huawei,HWDRA-M,DRA-TL00,2,-17,1
+huawei,HWDUA-M,DUA-AL00,2,-17,1
+huawei,HWDUA-M,DUA-L22,2,-17,1
+huawei,HWDUA-M,DUA-LX3,2,-17,1
+huawei,HWDUA-M,DUA-TL00,2,-17,1
+huawei,HWDUB-Q,DUB-AL00,2,-17,1
+huawei,HWDUB-Q,DUB-AL00a,2,-17,1
+huawei,HWDUB-Q,DUB-AL20,2,-17,1
+huawei,HWDUB-Q,DUB-LX1,2,-17,1
+huawei,HWDUB-Q,DUB-LX2,2,-17,1
+huawei,HWDUB-Q,DUB-LX3,2,-17,1
+huawei,HWDUB-Q,DUB-TL00,2,-17,1
+huawei,HWDUB-Q,DUB-TL00a,2,-17,1
+huawei,HWDUK,DUK-AL20,2,-17,1
+huawei,HWDUK,DUK-L09,2,-17,1
+huawei,HWDUK,DUK-TL30,2,-17,1
+huawei,HWY360-U6572,Delta Y360-U93,2,-17,1
+huawei,hwedison,EDI-AL10,2,-17,1
+huawei,hwedison,EDI-DL00,2,-17,1
+huawei,HWELE,ELE-AL00,2,-17,1
+huawei,HWELE,ELE-L04,2,-17,1
+huawei,HWELE,ELE-L09,2,-17,1
+huawei,HWELE,ELE-L14,2,-17,1
+huawei,HWELE,ELE-L29,2,-17,1
+huawei,HWELE,ELE-L39,2,-17,1
+huawei,HWELE,ELE-L49,2,-17,1
+huawei,HWELE,ELE-TL00,2,-17,1
+huawei,HWEML,EML-AL00,2,-17,1
+huawei,HWEML,EML-L09,2,-17,1
+huawei,HWEML,EML-L29,2,-17,1
+huawei,HWEML,EML-TL00,2,-17,1
+huawei,U8110,EQ U8110,2,-17,1
+huawei,hwes8100,ES8100,2,-17,1
+huawei,HWEVA,EVA-AL00,2,-17,1
+huawei,HWEVA,EVA-AL10,2,-17,1
+huawei,HWEVA,EVA-CL00,2,-17,1
+huawei,HWEVA,EVA-DL00,2,-17,1
+huawei,HWEVA,EVA-L09,2,-17,1
+huawei,HWEVA,EVA-L19,2,-17,1
+huawei,HWEVA,EVA-L29,2,-17,1
+huawei,HWEVA,EVA-TL00,2,-17,1
+huawei,HWEVR,EVR-AL00,2,-17,1
+huawei,HWEVR,EVR-AN00,2,-17,1
+huawei,HWEVR,EVR-L29,2,-17,1
+huawei,HWEVR,EVR-N29,2,-17,1
+huawei,HWEVR,EVR-TL00,2,-17,1
+huawei,hwu8655,Etisalat,2,-17,1
+huawei,hwm650,Express,2,-17,1
+huawei,HWFDR,FDR-A01L,2,-17,1
+huawei,HWFDR,FDR-A01w,2,-17,1
+huawei,HWFDR,FDR-A03L,2,-17,1
+huawei,hwfdr,FDR-A05L,2,-17,1
+huawei,HWFIG-H,FIG-AL00,2,-17,1
+huawei,HWFIG-H,FIG-AL10,2,-17,1
+huawei,HWFIG-H,FIG-LA1,2,-17,1
+huawei,HWFIG-H,FIG-LX1,2,-17,1
+huawei,HWFIG-H,FIG-LX2,2,-17,1
+huawei,HWFIG-H,FIG-LX3,2,-17,1
+huawei,HWFIG-H,FIG-TL00,2,-17,1
+huawei,HWFIG-H,FIG-TL10,2,-17,1
+huawei,HWFLA-H,FLA-AL00,2,-17,1
+huawei,HWFLA-H,FLA-AL10,2,-17,1
+huawei,HWFLA-H,FLA-AL20,2,-17,1
+huawei,HWFLA-H,FLA-LX1,2,-17,1
+huawei,HWFLA-H,FLA-LX2,2,-17,1
+huawei,HWFLA-H,FLA-LX3,2,-17,1
+huawei,HWFLA-H,FLA-TL00,2,-17,1
+huawei,HWFLA-H,FLA-TL10,2,-17,1
+huawei,HWFRD,FRD-AL00,2,-17,1
+huawei,HWFRD,FRD-AL10,2,-17,1
+huawei,HWFRD,FRD-DL00,2,-17,1
+huawei,HWFRD,FRD-L02,2,-17,1
+huawei,HWFRD,FRD-L04,2,-17,1
+huawei,HWFRD,FRD-L09,2,-17,1
+huawei,HWFRD,FRD-L14,2,-17,1
+huawei,HWFRD,FRD-L19,2,-17,1
+huawei,HWFRD,FRD-L24,2,-17,1
+huawei,HWFRD,FRD-TL00,2,-17,1
+huawei,hwG526-L11,G526-L11,2,-17,1
+huawei,hwG526-L22,G526-L22,2,-17,1
+huawei,hwG526-L33,G526-L33,2,-17,1
+huawei,hwG527-U081,G527-U081,2,-17,1
+huawei,hwG610-U00,G610-U00,2,-17,1
+huawei,hwG615-U10,G615-U10,2,-17,1
+huawei,hwG620-L75,G620-L75,2,-17,1
+huawei,hwG620S-L01,G620S-L01,2,-17,1
+huawei,hwG620S-L02,G620S-L02,2,-17,1
+huawei,hwG620S-L03,G620S-L03,2,-17,1
+huawei,hwG620S-UL00,G620S-UL00,2,-17,1
+huawei,hwG621-TL00,G621-TL00,2,-17,1
+huawei,hwG621-TL00,G621-TL00M,2,-17,1
+huawei,hwG630-U10,G630-U10,2,-17,1
+huawei,hwG630-U20,G630-U20,2,-17,1
+huawei,hwG630-U251,G630-U251,2,-17,1
+huawei,hwG7-L01,G7-L01,2,-17,1
+huawei,hwG7-L03,G7-L03,2,-17,1
+huawei,hwG7-TL00,G7-TL00,2,-17,1
+huawei,hwG735,G735-L03,2,-17,1
+huawei,hwG735,G735-L12,2,-17,1
+huawei,hwG735,G735-L23,2,-17,1
+huawei,hwG740-L00,G740-L00,2,-17,1
+huawei,HWGemini,GEM-701L,2,-17,1
+huawei,HWGemini,GEM-702L,2,-17,1
+huawei,HWGemini,GEM-703L,2,-17,1
+huawei,HWGemini,GEM-703LT,2,-17,1
+huawei,hwu9700L,GL07S,2,-17,1
+huawei,hwu8350,GM FOX,2,-17,1
+huawei,hwu8510,GM Ultimate Slim,2,-17,1
+huawei,hwu8860,GS02,2,-17,1
+huawei,hwu9200-92,GS03,2,-17,1
+huawei,hws10101w,GT01,2,-17,1
+huawei,hwu8500,Grameenphone Crystal,2,-17,1
+huawei,msm7225,Grameenphone Crystal,2,-17,1
+huawei,HWH1611-Q,H1611,2,-17,1
+huawei,HWH1621-Q,H1621,2,-17,1
+huawei,HWH710VL-Q,H1622,2,-17,1
+huawei,HWH1621-Q,H1623,2,-17,1
+huawei,HWH1711-Q,H1711,2,-17,1
+huawei,HWH1711-Q,H1711z,2,-17,1
+huawei,hwH30-C00,H30-C00,2,-17,1
+huawei,hwH30,H30-L02,2,-17,1
+huawei,hwH30-T00,H30-T00,2,-17,1
+huawei,hwH30-T10,H30-T10,2,-17,1
+huawei,hwH30-U10,H30-U10,2,-17,1
+huawei,hwH60,H60-L01,2,-17,1
+huawei,hwH60,H60-L02,2,-17,1
+huawei,hwH60,H60-L03,2,-17,1
+huawei,hwH60,H60-L04,2,-17,1
+huawei,hwH60,H60-L11,2,-17,1
+huawei,hwH60,H60-L12,2,-17,1
+huawei,hwH60,H60-L21,2,-17,1
+huawei,hwH60-L21,H60-L21,2,-17,1
+huawei,HWH710VL-Q,H710VL,2,-17,1
+huawei,HWH715BL-Q,H715BL,2,-17,1
+huawei,hwh866c,H866C,2,-17,1
+huawei,hwh882l,H882L,2,-17,1
+huawei,HWHDL,HDL-AL09,2,-17,1
+huawei,HWHDL,HDL-W09,2,-17,1
+huawei,HWHDN-H,HDN-L09,2,-17,1
+huawei,HWHDN-H,HDN-W09,2,-17,1
+huawei,HWHLK-H,HLK-AL00,2,-17,1
+huawei,HWHMA,HMA-AL00,2,-17,1
+huawei,HWHMA,HMA-L09,2,-17,1
+huawei,HWHMA,HMA-L29,2,-17,1
+huawei,HWHMA,HMA-TL00,2,-17,1
+huawei,hwH30,HONOR H30-L01,2,-17,1
+huawei,hwH30,HONOR H30-L01M,2,-17,1
+huawei,hwH30,HONOR H30-L02,2,-17,1
+huawei,HWHRY-HF,HRY-AL00,2,-17,1
+huawei,HWHRY-H,HRY-AL00,2,-17,1
+huawei,HWHRY-H,HRY-AL00T,2,-17,1
+huawei,HWHRY-HF,HRY-AL00Ta,2,-17,1
+huawei,HWHRY-HF,HRY-AL00a,2,-17,1
+huawei,HWHRY-H,HRY-LX1,2,-17,1
+huawei,HWHRY-H,HRY-LX1MEB,2,-17,1
+huawei,HWHRY-HF,HRY-LX1T,2,-17,1
+huawei,HWHRY-H,HRY-LX2,2,-17,1
+huawei,HWHRY-H,HRY-TL00,2,-17,1
+huawei,HWHRY-HF,HRY-TL00T,2,-17,1
+huawei,hwRIO-L01,HUAWEI,2,-17,1
+huawei,hwa199,HUAWEI A199,2,-17,1
+huawei,hwALE-Q,HUAWEI ALE-CL00,2,-17,1
+huawei,hwALE-Q,HUAWEI ALE-L04,2,-17,1
+huawei,HWATH,HUAWEI ATH-UL01,2,-17,1
+huawei,HWATH,HUAWEI ATH-UL06,2,-17,1
+huawei,hwu8815,HUAWEI Ascend G 300,2,-17,1
+huawei,hwu8825-1,HUAWEI Ascend G 330,2,-17,1
+huawei,hwG510-0200,HUAWEI Ascend G510,2,-17,1
+huawei,hwG525-U00,HUAWEI Ascend G525,2,-17,1
+huawei,hwp6-u06,HUAWEI Ascend P6,2,-17,1
+huawei,hwy210-0100,HUAWEI Ascend Y 210,2,-17,1
+huawei,hwy210-0200,HUAWEI Ascend Y 210D,2,-17,1
+huawei,hwY300-0100,HUAWEI Ascend Y300,2,-17,1
+huawei,hwy210-0200,HUAWEI Asend Y 210D,2,-17,1
+huawei,hwB199,HUAWEI B199,2,-17,1
+huawei,HWBLN-H,HUAWEI BLL-L21,2,-17,1
+huawei,HWBLN-H,HUAWEI BLL-L22,2,-17,1
+huawei,HWBLN-H,HUAWEI BLL-L23,2,-17,1
+huawei,hwC199,HUAWEI C199,2,-17,1
+huawei,hwC199s,HUAWEI C199s,2,-17,1
+huawei,hwc8650e,HUAWEI C8650+,2,-17,1
+huawei,hwc8655,HUAWEI C8655,2,-17,1
+huawei,hwc8810,HUAWEI C8810,2,-17,1
+huawei,hwc8812,HUAWEI C8812,2,-17,1
+huawei,hwc8812E,HUAWEI C8812E,2,-17,1
+huawei,hwc8813,HUAWEI C8813,2,-17,1
+huawei,hwc8813,HUAWEI C8813D,2,-17,1
+huawei,hwC8813DQ,HUAWEI C8813DQ,2,-17,1
+huawei,hwC8813Q,HUAWEI C8813Q,2,-17,1
+huawei,hwC8815,HUAWEI C8815,2,-17,1
+huawei,hwC8816,HUAWEI C8816,2,-17,1
+huawei,hwC8816D,HUAWEI C8816D,2,-17,1
+huawei,hwC8817E,HUAWEI C8817E,2,-17,1
+huawei,hwC8817L,HUAWEI C8817L,2,-17,1
+huawei,hwC8818,HUAWEI C8818,2,-17,1
+huawei,hwc8825D,HUAWEI C8825D,2,-17,1
+huawei,hwc8826D,HUAWEI C8826D,2,-17,1
+huawei,hwc8860E,HUAWEI C8860E,2,-17,1
+huawei,hwC8860E,HUAWEI C8860E,2,-17,1
+huawei,hwc8950D,HUAWEI C8950D,2,-17,1
+huawei,HWCAM-H,HUAWEI CAM-L03,2,-17,1
+huawei,HWCAM-H,HUAWEI CAM-L21,2,-17,1
+huawei,HWCAM-H,HUAWEI CAM-L23,2,-17,1
+huawei,HWCAM-H,HUAWEI CAM-L53,2,-17,1
+huawei,HWCAM-H,HUAWEI CAM-U22,2,-17,1
+huawei,HWCAN,HUAWEI CAN-AL10,2,-17,1
+huawei,HWCAN,HUAWEI CAN-L01,2,-17,1
+huawei,HWCAN,HUAWEI CAN-L02,2,-17,1
+huawei,HWCAN,HUAWEI CAN-L03,2,-17,1
+huawei,HWCAN,HUAWEI CAN-L11,2,-17,1
+huawei,HWCAN,HUAWEI CAN-L12,2,-17,1
+huawei,HWCAN,HUAWEI CAN-L13,2,-17,1
+huawei,HWCAZ,HUAWEI CAZ-AL00,2,-17,1
+huawei,HWCAZ,HUAWEI CAZ-AL10,2,-17,1
+huawei,HWCAN,HUAWEI CAZ-AL10,2,-17,1
+huawei,HWCAZ,HUAWEI CAZ-TL10,2,-17,1
+huawei,HWCAZ,HUAWEI CAZ-TL20,2,-17,1
+huawei,HWCRO-L6737M,HUAWEI CRO-L02,2,-17,1
+huawei,HWCRO-L6737M,HUAWEI CRO-L03,2,-17,1
+huawei,HWCRO-L6737M,HUAWEI CRO-L22,2,-17,1
+huawei,HWCRO-L6737M,HUAWEI CRO-L23,2,-17,1
+huawei,HWCRO-U6580M,HUAWEI CRO-U00,2,-17,1
+huawei,HWCRO-U6580M,HUAWEI CRO-U23,2,-17,1
+huawei,HWCRR,HUAWEI CRR-CL00,2,-17,1
+huawei,HWCRR,HUAWEI CRR-CL20,2,-17,1
+huawei,HWCRR,HUAWEI CRR-L09,2,-17,1
+huawei,HWCRR,HUAWEI CRR-TL00,2,-17,1
+huawei,HWCRR,HUAWEI CRR-UL00,2,-17,1
+huawei,HWCRR,HUAWEI CRR-UL20,2,-17,1
+huawei,HWCUN-L6735,HUAWEI CUN-L01,2,-17,1
+huawei,HWCUN-L6735,HUAWEI CUN-L02,2,-17,1
+huawei,HWCUN-L6735,HUAWEI CUN-L03,2,-17,1
+huawei,HWCUN-L6735,HUAWEI CUN-L21,2,-17,1
+huawei,HWCUN-L6735,HUAWEI CUN-L22,2,-17,1
+huawei,HWCUN-L6735,HUAWEI CUN-L23,2,-17,1
+huawei,HWCUN-L6735,HUAWEI CUN-L33,2,-17,1
+huawei,HWCUN-U6582,HUAWEI CUN-U29,2,-17,1
+huawei,hwD2-0082,HUAWEI D2-0082,2,-17,1
+huawei,hwD2-2010,HUAWEI D2-2010,2,-17,1
+huawei,hwD2-6070,HUAWEI D2-6070,2,-17,1
+huawei,hwg350,HUAWEI G350,2,-17,1
+huawei,hwg350,HUAWEI G350-U00,2,-17,1
+huawei,HWG350,HUAWEI G350-U20,2,-17,1
+huawei,hwG506-U151,HUAWEI G506-U151,2,-17,1
+huawei,hwG510-0010,HUAWEI G510-0010,2,-17,1
+huawei,hwG510-0100,HUAWEI G510-0100,2,-17,1
+huawei,hwG510-0200,HUAWEI G510-0200,2,-17,1
+huawei,hwG510-0251,HUAWEI G510-0251,2,-17,1
+huawei,hwG520-5000,HUAWEI G520-5000,2,-17,1
+huawei,hwG520-T10,HUAWEI G520-T10,2,-17,1
+huawei,HWG521-L,HUAWEI G521-L076,2,-17,1
+huawei,HWG521-L,HUAWEI G521-L176,2,-17,1
+huawei,hwG525-U00,HUAWEI G525-U00,2,-17,1
+huawei,hwG535-L11,HUAWEI G535-L11,2,-17,1
+huawei,hwG6-C00,HUAWEI G6-C00,2,-17,1
+huawei,hwG6-L11,HUAWEI G6-L11,2,-17,1
+huawei,hwG6-L22,HUAWEI G6-L22,2,-17,1
+huawei,hwG6-L33,HUAWEI G6-L33,2,-17,1
+huawei,hwG6-T00,HUAWEI G6-T00,2,-17,1
+huawei,hwG6-U00,HUAWEI G6-U00,2,-17,1
+huawei,hwG6-U10,HUAWEI G6-U10,2,-17,1
+huawei,hwG6-U251,HUAWEI G6-U251,2,-17,1
+huawei,hwG6-U34,HUAWEI G6-U34,2,-17,1
+huawei,HWG606-T00,HUAWEI G606-T00,2,-17,1
+huawei,HWG606,HUAWEI G606-T00,2,-17,1
+huawei,hwG610-C00,HUAWEI G610-C00,2,-17,1
+huawei,hwG610-T00,HUAWEI G610-T00,2,-17,1
+huawei,hwG610-T01,HUAWEI G610-T01,2,-17,1
+huawei,hwG610-T11,HUAWEI G610-T11,2,-17,1
+huawei,hwG610-U00,HUAWEI G610-U00,2,-17,1
+huawei,hwG610-U15,HUAWEI G610-U15,2,-17,1
+huawei,hwG610-U20,HUAWEI G610-U20,2,-17,1
+huawei,hwG610-U30,HUAWEI G610-U30,2,-17,1
+huawei,hwG615-U10,HUAWEI G615-U10,2,-17,1
+huawei,HWG616-L,HUAWEI G616-L076,2,-17,1
+huawei,hwG620S-L03,HUAWEI G620,2,-17,1
+huawei,hwG620-A2,HUAWEI G620-A2,2,-17,1
+huawei,hwG620-L72,HUAWEI G620-L72,2,-17,1
+huawei,HWG628-TL,HUAWEI G628-TL00,2,-17,1
+huawei,HWG629-UL,HUAWEI G629-UL00,2,-17,1
+huawei,hwG630-T00,HUAWEI G630-T00,2,-17,1
+huawei,hwG630-U00,HUAWEI G630-U00,2,-17,1
+huawei,hwG630-U251,HUAWEI G630-U251,2,-17,1
+huawei,hwG660-L075,HUAWEI G660-L075,2,-17,1
+huawei,hwG7-L03,HUAWEI G7,2,-17,1
+huawei,hwG7-L01,HUAWEI G7-L01,2,-17,1
+huawei,hwG7-L02,HUAWEI G7-L02,2,-17,1
+huawei,hwG7-L03,HUAWEI G7-L03,2,-17,1
+huawei,hwG7-L11,HUAWEI G7-L11,2,-17,1
+huawei,hwG7-TL00,HUAWEI G7-TL00,2,-17,1
+huawei,hwG7-UL20,HUAWEI G7-UL20,2,-17,1
+huawei,hwG700-T00,HUAWEI G700-T00,2,-17,1
+huawei,hwG700-T01,HUAWEI G700-T01,2,-17,1
+huawei,hwG700-U00,HUAWEI G700-U00,2,-17,1
+huawei,hwG700-U10,HUAWEI G700-U10,2,-17,1
+huawei,hwG700-U20,HUAWEI G700-U20,2,-17,1
+huawei,hwG716-L070,HUAWEI G716-L070,2,-17,1
+huawei,hwg718,HUAWEI G718,2,-17,1
+huawei,hwG730-C00,HUAWEI G730-C00,2,-17,1
+huawei,hwG730-L075,HUAWEI G730-L075,2,-17,1
+huawei,hwG730-T00,HUAWEI G730-T00,2,-17,1
+huawei,hwG730-U00,HUAWEI G730-U00,2,-17,1
+huawei,hwG730-U10,HUAWEI G730-U10,2,-17,1
+huawei,hwG730-U251,HUAWEI G730-U251,2,-17,1
+huawei,hwG730-U27,HUAWEI G730-U27,2,-17,1
+huawei,hwG730-U30,HUAWEI G730-U30,2,-17,1
+huawei,hwG750-T00,HUAWEI G750-T00,2,-17,1
+huawei,hwG750-T01,HUAWEI G750-T01,2,-17,1
+huawei,hwG750-T01M,HUAWEI G750-T01M,2,-17,1
+huawei,hwG750-T20,HUAWEI G750-T20,2,-17,1
+huawei,hwG750-U10,HUAWEI G750-U10,2,-17,1
+huawei,HWG7500,HUAWEI G7500,2,-17,1
+huawei,HWGRA,HUAWEI GRA-CL00,2,-17,1
+huawei,HWGRA,HUAWEI GRA-CL10,2,-17,1
+huawei,HWGRA,HUAWEI GRA-L09,2,-17,1
+huawei,HWGRA,HUAWEI GRA-TL00,2,-17,1
+huawei,HWGRA,HUAWEI GRA-UL00,2,-17,1
+huawei,HWGRA,HUAWEI GRA-UL10,2,-17,1
+huawei,HWH1611-Q,HUAWEI H1611,2,-17,1
+huawei,hwh866c,HUAWEI H866C,2,-17,1
+huawei,hwh868c,HUAWEI H868C,2,-17,1
+huawei,hwh871g,HUAWEI H871G,2,-17,1
+huawei,hwh881c,HUAWEI H881C,2,-17,1
+huawei,hwH891L,HUAWEI H891L,2,-17,1
+huawei,hwH892L,HUAWEI H892L,2,-17,1
+huawei,hwhn3-u00,HUAWEI HN3-U00,2,-17,1
+huawei,hwhn3-u01,HUAWEI HN3-U01,2,-17,1
+huawei,U8500,HUAWEI IDEOS U8500,2,-17,1
+huawei,msm7225,HUAWEI IDEOS U8500,2,-17,1
+huawei,hwu8655,HUAWEI IDEOS Y 200,2,-17,1
+huawei,HWKII-Q,HUAWEI KII-L03,2,-17,1
+huawei,HWKII-Q,HUAWEI KII-L05,2,-17,1
+huawei,HWKII-Q,HUAWEI KII-L21,2,-17,1
+huawei,HWKII-Q,HUAWEI KII-L22,2,-17,1
+huawei,HWKII-Q,HUAWEI KII-L23,2,-17,1
+huawei,HWKII-Q,HUAWEI KII-L33,2,-17,1
+huawei,HWLUA-L6735,HUAWEI LUA-L01,2,-17,1
+huawei,HWLUA-L6735,HUAWEI LUA-L02,2,-17,1
+huawei,HWLUA-L6735,HUAWEI LUA-L03,2,-17,1
+huawei,HWLUA-L6735,HUAWEI LUA-L13,2,-17,1
+huawei,HWLUA-L6735,HUAWEI LUA-L21,2,-17,1
+huawei,HWLUA-L6735,HUAWEI LUA-L23,2,-17,1
+huawei,HWLUA-U6582,HUAWEI LUA-U02,2,-17,1
+huawei,HWLUA-U6582,HUAWEI LUA-U03,2,-17,1
+huawei,HWLUA-U6582,HUAWEI LUA-U22,2,-17,1
+huawei,HWLUA-U6582,HUAWEI LUA-U23,2,-17,1
+huawei,HWLYO-L6735,HUAWEI LYO-L01,2,-17,1
+huawei,HWLYO-L6735,HUAWEI LYO-L02,2,-17,1
+huawei,HWLYO-L6735,HUAWEI LYO-L03,2,-17,1
+huawei,HWLYO-L6735,HUAWEI LYO-L21,2,-17,1
+huawei,HWMozart,HUAWEI M2-801L,2,-17,1
+huawei,HWMozart,HUAWEI M2-801W,2,-17,1
+huawei,HWMozart,HUAWEI M2-802L,2,-17,1
+huawei,HWMozart,HUAWEI M2-803L,2,-17,1
+huawei,hwliszt,HUAWEI M2-A01L,2,-17,1
+huawei,hwliszt,HUAWEI M2-A01W,2,-17,1
+huawei,hwm866,HUAWEI M866,2,-17,1
+huawei,hwm868,HUAWEI M868,2,-17,1
+huawei,hwm881,HUAWEI M881,2,-17,1
+huawei,HWMLA,HUAWEI MLA-AL00,2,-17,1
+huawei,HWMLA,HUAWEI MLA-AL10,2,-17,1
+huawei,HWMLA,HUAWEI MLA-L01,2,-17,1
+huawei,HWMLA,HUAWEI MLA-L02,2,-17,1
+huawei,HWMLA,HUAWEI MLA-L03,2,-17,1
+huawei,HWMLA,HUAWEI MLA-L11,2,-17,1
+huawei,HWMLA,HUAWEI MLA-L12,2,-17,1
+huawei,HWMLA,HUAWEI MLA-L13,2,-17,1
+huawei,HWMLA,HUAWEI MLA-TL00,2,-17,1
+huawei,HWMLA,HUAWEI MLA-TL10,2,-17,1
+huawei,HWMLA,HUAWEI MLA-UL00,2,-17,1
+huawei,hwmt1-t00,HUAWEI MT1-T00,2,-17,1
+huawei,hwmt1-u06,HUAWEI MT1-U06,2,-17,1
+huawei,hwmt2-c00,HUAWEI MT2-C00,2,-17,1
+huawei,hwmt2-l01,HUAWEI MT2-L01,2,-17,1
+huawei,hwmt2-l02,HUAWEI MT2-L02,2,-17,1
+huawei,hwmt2-l05,HUAWEI MT2-L05,2,-17,1
+huawei,hwmt7,HUAWEI MT7-CL00,2,-17,1
+huawei,hwmt7,HUAWEI MT7-J1,2,-17,1
+huawei,hwmt7,HUAWEI MT7-L09,2,-17,1
+huawei,hwmt7,HUAWEI MT7-TL00,2,-17,1
+huawei,hwmt7,HUAWEI MT7-TL10,2,-17,1
+huawei,hwmt7,HUAWEI MT7-UL00,2,-17,1
+huawei,hws7300u,HUAWEI MediaPad,2,-17,1
+huawei,hws7300w,HUAWEI MediaPad,2,-17,1
+huawei,hws7300c,HUAWEI MediaPad,2,-17,1
+huawei,hws8301l,HUAWEI MediaPad M1 8.0,2,-17,1
+huawei,hwt1a21l,HUAWEI MediaPad T1 10 4G,2,-17,1
+huawei,hwt1701,HUAWEI MediaPad T1 7.0 3G,2,-17,1
+huawei,hwt1821l,HUAWEI MediaPad T1 8.0 4G,2,-17,1
+huawei,HWNMO-H,HUAWEI NMO-L21,2,-17,1
+huawei,HWNMO-H,HUAWEI NMO-L22,2,-17,1
+huawei,HWNMO-H,HUAWEI NMO-L23,2,-17,1
+huawei,HWNMO-H,HUAWEI NMO-L31,2,-17,1
+huawei,HWNTS,HUAWEI NTS-AL00,2,-17,1
+huawei,HWNXT,HUAWEI NXT-AL10,2,-17,1
+huawei,HWNXT,HUAWEI NXT-CL00,2,-17,1
+huawei,HWNXT,HUAWEI NXT-DL00,2,-17,1
+huawei,HWNXT,HUAWEI NXT-L09,2,-17,1
+huawei,HWNXT,HUAWEI NXT-L29,2,-17,1
+huawei,HWNXT,HUAWEI NXT-TL00,2,-17,1
+huawei,HWNXT,HUAWEI NXT-TL00B,2,-17,1
+huawei,hwp2-0000,HUAWEI P2-0000,2,-17,1
+huawei,hwp2-6011,HUAWEI P2-6011,2,-17,1
+huawei,hwp2-6011,HUAWEI P2-6011-orange,2,-17,1
+huawei,hwp2-6070,HUAWEI P2-6070,2,-17,1
+huawei,hwp6s-u06,HUAWEI P6 S-U06,2,-17,1
+huawei,hwp6-c00,HUAWEI P6-C00,2,-17,1
+huawei,hwp6-t00,HUAWEI P6-T00,2,-17,1
+huawei,hwp6-t00,HUAWEI P6-T00V,2,-17,1
+huawei,hwp6-u06,HUAWEI P6-U06,2,-17,1
+huawei,hwp6-u06,HUAWEI P6-U06-orange,2,-17,1
+huawei,hwP7Mini,HUAWEI P7 mini,2,-17,1
+huawei,hwp7,HUAWEI P7-L00,2,-17,1
+huawei,hwp7,HUAWEI P7-L05,2,-17,1
+huawei,hwp7,HUAWEI P7-L07,2,-17,1
+huawei,hwp7,HUAWEI P7-L09,2,-17,1
+huawei,hwp7,HUAWEI P7-L10,2,-17,1
+huawei,hwp7,HUAWEI P7-L11,2,-17,1
+huawei,hwp7,HUAWEI P7-L12,2,-17,1
+huawei,HWP8max,HUAWEI P8max,2,-17,1
+huawei,hwRIO-AL00,HUAWEI RIO-AL00,2,-17,1
+huawei,hwRIO-CL00,HUAWEI RIO-CL00,2,-17,1
+huawei,hwRIO-L01,HUAWEI RIO-L01,2,-17,1
+huawei,HWRIO,HUAWEI RIO-L02,2,-17,1
+huawei,hwRIO-L02,HUAWEI RIO-L02,2,-17,1
+huawei,HWRIO,HUAWEI RIO-L03,2,-17,1
+huawei,hwRIO-L03,HUAWEI RIO-L03,2,-17,1
+huawei,HWRIO,HUAWEI RIO-TL00,2,-17,1
+huawei,HWRIO,HUAWEI RIO-UL00,2,-17,1
+huawei,HWSC-CL00,HUAWEI SC-CL00,2,-17,1
+huawei,HWSC-UL10,HUAWEI SC-UL10,2,-17,1
+huawei,hwSCC-Q,HUAWEI SCC-U21,2,-17,1
+huawei,hwSCL-Q,HUAWEI SCL-L01,2,-17,1
+huawei,hwSCL-Q,HUAWEI SCL-L02,2,-17,1
+huawei,hwSCL-Q,HUAWEI SCL-L03,2,-17,1
+huawei,hwSCL-Q,HUAWEI SCL-L04,2,-17,1
+huawei,hwSCL-Q,HUAWEI SCL-L21,2,-17,1
+huawei,hwSCLU-Q,HUAWEI SCL-U23,2,-17,1
+huawei,hwSCLU-Q,HUAWEI SCL-U31,2,-17,1
+huawei,hwu8650,HUAWEI SONIC,2,-17,1
+huawei,T8300,HUAWEI T8300,2,-17,1
+huawei,T8600,HUAWEI T8600,2,-17,1
+huawei,hwT8808D,HUAWEI T8808D,2,-17,1
+huawei,T8828,HUAWEI T8828,2,-17,1
+huawei,hwt8833,HUAWEI T8833,2,-17,1
+huawei,hwt8950,HUAWEI T8950,2,-17,1
+huawei,hwt8950N,HUAWEI T8950N,2,-17,1
+huawei,hwt8951,HUAWEI T8951,2,-17,1
+huawei,HWTAG-L6753,HUAWEI TAG-AL00,2,-17,1
+huawei,HWTAG-L6753,HUAWEI TAG-CL00,2,-17,1
+huawei,HWTAG-L6753,HUAWEI TAG-L01,2,-17,1
+huawei,HWTAG-L6753,HUAWEI TAG-L03,2,-17,1
+huawei,HWTAG-L6753,HUAWEI TAG-L13,2,-17,1
+huawei,HWTAG-L6753,HUAWEI TAG-L21,2,-17,1
+huawei,HWTAG-L6753,HUAWEI TAG-L22,2,-17,1
+huawei,HWTAG-L6753,HUAWEI TAG-L23,2,-17,1
+huawei,HWTAG-L6753,HUAWEI TAG-L32,2,-17,1
+huawei,HWTAG-L6753,HUAWEI TAG-TL00,2,-17,1
+huawei,HWTIT-L6735,HUAWEI TIT-AL00,4,-10,3
+huawei,HWTIT-AL00,HUAWEI TIT-AL00,4,-10,1
+huawei,HWTIT-L8916,HUAWEI TIT-CL00,4,-10,1
+huawei,HWTIT-L6735,HUAWEI TIT-CL10,4,-10,1
+huawei,HWTIT-L6735,HUAWEI TIT-L01,4,-10,1
+huawei,HWTIT-L6735,HUAWEI TIT-TL00,4,-10,1
+huawei,HWTIT-U6582,HUAWEI TIT-U02,4,-10,1
+huawei,hwu8661,HUAWEI U8661,2,-17,1
+huawei,hwu8666e,HUAWEI U8666E,2,-17,1
+huawei,hwu8666e-51,HUAWEI U8666E,2,-17,1
+huawei,hwu8666e-51,HUAWEI U8666E-51,2,-17,1
+huawei,hwu8666n,HUAWEI U8666N,2,-17,1
+huawei,hwu8681,HUAWEI U8681,2,-17,1
+huawei,hwu8815,HUAWEI U8815,2,-17,1
+huawei,hwu8815n,HUAWEI U8815N,2,-17,1
+huawei,hwu8818,HUAWEI U8818,2,-17,1
+huawei,hwu8825-1,HUAWEI U8825-1,2,-17,1
+huawei,hwu8825D,HUAWEI U8825D,2,-17,1
+huawei,hwu8950-1,HUAWEI U8950-1,2,-17,1
+huawei,hwu8950-51,HUAWEI U8950-51,2,-17,1
+huawei,hwu8950D,HUAWEI U8950D,2,-17,1
+huawei,hwu8950N-1,HUAWEI U8950N-1,2,-17,1
+huawei,hwu8950N-51,HUAWEI U8950N-51,2,-17,1
+huawei,hwu9508,HUAWEI U9508,2,-17,1
+huawei,hwu9510,HUAWEI U9510,2,-17,1
+huawei,hwu9510e,HUAWEI U9510E,2,-17,1
+huawei,HWVNS-Q,HUAWEI VNS-AL00,2,-17,1
+huawei,HWVNS-H,HUAWEI VNS-DL00,2,-17,1
+huawei,HWVNS-H,HUAWEI VNS-L21,2,-17,1
+huawei,HWVNS-H,HUAWEI VNS-L22,2,-17,1
+huawei,HWVNS-H,HUAWEI VNS-L23,2,-17,1
+huawei,HWVNS-H,HUAWEI VNS-L31,2,-17,1
+huawei,HWVNS-Q,HUAWEI VNS-L52,2,-17,1
+huawei,HWVNS-H,HUAWEI VNS-L53,2,-17,1
+huawei,HWVNS-Q,HUAWEI VNS-L62,2,-17,1
+huawei,HWVNS-H,HUAWEI VNS-TL00,2,-17,1
+huawei,sturgeon,HUAWEI WATCH,2,-17,1
+huawei,hwy220t,HUAWEI Y 220T,2,-17,1
+huawei,hwy210-0010,HUAWEI Y210-0010,2,-17,1
+huawei,hwy210-0100,HUAWEI Y210-0100,2,-17,1
+huawei,hwy210-0151,HUAWEI Y210-0151,2,-17,1
+huawei,hwy210-0200,HUAWEI Y210-0200,2,-17,1
+huawei,hwy210-0251,HUAWEI Y210-0251,2,-17,1
+huawei,hwy210-2010,HUAWEI Y210-2010,2,-17,1
+huawei,hwy220-t10,HUAWEI Y220-T10,2,-17,1
+huawei,HWY221-U,HUAWEI Y221-U03,2,-17,1
+huawei,HWY221-U,HUAWEI Y221-U12,2,-17,1
+huawei,HWY221-U,HUAWEI Y221-U22,2,-17,1
+huawei,HWY221-U,HUAWEI Y221-U33,2,-17,1
+huawei,HWY221-U,HUAWEI Y221-U43,2,-17,1
+huawei,HWY221-U,HUAWEI Y221-U53,2,-17,1
+huawei,hwY300-0000,HUAWEI Y300-0000,2,-17,1
+huawei,hwY300-0100,HUAWEI Y300-0100,2,-17,1
+huawei,hwY300-0151,HUAWEI Y300-0151,2,-17,1
+huawei,hwy310-5000,HUAWEI Y310-5000,2,-17,1
+huawei,hwy310-t10,HUAWEI Y310-T10,2,-17,1
+huawei,hwy320-c00,HUAWEI Y320-C00,2,-17,1
+huawei,HWY320-T00,HUAWEI Y320-T00,2,-17,1
+huawei,HWY320,HUAWEI Y320-U01,2,-17,1
+huawei,HWY320-U,HUAWEI Y320-U10,2,-17,1
+huawei,HWY320-U,HUAWEI Y320-U151,2,-17,1
+huawei,HWY320-U,HUAWEI Y320-U30,2,-17,1
+huawei,HWY320-U,HUAWEI Y320-U351,2,-17,1
+huawei,hwy321-c00,HUAWEI Y321-C00,2,-17,1
+huawei,HWY321-U,HUAWEI Y321-U051,2,-17,1
+huawei,HWY325-T,HUAWEI Y325-T00,2,-17,1
+huawei,hwY330-C00,HUAWEI Y330-C00,2,-17,1
+huawei,hwY330-U01,HUAWEI Y330-U01,2,-17,1
+huawei,hwY330-U05,HUAWEI Y330-U05,2,-17,1
+huawei,hwY330-U07,HUAWEI Y330-U07,2,-17,1
+huawei,hwY330-U08,HUAWEI Y330-U08,2,-17,1
+huawei,hwY330-U11,HUAWEI Y330-U11,2,-17,1
+huawei,hwY330-U15,HUAWEI Y330-U15,2,-17,1
+huawei,hwY330-U17,HUAWEI Y330-U17,2,-17,1
+huawei,hwY330-U21,HUAWEI Y330-U21,2,-17,1
+huawei,hwY336-A1,HUAWEI Y336-A1,2,-17,1
+huawei,HWY336-U,HUAWEI Y336-U02,2,-17,1
+huawei,HWY336-U,HUAWEI Y336-U12,2,-17,1
+huawei,HWY360-U,HUAWEI Y360-U03,2,-17,1
+huawei,HWY360-U6572,HUAWEI Y360-U103,2,-17,1
+huawei,HWY360-U,HUAWEI Y360-U12,2,-17,1
+huawei,HWY360-U,HUAWEI Y360-U23,2,-17,1
+huawei,HWY360-U,HUAWEI Y360-U31,2,-17,1
+huawei,HWY360-U,HUAWEI Y360-U42,2,-17,1
+huawei,HWY360-U,HUAWEI Y360-U61,2,-17,1
+huawei,HWY360-U6572,HUAWEI Y360-U72,2,-17,1
+huawei,HWY360-U6572,HUAWEI Y360-U82,2,-17,1
+huawei,HWY360-U6572,HUAWEI Y360-U93,2,-17,1
+huawei,HWY500-T00,HUAWEI Y500-T00,2,-17,1
+huawei,HWY511-T,HUAWEI Y511-T00,2,-17,1
+huawei,HWY511-U,HUAWEI Y511-U10,2,-17,1
+huawei,HWY511-U,HUAWEI Y511-U251,2,-17,1
+huawei,HWY511-U,HUAWEI Y511-U30,2,-17,1
+huawei,HWY516-T,HUAWEI Y516-T00,2,-17,1
+huawei,HWY518-T,HUAWEI Y518-T00,2,-17,1
+huawei,HWY520-U,HUAWEI Y520-U03,2,-17,1
+huawei,HWY520-U,HUAWEI Y520-U12,2,-17,1
+huawei,HWY520-U,HUAWEI Y520-U22,2,-17,1
+huawei,HWY520-U,HUAWEI Y520-U33,2,-17,1
+huawei,HWY523,HUAWEI Y523-L076,2,-17,1
+huawei,HWY523,HUAWEI Y523-L176,2,-17,1
+huawei,hwY530-U051,HUAWEI Y530,2,-17,1
+huawei,hwY530-U00,HUAWEI Y530-U00,2,-17,1
+huawei,hwY530-U051,HUAWEI Y530-U051,2,-17,1
+huawei,HWY535-C00,HUAWEI Y535-C00,2,-17,1
+huawei,HWY535D-C00,HUAWEI Y535D-C00,2,-17,1
+huawei,hwY536A1,HUAWEI Y536A1,2,-17,1
+huawei,HWY540-U,HUAWEI Y540-U01,2,-17,1
+huawei,HWY541-U,HUAWEI Y541-U02,2,-17,1
+huawei,hwY550-L03,HUAWEI Y550,2,-17,1
+huawei,hwY550-L01,HUAWEI Y550-L01,2,-17,1
+huawei,hwY550-L02,HUAWEI Y550-L02,2,-17,1
+huawei,hwY550-L03,HUAWEI Y550-L03,2,-17,1
+huawei,HWY560-CL,HUAWEI Y560-CL00,2,-17,1
+huawei,HWY560-L,HUAWEI Y560-L01,2,-17,1
+huawei,HWY560-L,HUAWEI Y560-L02,2,-17,1
+huawei,HWY560-L,HUAWEI Y560-L03,2,-17,1
+huawei,HWY560-L,HUAWEI Y560-L23,2,-17,1
+huawei,HWY560-U,HUAWEI Y560-U02,2,-17,1
+huawei,HWY560-U,HUAWEI Y560-U03,2,-17,1
+huawei,HWY560-U,HUAWEI Y560-U12,2,-17,1
+huawei,HWY560-U,HUAWEI Y560-U23,2,-17,1
+huawei,HWY600-U,HUAWEI Y600-U00,2,-17,1
+huawei,HWY600-U,HUAWEI Y600-U151,2,-17,1
+huawei,HWY600-U,HUAWEI Y600-U20,2,-17,1
+huawei,HWY600-U,HUAWEI Y600-U351,2,-17,1
+huawei,HWY600-U,HUAWEI Y600-U40,2,-17,1
+huawei,HWY600D-C00,HUAWEI Y600D-C00,2,-17,1
+huawei,HWY610-U,HUAWEI Y610-U00,2,-17,1
+huawei,HWY618-T,HUAWEI Y618-T00,2,-17,1
+huawei,HWY625-U,HUAWEI Y625-U13,2,-17,1
+huawei,HWY625-U,HUAWEI Y625-U21,2,-17,1
+huawei,HWY625-U,HUAWEI Y625-U32,2,-17,1
+huawei,HWY625-U,HUAWEI Y625-U43,2,-17,1
+huawei,HWY625-U,HUAWEI Y625-U51,2,-17,1
+huawei,hwY635,HUAWEI Y635-CL00,2,-17,1
+huawei,hwY635,HUAWEI Y635-L02,2,-17,1
+huawei,hwY635,HUAWEI Y635-L03,2,-17,1
+huawei,hwY635,HUAWEI Y635-TL00,2,-17,1
+huawei,hwc8850,HUAWEI-C8850,2,-17,1
+huawei,hwm835,HUAWEI-M835,2,-17,1
+huawei,hwm860,HUAWEI-M860,2,-17,1
+huawei,msm7625,HUAWEI-M860,2,-17,1
+huawei,hwm920,HUAWEI-M920,2,-17,1
+huawei,hwm931,HUAWEI-M931,2,-17,1
+huawei,qsd8k_s7,HUAWEI-S7,2,-17,1
+huawei,hwu8850,HUAWEI-U8850,2,-17,1
+huawei,hwu9000,HUAWEI-U9000,2,-17,1
+huawei,sturgeon,HUAWEI-WATCH,2,-17,1
+huawei,hwu8815,HUAWEI_Ascend G 300,2,-17,1
+huawei,msm7225,HUAWEI_IDEOS_U8500,2,-17,1
+huawei,hwu8500,HUAWEI_IDEOS_U8500,2,-17,1
+huawei,hwu8650,HUAWEI_IDEOS_U8650,2,-17,1
+huawei,hwu8800Pro,HUAWEI_IDEOS_X5,2,-17,1
+huawei,hwu8860,HUAWEI_U8860,2,-17,1
+huawei,hwu9501L,HW-01E,2,-17,1
+huawei,HW-01K,HW-01K,-1,-32,3
+huawei,HW-02L,HW-02L,2,-17,1
+huawei,HW-03E,HW-03E,2,-17,1
+huawei,hwH60,HW-H60-J1,2,-17,1
+huawei,hwSCL-Q,HW-SCL-L32,2,-17,1
+huawei,HWHWI,HWI-AL00,2,-17,1
+huawei,HWHWI,HWI-TL00,2,-17,1
+huawei,hwfdra04l,HWT31,3,-24,3
+huawei,HWPIC,HWV31,-1,-3,1
+huawei,HWANE,HWV32,3,-3,1
+huawei,HWMAR,HWV33,2,-17,1
+huawei,hwHiTV-M1,HiTV-M1,2,-17,1
+huawei,HWHol-T,Hol-T00,2,-17,1
+huawei,HWHol-U,Hol-U10,2,-17,1
+huawei,HWHol-U,Hol-U19,2,-17,1
+huawei,hwt1821l,Honor T1 8.0,2,-17,1
+huawei,U8110,Huawei,2,-17,1
+huawei,msm7225,Huawei,2,-17,1
+huawei,hwu8160,Huawei 858,2,-17,1
+huawei,hwu8510,Huawei IDEOS X3,2,-17,1
+huawei,HuaweiU8180,Huawei Ideos X1,2,-17,1
+huawei,hws7300u,Huawei S7-312u,2,-17,1
+huawei,U8110,Huawei U8110,2,-17,1
+huawei,hwu8800-51,Huawei U8800-51,2,-17,1
+huawei,hwY301A1,Huawei Y301A1,2,-17,1
+huawei,hwY301A2,Huawei Y301A2,2,-17,1
+huawei,hwh867g,Huawei-H867G,2,-17,1
+huawei,hwu8652,Huawei-U8652,2,-17,1
+huawei,hwu8665,Huawei-U8665,2,-17,1
+huawei,hwu8687,Huawei-U8687,2,-17,1
+huawei,hwes8500,HuaweiES8500,2,-17,1
+huawei,hwG510-0100,HuaweiG510-0100,2,-17,1
+huawei,hwG510-0100,HuaweiG510-0100-orange,2,-17,1
+huawei,HuaweiU8180,HuaweiU8180,2,-17,1
+huawei,msm7225,HuaweiU8300,2,-17,1
+huawei,hwu8350,HuaweiU8350,2,-17,1
+huawei,hwu8500,HuaweiU8500,2,-17,1
+huawei,hwu8510,HuaweiU8510,2,-17,1
+huawei,hwu8650,HuaweiU8650,2,-17,1
+huawei,hwu8800Pro,HuaweiU8800Pro,2,-17,1
+huawei,U8100,Huawei_8100-9,2,-17,1
+huawei,hwu8500,ICE,2,-17,1
+huawei,qsd8k_s7,IDEOS S7,2,-17,1
+huawei,qsd8k_slim,IDEOS S7 Slim,2,-17,1
+huawei,HuaweiU8180,IDEOS X1,2,-17,1
+huawei,msm7230,IDEOS X5,2,-17,1
+huawei,hwu8800-51,IDEOS X5,2,-17,1
+huawei,hwu8800Pro,IDEOS X5,2,-17,1
+huawei,hwu8800,IDEOS X5,2,-17,1
+huawei,HWINE,INE-AL00,2,-17,1
+huawei,HWINE,INE-LX1,2,-17,1
+huawei,HWINE,INE-LX1r,2,-17,1
+huawei,HWINE,INE-LX2,2,-17,1
+huawei,HWINE,INE-LX2r,2,-17,1
+huawei,HWINE,INE-TL00,2,-17,1
+huawei,Ice-Twist,Ice-Twist,2,-17,1
+huawei,msm7625,Ideos,2,-17,1
+huawei,msm7225,Ideos,2,-17,1
+huawei,u8150,Ideos,2,-17,1
+huawei,U8150,Ideos,2,-17,1
+huawei,qsd8k_s7,Ideos S7,2,-17,1
+huawei,HWJAT-M,JAT-AL00,2,-17,1
+huawei,HWJAT-M,JAT-L29,2,-17,1
+huawei,HWJAT-M,JAT-L41,2,-17,1
+huawei,HWJAT-M,JAT-LX1,2,-17,1
+huawei,HWJAT-M,JAT-LX3,2,-17,1
+huawei,HWJAT-M,JAT-TL00,2,-17,1
+huawei,hwjdn,JDN-AL00,2,-17,1
+huawei,hwjdn,JDN-L01,2,-17,1
+huawei,hwjdn,JDN-W09,2,-17,1
+huawei,HWJDN2,JDN2-AL00,2,-17,1
+huawei,HWJDN2,JDN2-AL00HN,2,-17,1
+huawei,HWJDN2,JDN2-L09,2,-17,1
+huawei,HWJDN2,JDN2-W09,2,-17,1
+huawei,HWJDN2,JDN2-W09HN,2,-17,1
+huawei,HWJKM-H,JKM-AL00,2,-17,1
+huawei,HWJKM-HM,JKM-AL00a,2,-17,1
+huawei,HWJKM-HM,JKM-AL00b,2,-17,1
+huawei,HWJKM-H,JKM-LX1,2,-17,1
+huawei,HWJKM-H,JKM-LX2,2,-17,1
+huawei,HWJKM-H,JKM-LX3,2,-17,1
+huawei,HWJKM-H,JKM-TL00,2,-17,1
+huawei,HWJMM-Q,JMM-AL00,2,-17,1
+huawei,HWJMM-Q,JMM-AL10,2,-17,1
+huawei,HWJMM,JMM-L22,2,-17,1
+huawei,HWJMM-Q,JMM-TL00,2,-17,1
+huawei,HWJMM-Q,JMM-TL10,2,-17,1
+huawei,HWJSN-H,JSN-AL00,2,-17,1
+huawei,HWJSN-HM,JSN-AL00a,2,-17,1
+huawei,HWJSN-H,JSN-L21,2,-17,1
+huawei,HWJSN-H,JSN-L22,2,-17,1
+huawei,HWJSN-H,JSN-L23,2,-17,1
+huawei,HWJSN-H,JSN-L42,2,-17,1
+huawei,HWJSN-H,JSN-TL00,2,-17,1
+huawei,HWKII-Q,KII-L21,2,-17,1
+huawei,HNKIW-Q,KIW-AL10,7,-25,1
+huawei,HNKIW-Q,KIW-AL20,7,-25,1
+huawei,HNKIW-Q,KIW-CL00,7,-25,1
+huawei,HNKIW-Q,KIW-L21,7,-25,1
+huawei,HNKIW-Q,KIW-L22,7,-25,1
+huawei,HNKIW-Q,KIW-L23,7,-25,1
+huawei,HNKIW-Q,KIW-L24,7,-25,3
+huawei,HNKIW-Q,KIW-TL00,7,-25,1
+huawei,HNKIW-Q,KIW-TL00H,7,-25,1
+huawei,HNKIW-Q,KIW-UL00,7,-25,1
+huawei,HWKNT,KNT-AL10,2,-17,1
+huawei,HWKNT,KNT-AL20,2,-17,1
+huawei,HWKNT,KNT-TL10,2,-17,1
+huawei,HWKNT,KNT-UL10,2,-17,1
+huawei,HWKobe-Q,KOB-L09,2,-17,1
+huawei,HWKobe-Q,KOB-W09,2,-17,1
+huawei,HWKSA-M,KSA-AL00,2,-17,1
+huawei,HWKSA-M,KSA-LX2,2,-17,1
+huawei,HWKSA-M,KSA-LX3,2,-17,1
+huawei,HWKSA-M,KSA-LX9,2,-17,1
+huawei,HWKSA-M,KSA-TL00,2,-17,1
+huawei,KVY625-U,Kavak Y625-U03,2,-17,1
+huawei,hwG535-L11,Kestrel,2,-17,1
+huawei,hwu8650,Kyivstar Aqua,2,-17,1
+huawei,HuaweiU8180,Kyivstar Terra,2,-17,1
+huawei,HWLDN-Q,LDN-AL00,2,-17,1
+huawei,HWLDN-Q,LDN-AL10,2,-17,1
+huawei,HWLDN-Q,LDN-AL20,2,-17,1
+huawei,HWLDN-Q,LDN-L01,2,-17,1
+huawei,HWLDN-Q,LDN-L21,2,-17,1
+huawei,HWLDN-Q,LDN-LX2,2,-17,1
+huawei,HWLDN-Q,LDN-LX3,2,-17,1
+huawei,HWLDN-Q,LDN-TL00,2,-17,1
+huawei,HWLDN-Q,LDN-TL10,2,-17,1
+huawei,HWLDN-Q,LDN-TL20,2,-17,1
+huawei,sawfish,LEO-BX9,2,-17,1
+huawei,sawshark,LEO-DLXX,2,-17,1
+huawei,HWLLD-H,LLD-AL00,2,-17,1
+huawei,HWLLD-H,LLD-AL10,2,-17,1
+huawei,HWLLD-H2,LLD-AL20,2,-17,1
+huawei,HWLLD-H2,LLD-AL30,2,-17,1
+huawei,HWLLD-H,LLD-L21,2,-17,1
+huawei,HWLLD-H,LLD-L31,2,-17,1
+huawei,HWLLD-H,LLD-TL10,2,-17,1
+huawei,HWLND-Q,LND-AL30,2,-17,1
+huawei,HWLND-Q,LND-AL40,2,-17,1
+huawei,HWLND-Q,LND-L29,2,-17,1
+huawei,HWLND-Q,LND-TL30,2,-17,1
+huawei,HWLND-Q,LND-TL40,2,-17,1
+huawei,HWLON,LON-AL00,2,-17,1
+huawei,HWLON,LON-L29,2,-17,1
+huawei,HWLYA,LYA-AL00,2,-17,1
+huawei,HWLYA,LYA-AL00P,2,-17,1
+huawei,HWLYA,LYA-AL10,2,-17,1
+huawei,HWLYA,LYA-L09,2,-17,1
+huawei,HWLYA,LYA-L0C,2,-17,1
+huawei,HWLYA,LYA-L29,2,-17,1
+huawei,HWLYA,LYA-TL00,2,-17,1
+huawei,HWLYO-L6735,LYO-L21,2,-17,1
+huawei,hwy210-0200,Leopard MF808,2,-17,1
+huawei,hwY330-U01,Luno,2,-17,1
+huawei,hwmediaqm220,M220,2,-17,1
+huawei,hwmediaqm220,M220c,2,-17,1
+huawei,hwsingleboxm310w,M310,2,-17,1
+huawei,HWM311,M311,2,-17,1
+huawei,m321,M321,2,-17,1
+huawei,m330,M330,2,-17,1
+huawei,HWM380,M380-10,2,-17,1
+huawei,M620,M620,2,-17,1
+huawei,hwm650,M650,2,-17,1
+huawei,hwm660,M660,2,-17,1
+huawei,msm7625,M860,2,-17,1
+huawei,M860,M860,2,-17,1
+huawei,hwm865,M865,2,-17,1
+huawei,hwm865c,M865C,2,-17,1
+huawei,hwm866,M866,2,-17,1
+huawei,hwm886,M886,2,-17,1
+huawei,HWMAR,MAR-AL00,2,-17,1
+huawei,HWMAR,MAR-LX1A,2,-17,1
+huawei,HWMAR,MAR-LX1Am,2,-17,1
+huawei,HWMAR,MAR-LX1B,2,-17,1
+huawei,HWMAR,MAR-LX1H,2,-17,1
+huawei,HWMAR,MAR-LX1M,2,-17,1
+huawei,HWMAR,MAR-LX1Mm,2,-17,1
+huawei,HWMAR,MAR-LX1R,2,-17,1
+huawei,HWMAR,MAR-LX2,2,-17,1
+huawei,HWMAR,MAR-LX2B,2,-17,1
+huawei,HWMAR,MAR-LX2J,2,-17,1
+huawei,HWMAR,MAR-LX2m,2,-17,1
+huawei,HWMAR,MAR-LX3A,2,-17,1
+huawei,HWMAR,MAR-LX3Am,2,-17,1
+huawei,HWMAR,MAR-LX3Bm,2,-17,1
+huawei,HWMAR,MAR-TL00,2,-17,1
+huawei,hwu8500,MF8503,2,-17,1
+huawei,HWMHA,MHA-AL00,2,-27,1
+huawei,HWMHA,MHA-L09,2,-27,1
+huawei,HWMHA,MHA-L29,2,-27,3
+huawei,HWMHA,MHA-TL00,2,-27,1
+huawei,HWMLA,MLA-AL00,2,-17,1
+huawei,HWMLA,MLA-AL10,2,-17,1
+huawei,HWMLA,MLA-L01,2,-17,1
+huawei,HWMLA,MLA-L02,2,-17,1
+huawei,HWMLA,MLA-L03,2,-17,1
+huawei,HWMLA,MLA-L11,2,-17,1
+huawei,HWMLA,MLA-L12,2,-17,1
+huawei,HWMLA,MLA-L13,2,-17,1
+huawei,HWMLA,MLA-TL00,2,-17,1
+huawei,HWMLA,MLA-UL00,2,-17,1
+huawei,HWMON-Q,MON-AL19,2,-17,1
+huawei,HWMON-Q,MON-AL19B,2,-17,1
+huawei,HWMON-Q,MON-W19,2,-17,1
+huawei,HWMRD-M,MRD-AL00,2,-17,1
+huawei,HWMRD-M1,MRD-LX1,2,-17,1
+huawei,HWMRD-M1,MRD-LX1F,2,-17,1
+huawei,HWMRD-M1,MRD-LX1N,2,-17,1
+huawei,HWMRD-M1,MRD-LX2,2,-17,1
+huawei,HWMRD-M1,MRD-LX3,2,-17,1
+huawei,HWMRD-M,MRD-TL00,2,-17,1
+huawei,hwMS4C,MS4C,2,-17,1
+huawei,hwt802,MT-803G,2,-17,1
+huawei,hwMT2L03,MT2L03,2,-17,1
+huawei,hwMT2L03LITE,MT2L03,2,-17,1
+huawei,hwu8160,MTC 950,2,-17,1
+huawei,hwu8650,MTC 955,2,-17,1
+huawei,hwu8510,MTC Bravo,2,-17,1
+huawei,hwu8500,MTC Evo,2,-17,1
+huawei,msm7225,MTC Evo,2,-17,1
+huawei,hwu8666,MTC Fit,2,-17,1
+huawei,hwu8160,MTC Mini,2,-17,1
+huawei,hwu8800,MTC Neo,2,-17,1
+huawei,hwu8800Pro,MTC Neo,2,-17,1
+huawei,hwu8350,MTC Pro,2,-17,1
+huawei,hwu8816,MTC Viva,2,-17,1
+huawei,U8110,MTC_A,2,-17,1
+huawei,U8500,MTC_EVO,2,-17,1
+huawei,hwc8511,MTS-SP101,2,-17,1
+huawei,hwc8800,MTS-SP140,2,-17,1
+huawei,HWMYA-L6737,MYA-AL00,2,-17,1
+huawei,HWMYA-L6737,MYA-AL10,2,-17,1
+huawei,HWMYA-L6737,MYA-L02,2,-17,1
+huawei,HWMYA-L6737,MYA-L03,2,-17,1
+huawei,HWMYA-L6737,MYA-L11,2,-17,1
+huawei,HWMYA-L6737,MYA-L13,2,-17,1
+huawei,HWMYA-L6737,MYA-L22,2,-17,1
+huawei,HWMYA-L6737,MYA-L23,2,-17,1
+huawei,HWMYA-L6737,MYA-L41,2,-17,1
+huawei,HWMYA-L6737,MYA-TL00,2,-17,1
+huawei,HWMYA-L6737,MYA-TL10,2,-17,1
+huawei,HWMYA-U6580,MYA-U29,2,-17,1
+huawei,hws7300u,MediaPad,2,-17,1
+huawei,hws10101l,MediaPad 10 FHD,2,-17,1
+huawei,hws10101w,MediaPad 10 FHD,2,-17,1
+huawei,hws10101u,MediaPad 10 FHD,2,-17,1
+huawei,hws10103l,MediaPad 10 FHD,2,-17,1
+huawei,hws10201l,MediaPad 10 LINK,2,-17,1
+huawei,hws10201u,MediaPad 10 LINK,2,-17,1
+huawei,hws10201w,MediaPad 10 LINK,2,-17,1
+huawei,hws10231l,MediaPad 10 Link+,2,-17,1
+huawei,hws7601u,MediaPad 7 Classic,2,-17,1
+huawei,hws7930u,MediaPad 7 Lite,2,-17,1
+huawei,hws7930w,MediaPad 7 Lite,2,-17,1
+huawei,hws7601u,MediaPad 7 Lite II,2,-17,1
+huawei,hws7951w,MediaPad 7 Lite+,2,-17,1
+huawei,hws7601us,MediaPad 7 Vogue,2,-17,1
+huawei,hws7601u,MediaPad 7 Vogue,2,-17,1
+huawei,hws7601c,MediaPad 7 Vogue,2,-17,1
+huawei,hws7601w,MediaPad 7 Vogue,2,-17,1
+huawei,hws7701w,MediaPad 7 Youth,2,-17,1
+huawei,hws7701u,MediaPad 7 Youth,2,-17,1
+huawei,hws7721u,MediaPad 7 Youth 2,2,-17,1
+huawei,hws8301l,MediaPad M1 8.0,2,-17,1
+huawei,hws8301l,MediaPad M1 8.0 (LTE),2,-17,1
+huawei,hws8301l,MediaPad M1 8.0 (WIFI),2,-17,1
+huawei,hws8701,MediaPad T1 8.0,2,-17,1
+huawei,hwt1821l,MediaPad T1 8.0 Pro,2,-17,1
+huawei,hw7d501l,MediaPad X1,2,-17,1
+huawei,hw7d501l,MediaPad X1 7.0,2,-17,1
+huawei,hwu8666e,MegaFon SP-A3,2,-17,1
+huawei,hwu8500,MegaFon U8500,2,-17,1
+huawei,hwy210-0200,NATCOM N8302,2,-17,1
+huawei,HWNCE-L6750,NCE-AL00,2,-17,1
+huawei,HWNCE-L6750,NCE-AL10,2,-17,1
+huawei,HWNCE-L6750,NCE-TL10,2,-17,1
+huawei,HNNEM-H,NEM-AL10,2,-17,1
+huawei,HNNEM-H,NEM-L21,2,-17,1
+huawei,HNNEM-H,NEM-L22,2,-17,1
+huawei,HNNEM-H,NEM-L51,2,-17,1
+huawei,HNNEM-H,NEM-TL00,2,-17,1
+huawei,HNNEM-H,NEM-TL00H,2,-17,1
+huawei,HNNEM-H,NEM-UL10,2,-17,1
+huawei,HWNEO,NEO-AL00,-3,-28,1
+huawei,HWNEO,NEO-L29,-3,-28,3
+huawei,HWNTS,NTS-AL00,2,-17,1
+huawei,HWNXT,NXT-AL10,2,-17,1
+huawei,HWNXT,NXT-CL00,2,-17,1
+huawei,HWNXT,NXT-DL00,2,-17,1
+huawei,HWNXT,NXT-L09,2,-17,1
+huawei,HWNXT,NXT-L29,2,-17,1
+huawei,HWNXT,NXT-TL00,2,-17,1
+huawei,hwu8180,Netphone 501,2,-17,1
+huawei,angler,Nexus 6P,6,-27,3
+huawei,QAY221-U,ORINOQUIA Auyantepui+Y221-U03,2,-17,1
+huawei,orinoquiac8688V,ORINOQUIA C8688V,2,-17,1
+huawei,hwG510-0200,Orange Daytona,2,-17,1
+huawei,hwG535-L11,Orange Gova,2,-17,1
+huawei,hwG740-L00,Orange Yumo,2,-17,1
+huawei,oay210,Orinoquia Auyantepui Y210,2,-17,1
+huawei,hws7721u,Orinoquia Gran Roraima + S7-722u,2,-17,1
+huawei,hws7701u,Orinoquia Gran Roraima S7-702u,2,-17,1
+huawei,hws7930u,Orinoquia Roraima S7-932u,2,-17,1
+huawei,qsd8k_s7,Oysters SmaKit S7,2,-17,1
+huawei,hwP6s-l04,P6 S-L04,2,-17,1
+huawei,HWPAR,PAR-AL00,2,-17,1
+huawei,HWPAR,PAR-L21,2,-17,1
+huawei,HWPAR,PAR-L29,2,-17,1
+huawei,HWPAR,PAR-LX1,2,-17,1
+huawei,HWPAR,PAR-LX1M,2,-17,1
+huawei,HWPAR,PAR-LX9,2,-17,1
+huawei,HWPAR,PAR-TL00,2,-17,1
+huawei,HWPAR,PAR-TL20,2,-17,1
+huawei,HWPCT,PCT-AL10,2,-17,1
+huawei,HWPCT,PCT-L29,2,-17,1
+huawei,HWPCT,PCT-TL10,2,-17,1
+huawei,hwPE,PE-CL00,2,-17,1
+huawei,hwPE,PE-TL00M,2,-17,1
+huawei,hwPE,PE-TL10,2,-17,1
+huawei,hwPE,PE-TL20,2,-17,1
+huawei,hwPE,PE-UL00,2,-17,1
+huawei,HWPIC,PIC-AL00,-1,-3,3
+huawei,HWPIC,PIC-LX9,-1,-3,1
+huawei,HWPIC,PIC-TL00,-1,-3,1
+huawei,hwple703l,PLE-701L,2,-17,1
+huawei,hwple703l,PLE-703L,2,-17,1
+huawei,HWPLK,PLK-AL10,2,-17,1
+huawei,HWPLK,PLK-CL00,2,-17,1
+huawei,HWPLK,PLK-L01,2,-17,1
+huawei,HWPLK,PLK-TL00,2,-17,1
+huawei,HWPLK,PLK-TL01H,2,-17,1
+huawei,HWPLK,PLK-UL00,2,-17,1
+huawei,HWPOT-H,POT-AL00,2,-17,1
+huawei,HWPOT-HF,POT-AL00a,2,-17,1
+huawei,HWPOT-HF,POT-AL10,2,-17,1
+huawei,HWPOT-H,POT-LX1,2,-17,1
+huawei,HWPOT-H,POT-LX1A,2,-17,1
+huawei,HWPOT-H,POT-LX1AF,2,-17,1
+huawei,HWPOT-H,POT-LX1T,2,-17,1
+huawei,HWPOT-H,POT-LX2J,2,-17,1
+huawei,HWPOT-H,POT-LX3,2,-17,1
+huawei,HWPOT-HF,POT-TL00a,2,-17,1
+huawei,HWPRA-H,PRA-AL00,1,-3,1
+huawei,HWPRA-H,PRA-AL00X,1,-3,1
+huawei,HWPRA-H,PRA-LA1,1,-3,1
+huawei,HWPRA-H,PRA-LX1,1,-3,3
+huawei,HWPRA-H,PRA-LX2,1,-3,1
+huawei,HWPRA-H,PRA-LX3,1,-3,1
+huawei,HWPRA-H,PRA-TL10,1,-3,1
+huawei,hwY300-0151,Pelephone-Y300-,2,-17,1
+huawei,hwG620S-L03,Personal Huawei G620S,2,-17,1
+huawei,hwY550-L03,Personal Huawei Y550,2,-17,1
+huawei,hwu8350,Personal U8350,2,-17,1
+huawei,hwu8655,Personal U8655-51,2,-17,1
+huawei,hwu8815,Personal U8815-51,2,-17,1
+huawei,hwu8651,Prism,2,-17,1
+huawei,hwu8686,Prism II,2,-17,1
+huawei,U8220,Pulse,2,-17,1
+huawei,msm7201a,Pulse,2,-17,1
+huawei,Pulse,Pulse,2,-17,1
+huawei,U8110,Pulse Mini,2,-17,1
+huawei,msm7225,Pulse Mini,2,-17,1
+huawei,HWQ22,Q22,2,-17,1
+huawei,hwt102,QH-10,2,-17,1
+huawei,msm7225,RBM C,2,-17,1
+huawei,hwu8800Pro,RBM_HD,2,-17,1
+huawei,HWRIO,RIO-L03,2,-17,1
+huawei,HWRNE,RNE-AL00,2,-17,1
+huawei,HWRNE,RNE-L01,2,-17,1
+huawei,HWRNE,RNE-L02,2,-17,1
+huawei,HWRNE,RNE-L03,2,-17,1
+huawei,HWRNE,RNE-L21,2,-17,1
+huawei,HWRNE,RNE-L22,2,-17,1
+huawei,HWRNE,RNE-L23,2,-17,1
+huawei,HWRVL,RVL-AL09,2,-17,1
+huawei,hws10231l,S10-232L,2,-17,1
+huawei,msm7225,S31HW,2,-17,1
+huawei,hwu8510,S41HW,2,-17,1
+huawei,hwS42HW,S42HW,2,-17,1
+huawei,qsd8k_s7,S7,2,-17,1
+huawei,hws7721u,S7-721u,2,-17,1
+huawei,hws8301l,S8-303L,2,-17,1
+huawei,hws8301l,S8-303LT,2,-17,1
+huawei,hws8301l,S8-306L,2,-17,1
+huawei,hws8701,S8-701u,2,-17,1
+huawei,hws8701,S8-701w,2,-17,1
+huawei,hwt1821l,S8-821w,2,-17,1
+huawei,hnSCC-Q,SCC-U21,2,-17,1
+huawei,hwSCC-Q,SCC-U21,2,-17,1
+huawei,hwSCL-Q,SCL-AL00,2,-17,1
+huawei,hnSCL-Q,SCL-AL00,2,-17,1
+huawei,hnSCL-Q,SCL-CL00,2,-17,1
+huawei,hwSCL-Q,SCL-L01,2,-17,1
+huawei,hnSCL-Q,SCL-TL00,2,-17,1
+huawei,hnSCL-Q,SCL-TL00H,2,-17,1
+huawei,hwSCLU-Q,SCL-U23,2,-17,1
+huawei,HWSHT,SHT-AL09,2,-17,1
+huawei,HWSHT,SHT-W09,2,-17,1
+huawei,HWSLA-Q,SLA-AL00,2,-17,1
+huawei,HWSLA-Q,SLA-L02,2,-17,1
+huawei,HWSLA-Q,SLA-L03,2,-17,1
+huawei,HWSLA-Q,SLA-L22,2,-17,1
+huawei,HWSLA-Q,SLA-L23,2,-17,1
+huawei,HWSLA-Q,SLA-TL10,2,-17,1
+huawei,HWSNE,SNE-AL00,2,-17,1
+huawei,HWSNE,SNE-LX1,2,-17,1
+huawei,HWSNE,SNE-LX2,2,-17,1
+huawei,HWSNE,SNE-LX3,2,-17,1
+huawei,hwu8650,SONIC,2,-17,1
+huawei,hwu8660,SONIC,2,-17,1
+huawei,hwu8655,STARTRAIL II,2,-17,1
+huawei,HWSTF,STF-AL00,2,-17,1
+huawei,HWSTF,STF-AL10,2,-17,1
+huawei,HWSTF,STF-L09,2,-17,1
+huawei,HWSTF,STF-L09S,2,-17,1
+huawei,HWSTF,STF-TL10,2,-17,1
+huawei,HWSTK-HF,STK-AL00,2,-17,1
+huawei,HWSTK-HF,STK-L21,2,-17,1
+huawei,HWSTK-HF,STK-L22,2,-17,1
+huawei,HWSTK-HF,STK-LX1,2,-17,1
+huawei,HWSTK-HF,STK-LX3,2,-17,1
+huawei,HWSTK-HF,STK-TL00,2,-17,1
+huawei,msm7225,Smile,2,-17,1
+huawei,hws10231l,SpeedTAB,2,-17,1
+huawei,hwG535-L11,Speedsurfer,2,-17,1
+huawei,hws7300u,SpringBoard,2,-17,1
+huawei,HuaweiU8180,Starshine,2,-17,1
+huawei,HuaweiU8180,Stockholm,2,-17,1
+huawei,hwt101,T-101,2,-17,1
+huawei,hwu8680,T-Mobile myTouch,2,-17,1
+huawei,hwu8730,T-Mobile myTouch Q,2,-17,1
+huawei,hwt1701,T1 7.0,2,-17,1
+huawei,hwt1701,T1-701u,2,-17,1
+huawei,hwt1701,T1-701ua,2,-17,1
+huawei,hwt1701,T1-701us,2,-17,1
+huawei,hwt1701,T1-701w,2,-17,1
+huawei,hwt1821l,T1-821L,2,-17,1
+huawei,hwt1821l,T1-821W,2,-17,1
+huawei,hwt1821l,T1-821w,2,-17,1
+huawei,hwt1823l,T1-823L,2,-17,1
+huawei,hwt1821l,T1-823L,2,-17,1
+huawei,hwt1a21l,T1-A21L,2,-17,1
+huawei,hwt1a21l,T1-A21W,2,-17,1
+huawei,hwt1a21l,T1-A21w,2,-17,1
+huawei,hwt1a21l,T1-A22L,2,-17,1
+huawei,hwt1a21l,T1-A23L,2,-17,1
+huawei,hwt101,T101 PAD,2,-17,1
+huawei,hwt102,T102 PAD,2,-17,1
+huawei,hwt801,T801 PAD,2,-17,1
+huawei,hwt802,T802 PAD,2,-17,1
+huawei,hwt8620,T8620,2,-17,1
+huawei,hwt8830,T8830,2,-17,1
+huawei,hwT8830Pro,T8830Pro,2,-17,1
+huawei,hwt9200,T9200,2,-17,1
+huawei,hwt9510e,T9510E,2,-17,1
+huawei,M620,TB01,2,-17,1
+huawei,HWTIT-L6735,TIT-AL00,4,-10,1
+huawei,HWTIT-L6735,TIT-L01,4,-10,1
+huawei,HWTNY,TNY-AL00,2,-17,1
+huawei,HWTNY,TNY-TL00,2,-17,1
+huawei,HWTRT-Q,TRT-AL00,2,-17,1
+huawei,HWTRT-Q,TRT-AL00A,2,-17,1
+huawei,HWTRT-Q,TRT-L21A,2,-17,1
+huawei,HWTRT-Q,TRT-L53,2,-17,1
+huawei,HWTRT-Q,TRT-LX1,2,-17,1
+huawei,HWTRT-Q,TRT-LX2,2,-17,1
+huawei,HWTRT-Q,TRT-LX3,2,-17,1
+huawei,HWTRT-Q,TRT-TL10,2,-17,1
+huawei,HWTRT-Q,TRT-TL10A,2,-17,1
+huawei,U8110,TSP21,2,-17,1
+huawei,hwu8860,TURKCELL MaxiPRO5,2,-17,1
+huawei,msm7225,Tactile internet,2,-17,1
+huawei,U8100,Tactile internet,2,-17,1
+huawei,hws7951w,Telpad Dual S,2,-17,1
+huawei,hws7961w,Telpad QS,2,-17,1
+huawei,hwt1701,Telpad QS,2,-17,1
+huawei,hws7961w,Telpad Quad S,2,-17,1
+huawei,hwu8350,Temptation,2,-17,1
+huawei,U8110,Turkcell T10,2,-17,1
+huawei,msm7225,Turkcell T10,2,-17,1
+huawei,hwu8650,Turkcell T20,2,-17,1
+huawei,U8100,U8100,2,-17,1
+huawei,U8110,U8110,2,-17,1
+huawei,msm7225,U8110,2,-17,1
+huawei,hwu8180,U8180,2,-17,1
+huawei,msm7625,U8180,2,-17,1
+huawei,HuaweiU8180,U8180,2,-17,1
+huawei,hwu8185,U8185,2,-17,1
+huawei,hwu8186,U8186,2,-17,1
+huawei,U8220,U8220,2,-17,1
+huawei,U8220,U8220PLUS,2,-17,1
+huawei,hwu8230,U8230,2,-17,1
+huawei,msm7201a,U8230,2,-17,1
+huawei,U8230,U8230,2,-17,1
+huawei,msm7225,U8300,2,-17,1
+huawei,U8300,U8300,2,-17,1
+huawei,hwu8350,U8350,2,-17,1
+huawei,hwu8350,U8350-51,2,-17,1
+huawei,hwu8500,U8500,2,-17,1
+huawei,msm7225,U8500,2,-17,1
+huawei,hwu8510,U8510,2,-17,1
+huawei,hwu8520,U8520,2,-17,1
+huawei,hwu8600,U8600,2,-17,1
+huawei,hwu8650,U8650,2,-17,1
+huawei,hwu8650,U8650-1,2,-17,1
+huawei,hwu8651,U8651,2,-17,1
+huawei,hwu8651,U8651T,2,-17,1
+huawei,hwu8652,U8652,2,-17,1
+huawei,hwu8652-51,U8652-51,2,-17,1
+huawei,hwu8655,U8655,2,-17,1
+huawei,hwu8655,U8655-1,2,-17,1
+huawei,hwu8655,U8655-51,2,-17,1
+huawei,hwu8666,U8666-1,2,-17,1
+huawei,hwu8666-51,U8666-51,2,-17,1
+huawei,hwu8666,U8666-51,2,-17,1
+huawei,hwu8667,U8667,2,-17,1
+huawei,hwu8800,U8800,2,-17,1
+huawei,hwu8800-51,U8800,2,-17,1
+huawei,hwu8800Pro,U8800 Pro,2,-17,1
+huawei,hwu8800-51,U8800-51,2,-17,1
+huawei,hwu8800Pro,U8800Pro,2,-17,1
+huawei,hwu8812D,U8812D,2,-17,1
+huawei,hwu8815,U8815,2,-17,1
+huawei,hwu8815,U8815-51,2,-17,1
+huawei,hwu8815n,U8815N,2,-17,1
+huawei,hwu8816,U8816,2,-17,1
+huawei,hwu8818,U8818,2,-17,1
+huawei,hwu8820,U8820,2,-17,1
+huawei,hwu8832D,U8832D,2,-17,1
+huawei,hwu8836D,U8836D,2,-17,1
+huawei,hwu8860,U8860,2,-17,1
+huawei,hwu8860,U8860-51,2,-17,1
+huawei,hwu8867Z,U8867Z,2,-17,1
+huawei,hwu9200,U9200,2,-17,1
+huawei,hwu9200-92,U9200,2,-17,1
+huawei,hwu9200,U9200E,2,-17,1
+huawei,hwu9200E,U9200E,2,-17,1
+huawei,hwU9202L,U9202L-1,2,-17,1
+huawei,hwU9202L,U9202L-3,2,-17,1
+huawei,hwu9500,U9500,2,-17,1
+huawei,hwu9500,U9500E,2,-17,1
+huawei,hwu9510,U9510,2,-17,1
+huawei,hwum840,UM840,2,-17,1
+huawei,hwm865,USCCADR3305,2,-17,1
+huawei,hwm866,USCCADR3310,2,-17,1
+huawei,hwu8800,Ucell,2,-17,1
+huawei,hwG535-L11,Ultym5,2,-17,1
+huawei,hwY330-U11,V8510,2,-17,1
+huawei,HWVCE,VCE-AL00,2,-17,1
+huawei,HWVCE,VCE-L22,2,-17,1
+huawei,HWVCE,VCE-TL00,2,-17,1
+huawei,HWVNS-H,VEN-L22,2,-17,1
+huawei,HWVIE,VIE-AL10,2,-17,1
+huawei,HWVIE,VIE-L09,2,-17,1
+huawei,HWVIE,VIE-L29,2,-17,1
+huawei,hwy210-0200,VIETTEL V8404,2,-17,1
+huawei,HWY511-U,VIETTEL V8506,2,-17,1
+huawei,HWVKY,VKY-AL00,2,-17,1
+huawei,HWVKY,VKY-L09,2,-17,1
+huawei,HWVKY,VKY-L29,2,-17,1
+huawei,HWVKY,VKY-TL00,2,-17,1
+huawei,HWVOG,VOG-AL00,2,-17,1
+huawei,HWVOG,VOG-AL10,2,-17,1
+huawei,HWVOG,VOG-L04,2,-17,1
+huawei,HWVOG,VOG-L09,2,-17,1
+huawei,HWVOG,VOG-L29,2,-17,1
+huawei,HWVOG,VOG-TL00,2,-17,1
+huawei,HWVTR,VTR-AL00,2,-17,1
+huawei,HWVTR,VTR-L09,2,-17,1
+huawei,HWVTR,VTR-L29,2,-17,1
+huawei,HWVTR,VTR-TL00,2,-17,1
+huawei,U8100,Videocon_V7400,2,-17,1
+huawei,U8120,Vodafone 845,2,-17,1
+huawei,msm7225,Vodafone 845,2,-17,1
+huawei,hwu8160,Vodafone 858,2,-17,1
+huawei,HWWAS-H,WAS-AL00,2,-4,1
+huawei,HWWAS-H,WAS-L03T,2,-4,1
+huawei,HWWAS-H,WAS-LX1,2,-4,1
+huawei,HWWAS-H,WAS-LX1A,2,-4,1
+huawei,HWWAS-H,WAS-LX2,2,-4,1
+huawei,HWWAS-H,WAS-LX2J,2,-4,1
+huawei,HWWAS-H,WAS-LX3,2,-4,3
+huawei,HWWAS-H,WAS-TL10,2,-4,1
+huawei,hw7d501l,X1 7.0,2,-17,1
+huawei,HWY220-U,Y220-U00,2,-17,1
+huawei,HWY220-U,Y220-U05,2,-17,1
+huawei,HWY220-U,Y220-U10,2,-17,1
+huawei,HWY220-U,Y220-U17,2,-17,1
+huawei,HWY320,Y320-U01,2,-17,1
+huawei,hwY340-U081,Y340-U081,2,-17,1
+huawei,HWY511-T,Y511-T00,2,-17,1
+huawei,HWY511-U,Y511-U00,2,-17,1
+huawei,hwY538,Y538,2,-17,1
+huawei,HWY541-U,Y541-U02,2,-17,1
+huawei,hwY545-U05,Y545-U05,2,-17,1
+huawei,hwY550-L02,Y550-L02,2,-17,1
+huawei,hwY550-L03,Y550-L03,2,-17,1
+huawei,hwY635,Y635-L01,2,-17,1
+huawei,hwY635,Y635-L02,2,-17,1
+huawei,hwY635,Y635-L03,2,-17,1
+huawei,hwY635,Y635-L21,2,-17,1
+huawei,hwY635,Y635-TL00,2,-17,1
+huawei,HWYAL,YAL-AL00,2,-17,1
+huawei,HWYAL,YAL-AL10,2,-17,1
+huawei,HWYAL,YAL-L21,2,-17,1
+huawei,HWYAL,YAL-L41,2,-17,1
+huawei,HWYAL,YAL-TL00,2,-17,1
+huawei,d-01G,d-01G,2,-17,1
+huawei,d-01H,d-01H,2,-17,1
+huawei,d-02H,d-02H,2,-17,1
+huawei,hwmediaqm220,dTV01,2,-17,1
+huawei,hws10201w,dtab 01,2,-17,1
+huawei,dtab01,dtab01,2,-17,1
+huawei,hweH811,eH811,2,-17,1
+huawei,U8110,life:) Android,2,-17,1
+huawei,u8800,u8800,2,-17,1
+huawei,hwu8800,u8800,2,-17,1
+huawei,msm7230,u8800,2,-17,1
+itel,GP10X2019,GP10X2019,3,-26,1
+itel,ITELL_K4700Q,ITELL K4700Q,3,-26,1
+itel,Spice-F311,Spice F311,3,-26,1
+itel,it1512,it1512,3,-26,1
+itel,itel_A11,itel A11,3,-26,1
+itel,itel_A12,itel A12,3,-26,1
+itel,itel_A13,itel A13,3,-26,1
+itel,itel-A13Plus,itel A13Plus,3,-26,1
+itel,itel-A14,itel A14,3,-26,1
+itel,itel-A14,itel A14RU,3,-26,1
+itel,itel-A14S,itel A14S,3,-26,1
+itel,itel-A14,itel A14TZ,3,-26,1
+itel,itel-A15,itel A15,3,-26,1
+itel,itel-A15,itel A15R,3,-26,1
+itel,itel-A16-BD,itel A16,3,-26,1
+itel,itel-A16,itel A16,3,-26,1
+itel,itel-A16-Plus-BD,itel A16 Plus,3,-26,1
+itel,itel-A16-Plus,itel A16 Plus,3,-26,1
+itel,itel-A16-Plus,itel A16 Plus RU,3,-26,1
+itel,itel-A16S,itel A16S,3,-26,1
+itel,itel-A16,itel A16TZ,3,-26,1
+itel,itel-A20,itel A20,3,-26,1
+itel,itel_A21,itel A21,3,-26,1
+itel,itel-A22,itel A22,3,-26,1
+itel,itel-A22-Pro,itel A22 Pro,3,-26,1
+itel,itel-A23F,itel A23,3,-26,1
+itel,itel-A23,itel A23,3,-26,1
+itel,itel-A23F,itel A23P,3,-26,1
+itel,itel-A23,itel A23R,3,-26,1
+itel,itel-A23S,itel A23S,3,-26,1
+itel,itel_A31,itel A31,3,-26,1
+itel,itel-A31Plus,itel A31Plus,3,-26,1
+itel,itel-A32F,itel A32F,3,-26,3
+itel,itel-A40,itel A40,3,-26,1
+itel,itel_A41,itel A41,3,-26,1
+itel,itel_A41Plus,itel A41 Plus,3,-26,1
+itel,itel-A42Plus,itel A42 Plus,3,-26,1
+itel,itel-A43,itel A43,3,-26,1
+itel,itel-A44,itel A44,3,-26,1
+itel,itel-A44-Power,itel A44 Power,3,-26,1
+itel,itel-A44-Pro,itel A44 Pro,3,-26,1
+itel,itel-A45,itel A45,3,-26,1
+itel,itel_A51,itel A51,3,-26,1
+itel,itel-A52,itel A52,3,-26,1
+itel,itel-A52-Lite,itel A52 Lite,3,-26,1
+itel,itel-A52B,itel A52B,3,-26,1
+itel,itel-A52S-Lite,itel A52S Lite,3,-26,1
+itel,itel-A62,itel A62,3,-26,1
+itel,itel-L5002,itel L5002,3,-26,1
+itel,itel-L5002P,itel L5002P,3,-26,1
+itel,itel-L5502,itel L5502,3,-26,1
+itel,itel-L5502S,itel L5502S,3,-26,1
+itel,itel-L5503,itel L5503,3,-26,1
+itel,itel-L5503L,itel L5503L,3,-26,1
+itel,itel-L5505,itel L5505,3,-26,1
+itel,itel-L6002P,itel L6002P,3,-26,1
+itel,itel-L6003P,itel L6003P,3,-26,1
+itel,itel-L6004,itel L6004,3,-26,1
+itel,itel-L6004L,itel L6004L,3,-26,1
+itel,itel-L6004P,itel L6004P,3,-26,1
+itel,itel-L6005,itel L6005,3,-26,1
+itel,itel-L6501,itel L6501,3,-26,1
+itel,itel_P11,itel P11,3,-26,1
+itel,itel_P12,itel P12,3,-26,1
+itel,itel-P13,itel P13,3,-26,1
+itel,itel-P13-Plus,itel P13 Plus,3,-26,1
+itel,itel-P31,itel P31,3,-26,1
+itel,itel-P32,itel P32,3,-26,1
+itel,itel_P41,itel P41,3,-26,1
+itel,P51,itel P51,3,-26,1
+itel,itel_Prime4,itel Prime 4,3,-26,1
+itel,S11,itel S11,3,-26,1
+itel,S11Plus,itel S11 Plus,3,-26,1
+itel,itel-S11-Pro,itel S11 Pro,3,-26,1
+itel,S11Plus,itel S11Plus,3,-26,1
+itel,itel-S11X,itel S11X,3,-26,1
+itel,itel-S12,itel S12,3,-26,1
+itel,itel-S13,itel S13,3,-26,1
+itel,itel-S13Pro,itel S13 Pro,3,-26,1
+itel,itel-S21,itel S21,3,-26,1
+itel,S31,itel S31,3,-26,1
+itel,itel-S32,itel S32,3,-26,1
+itel,itel-S32LTE,itel S32LTE,3,-26,1
+itel,itel-S33,itel S33,3,-26,1
+itel,itel_S41,itel S41,3,-26,1
+itel,itel-S42,itel S42,3,-26,1
+itel,itel-W4003,itel W4003,3,-26,1
+itel,itel-W5001P,itel W5001P,3,-26,1
+itel,itel-W5003,itel W5003,3,-26,1
+itel,itel-W5004,itel W5004,3,-26,1
+itel,itel-W5005,itel W5005,3,-26,1
+itel,itel-W5005P,itel W5005P,3,-26,1
+itel,itel-W5008,itel W5008,3,-26,1
+itel,itel-W5503,itel W5503,3,-26,1
+itel,itel-W5504,itel W5504,3,-26,1
+itel,itel-W5505,itel W5505,3,-26,1
+itel,itel-W6001,itel W6001,3,-26,1
+itel,itel-W6002,itel W6002,3,-26,1
+itel,itel-W6002E,itel W6002E,3,-26,1
+itel,itel-W6003,itel W6003,3,-26,1
+itel,itel-W6004,itel W6004,3,-26,1
+itel,itel-W6004P,itel W6004P,3,-26,1
+itel,itel-W6501,itel W6501,3,-26,1
+itel,itel_it1355,itel it1355,3,-26,1
+itel,itel_it1355M,itel it1355M,3,-26,1
+itel,itel_it1407,itel it1407,3,-26,1
+itel,itel_it1408,itel it1408,3,-26,1
+itel,itel_it1408C,itel it1408,3,-26,1
+itel,itel_it1409,itel it1409,3,-26,1
+itel,itel-it1460-Pro,itel it1460,3,-26,1
+itel,itel-it1460-Pro,itel it1460 Pro,3,-26,1
+itel,itel_it1506,itel it1506,3,-26,1
+itel,itel_it1507C,itel it1507,3,-26,1
+itel,itel_it1507,itel it1507,3,-26,1
+itel,itel_it1508,itel it1508,3,-26,1
+itel,itel_it1508C,itel it1508,3,-26,1
+itel,itel_it1508Plus,itel it1508,3,-26,1
+itel,itel_it1508C,itel it1508 GPS,3,-26,1
+itel,itel_it1508Plus,itel it1508 Plus,3,-26,1
+itel,itel_it1513,itel it1513,3,-26,1
+itel,itel_it1516Plus,itel it1516 Plus,3,-26,1
+itel,itel_it1518,itel it1518,3,-26,1
+itel,itel_it1551,itel it1551,3,-26,1
+itel,itel_it1551C,itel it1551,3,-26,1
+itel,itel_it1556,itel it1556,3,-26,1
+itel,itel_it1556Plus,itel it1556 Plus,3,-26,1
+itel,itel_it1556Plus,itel it1556 plus,3,-26,1
+itel,itel_it1655,itel it1655,3,-26,1
+itel,itel_it1655S,itel it1655S,3,-26,1
+itel,itel_it1702,itel it1702,3,-26,1
+itel,itel_it1703,itel it1703,3,-26,1
+itel,itel-it1520,itel-it1520,3,-26,1
+itel,itel-it1553,itel-it1553,3,-26,1
+itel,itel_it1505,itel_it1505,3,-26,1
+itel,itel_it1550,itel_it1550,3,-26,1
+lava,A1,A1,6,-26,1
+lava,A3,A3,6,-26,1
+lava,A3_mini,A3_mini,6,-26,1
+lava,A50,A50,6,-26,1
+lava,A52,A52,6,-26,1
+lava,A55,A55,6,-26,1
+lava,A67,A67,6,-26,1
+lava,A68,A68,6,-26,1
+lava,A71,A71,6,-26,1
+lava,A72,A72,6,-26,1
+lava,A73,A73,6,-26,1
+lava,A76Plus,A76Plus,6,-26,1
+lava,A77,A77,6,-26,1
+lava,LA79,A79,6,-26,1
+lava,LA82,A82,6,-26,1
+lava,A97,A97,6,-26,1
+lava,A97_2GB,A97 2GB,6,-26,1
+lava,A97_2GB_PLUS,A97 2GB PLUS,6,-26,1
+lava,A97,A97 IPS,6,-26,1
+lava,AF9010,AF9010,6,-26,1
+lava,AF9010_F,AF9010_F,6,-26,1
+lava,AF9020,AF9020,6,-26,1
+lava,AH9910,AH9910,6,-26,1
+lava,AN9910,AN9910,6,-26,1
+lava,XE2X,Era 2X,6,-26,1
+lava,XE2X3GB,Era 2X 3GB,6,-26,1
+lava,IFF2,Fuel F2,6,-26,1
+lava,AF9030,LAVA AF9030,6,-26,1
+lava,LE9810,LAVA LE9810,6,-26,1
+lava,LE9820,LAVA LE9820,6,-26,1
+lava,LE9930,LAVA LE9930,6,-26,1
+lava,LE9940,LAVA LE9940,6,-26,1
+lava,LE9940_W,LAVA LE9940_W,6,-26,1
+lava,LF9810_2GB,LAVA LF9810_2GB,6,-26,1
+lava,LH9930,LAVA LH9930,6,-26,1
+lava,LH9931,LAVA LH9931,6,-26,1
+lava,LH9950,LAVA LH9950,6,-26,1
+lava,LN9810,LAVA LN9810,6,-26,1
+lava,V5,LAVA V5,6,-26,1
+lava,LAVAA1,LAVAA1,6,-26,1
+lava,LAVA_A3,LAVA_A3,6,-26,1
+lava,LAVA_A44,LAVA_A44,6,-26,1
+lava,LAVA_R1,LAVA_R1,6,-26,1
+lava,LE9910,LE9910,6,-26,1
+lava,LE9920,LE9920,6,-26,1
+lava,LE9920_P,LE9920_P,6,-26,1
+lava,LH9810,LH9810,6,-26,1
+lava,LH9910,LH9910,6,-26,1
+lava,LN9820,LN9820,6,-26,1
+lava,LN9820,LN9821,6,-26,1
+lava,LN9910_2GB,LN9910_2GB,6,-26,1
+lava,LT900,LT900,6,-26,1
+lava,A89,Lava A89,6,-26,1
+lava,Z61P,Lava Z61P,6,-26,1
+lava,X10,LavaX10,6,-26,1
+lava,P3,P3,6,-26,1
+lava,P7,P7,6,-26,1
+lava,P7plus,P7plus,6,-26,1
+lava,PixelV1_sprout,PixelV1,6,-26,1
+lava,PixelV1G_sprout,PixelV1,6,-26,1
+lava,R1_Lite,R1_Lite,6,-26,1
+lava,R2,R2,6,-26,1
+lava,R3,R3,6,-26,1
+lava,S1,S1,6,-26,1
+lava,T101,T101,6,-26,1
+lava,T71,T71,6,-26,1
+lava,T71_w,T71_w,6,-26,1
+lava,V23GB,V23GB,6,-26,1
+lava,V2s,V2s,6,-26,1
+lava,V2s,V2s M,6,-26,1
+lava,V5,V5,6,-26,1
+lava,X10,X10,6,-26,1
+lava,X11,X11,6,-26,1
+lava,X12,X12,6,-26,1
+lava,X17,X17,6,-26,1
+lava,X19,X19,6,-26,1
+lava,X28,X28,6,-26,1
+lava,X28_plus,X28 Plus,6,-26,1
+lava,X3,X3,6,-26,1
+lava,X38,X38,6,-26,1
+lava,X382GB,X38 2GB,6,-26,1
+lava,X41,X41,6,-26,1
+lava,X41_Plus,X41 Plus,6,-26,1
+lava,LX46,X46,6,-26,1
+lava,X50,X50,6,-26,1
+lava,X50_Plus,X50 Plus,6,-26,1
+lava,X81,X81,6,-26,1
+lava,XOLO_One_HD,XOLO One HD,6,-26,1
+lava,LAVA_Z10,Z10,6,-26,1
+lava,Z25,Z25,6,-26,1
+lava,Z40,Z40,6,-26,1
+lava,Z50,Z50,6,-26,3
+lava,Z50_Pro,Z50_Pro,6,-26,1
+lava,Z51,Z51,6,-26,1
+lava,Z60,Z60,6,-26,1
+lava,Z60s,Z60s,6,-26,1
+lava,Z61,Z61,6,-26,1
+lava,Z61_2GB,Z61_2GB,6,-26,1
+lava,Z70,Z70,6,-26,1
+lava,Z80,Z80,6,-26,1
+lava,Z81,Z81,6,-26,1
+lava,Z90,Z90,6,-26,1
+lava,Z91,Z91,6,-26,1
+lava,Z92,Z92,6,-26,1
+lava,ZX,ZX,6,-26,1
+lava,era_2,era 2,6,-26,1
+lava,XOLO_era_4K,era 4K,6,-26,1
+lava,era1X,era1X,6,-26,1
+lava,era1X,era1Xpro,6,-26,1
+lava,era_4G,era_4G,6,-26,1
+lava,era_X,era_X,6,-26,1
+lava,iris31,iris 31,6,-26,1
+lava,iris_50_Pro,iris 50 Pro,6,-26,1
+lava,iris30,iris30,6,-26,1
+lava,iris40,iris40,6,-26,1
+lava,iris42,iris42,6,-26,1
+lava,iris50,iris50,6,-26,1
+lava,iris50c,iris50,6,-26,1
+lava,iris505,iris505,6,-26,1
+lava,iris51,iris51,6,-26,1
+lava,iris512,iris512,6,-26,1
+lava,iris515,iris515,6,-26,1
+lava,iris53,iris53,6,-26,1
+lava,iris560,iris560,6,-26,1
+lava,iris565,iris565,6,-26,1
+lava,iris60,iris60,6,-26,1
+lava,iris605,iris605,6,-26,1
+lava,iris60c,iris60c,6,-26,1
+lava,iris65,iris65,6,-26,1
+lava,iris702,iris702,6,-26,1
+lava,iris80,iris80,6,-26,1
+lava,iris820,iris820,6,-26,1
+lava,iris821,iris821,6,-26,1
+lava,iris870,iris870,6,-26,1
+lava,iris88,iris88,6,-26,1
+lava,iris880,iris880,6,-26,1
+lava,iris88_go,iris88_go,6,-26,1
+lava,iris88_lite,iris88_lite,6,-26,1
+lava,iris88s,iris88s,6,-26,1
+lava,iris90,iris90,6,-26,1
+leagoo,KIICAA_MIX,KIICAA MIX,-29,-23,1
+leagoo,KIICAA_POWER,KIICAA POWER,-29,-23,1
+leagoo,LeaPad_X,LeaPad_X,-29,-23,1
+leagoo,M10,M10,-29,-23,1
+leagoo,M10A,M10A,-29,-23,1
+leagoo,M11,M11,-29,-23,1
+leagoo,M12,M12,-29,-23,1
+leagoo,M12A,M12A,-29,-23,1
+leagoo,M13,M13,-29,-23,1
+leagoo,M15,M15,-29,-23,1
+leagoo,M9,M9,-29,-23,1
+leagoo,M9_Pro,M9 Pro,-29,-23,1
+leagoo,M9A_Pro,M9A Pro,-29,-23,1
+leagoo,P1,P1,-29,-23,1
+leagoo,P1_Pro,P1 Pro,-29,-23,1
+leagoo,Power_2,Power 2,-29,-23,1
+leagoo,Power_2_Pro,Power 2 Pro,-29,-23,1
+leagoo,Power_5,Power 5,-29,-23,1
+leagoo,Power_5_Lite,Power 5 Lite,-29,-23,1
+leagoo,S10,S10,-29,-23,1
+leagoo,S11,S11,-29,-23,1
+leagoo,S8,S8,-29,-23,1
+leagoo,S8Pro,S8 Pro,-29,-23,1
+leagoo,S9,S9,-29,-23,1
+leagoo,T5,T5,-29,-23,1
+leagoo,T5c,T5c,-29,-23,3
+leagoo,T8,T8,-29,-23,1
+leagoo,T8s,T8s,-29,-23,1
+leagoo,XRover,XRover,-29,-23,1
+leagoo,XRover_C,XRover C,-29,-23,1
+leagoo,Z10,Z10,-29,-23,1
+leagoo,Z10-E,Z10-E,-29,-23,1
+leagoo,Z13,Z13,-29,-23,1
+leagoo,Z7,Z7,-29,-23,1
+leagoo,Z9,Z9,-29,-23,1
+leagoo,Z9A,Z9A,-29,-23,1
+lenovo,501LV,501LV,3,-24,1
+lenovo,601LV,601LV,3,-24,1
+lenovo,602LV,602LV,3,-24,1
+lenovo,701LV,701LV,3,-24,1
+lenovo,702LV,702LV,3,-24,1
+lenovo,801LV,801LV,3,-24,1
+lenovo,A1_07,A1_07,3,-24,1
+lenovo,A2107A-H,A2107A-H,3,-24,1
+lenovo,lenovo75_a2_att_ics,A2107A-H,3,-24,1
+lenovo,A30t,A30t,3,-24,1
+lenovo,T702T,A66t,3,-24,1
+lenovo,msm7627_surf,A68e,3,-24,1
+lenovo,A7700,A7700,3,-24,1
+lenovo,bumblebee,AQUOS 50S1,3,-24,1
+lenovo,sun,AQUOS 50U3A,3,-24,1
+lenovo,jazz,AQUOS 58U1,3,-24,1
+lenovo,jazz,AQUOS 60LX765A,3,-24,1
+lenovo,jazz,AQUOS 60UE20A,3,-24,1
+lenovo,sun,AQUOS 65UR30A,3,-24,1
+lenovo,sun,AQUOS 70UD30A,3,-24,1
+lenovo,sun,AQUOS 70UG30A,3,-24,1
+lenovo,sun,AQUOS 70XU30A,3,-24,1
+lenovo,reks_cheets,Braswell Chrome OS Device,3,-24,1
+lenovo,A3000,EveryPad,3,-24,1
+lenovo,A3500F,EveryPad2,3,-24,1
+lenovo,PB1-770M,EveryPad3,3,-24,1
+lenovo,A10,IdeaPadA10,3,-24,1
+lenovo,a2_wifi_row,IdeaTab A2107A-F,3,-24,1
+lenovo,a2_wifi,IdeaTab A2107A-F,3,-24,1
+lenovo,lenovo75_a2_ics,IdeaTab A2107A-H,3,-24,1
+lenovo,a2_3g_data,IdeaTab A2107A-H,3,-24,1
+lenovo,A3000,IdeaTab A3000-F,3,-24,1
+lenovo,A3000,IdeaTab A3000-H,3,-24,1
+lenovo,K2110A-F,IdeaTab K2110A-F,3,-24,1
+lenovo,msm8660_surf,IdeaTab S2007A-F,3,-24,1
+lenovo,msm8660_surf,IdeaTab S2007A-H,3,-24,1
+lenovo,msm8660_surf,IdeaTab S2010A-D,3,-24,1
+lenovo,msm8660_surf,IdeaTab S2010A-F,3,-24,1
+lenovo,msm8660_surf,IdeaTab S2010A-H,3,-24,1
+lenovo,S6000,IdeaTab S6000-F,3,-24,1
+lenovo,S6000,IdeaTab S6000-H,3,-24,1
+lenovo,A1000F,IdeaTabA1000-F,3,-24,1
+lenovo,A1000G,IdeaTabA1000-G,3,-24,1
+lenovo,A1000LF,IdeaTabA1000L-F,3,-24,1
+lenovo,A1010T,IdeaTabA1010-T,3,-24,1
+lenovo,A1020T,IdeaTabA1020-T,3,-24,1
+lenovo,A2109A,IdeaTabA2109A,3,-24,1
+lenovo,A2207A-H,IdeaTabA2207A-H,3,-24,1
+lenovo,A5000E,IdeaTabA5000-E,3,-24,1
+lenovo,S2109A,IdeaTabS2109A-F,3,-24,1
+lenovo,msm8960,IdeaTabS2110AF,3,-24,1
+lenovo,msm8960,IdeaTabS2110AH,3,-24,1
+lenovo,sanpaolo,IdeaTabV2007A,3,-24,1
+lenovo,santiago,IdeaTabV2010A,3,-24,1
+lenovo,santiago,IdeaTabV2010A-W,3,-24,1
+lenovo,reks_cheets,Intel Braswell Chromebook,3,-24,1
+lenovo,ventana,K1,3,-24,1
+lenovo,K1,K1,3,-24,1
+lenovo,K350t,K350t,3,-24,1
+lenovo,L18011,L18011,3,-24,1
+lenovo,LAVIETabE10FHD2,LAVIE Tab E 10FHD2,3,-24,1
+lenovo,LAVIETabE7SD1,LAVIE Tab E 7SD1,3,-24,1
+lenovo,LIFETAB_E10310,LIFETAB_E10310,3,-24,1
+lenovo,LIFETAB_E7310,LIFETAB_E7310,3,-24,1
+lenovo,LIFETAB_E7310,LIFETAB_E7312,3,-24,1
+lenovo,LIFETAB_S9512,LIFETAB_S9512,3,-24,1
+lenovo,A305e,LNV-Lenovo A305e,3,-24,1
+lenovo,A370e,LNV-Lenovo A370e,3,-24,1
+lenovo,A375e,LNV-Lenovo A375e,3,-24,1
+lenovo,A380e,LNV-Lenovo A380e,3,-24,1
+lenovo,A385e,LNV-Lenovo A385e,3,-24,1
+lenovo,A395e,LNV-Lenovo A395e,3,-24,1
+lenovo,A505e,LNV-Lenovo A505e,3,-24,1
+lenovo,A560_msm8610,LNV-Lenovo A560,3,-24,1
+lenovo,A600e_msm8625,LNV-Lenovo A600e,3,-24,1
+lenovo,A630e,LNV-Lenovo A630e,3,-24,1
+lenovo,A690e,LNV-Lenovo A690e,3,-24,1
+lenovo,A780e,LNV-Lenovo A780e,3,-24,1
+lenovo,A785e,LNV-Lenovo A785e,3,-24,1
+lenovo,msm7627a,LNV-Lenovo A790e,3,-24,1
+lenovo,kitone,LNV-Lenovo K910e,3,-24,1
+lenovo,S870e,LNV-Lenovo S870e,3,-24,1
+lenovo,A560e_msm7627a,LNV-Lenovo_A560e,3,-24,1
+lenovo,A7-30HC,Lenovo 2 A7-30HC,3,-24,1
+lenovo,A7-30TC,Lenovo 2 A7-30TC,3,-24,1
+lenovo,A8-50F,Lenovo 2 A8-50F,3,-24,1
+lenovo,A8-50LC,Lenovo 2 A8-50LC,3,-24,1
+lenovo,amazon_w,Lenovo A1-32AB0,3,-24,1
+lenovo,A1000,Lenovo A1000,3,-24,1
+lenovo,scx35_sp7731gea_taichi,Lenovo A1000m,3,-24,1
+lenovo,A1010a20,Lenovo A1010a20,2,-25,3
+lenovo,A1900,Lenovo A1900,3,-24,1
+lenovo,A2010-a,Lenovo A2010-a,3,-24,1
+lenovo,A2010l36,Lenovo A2010l36,3,-24,1
+lenovo,A2016a40,Lenovo A2016a40,3,-24,1
+lenovo,A2016b30,Lenovo A2016b30,3,-24,1
+lenovo,A2016b31,Lenovo A2016b31,3,-24,1
+lenovo,angus3A4,Lenovo A2020a40,3,-24,1
+lenovo,angus3A41,Lenovo A2020a40,3,-24,1
+lenovo,A208t,Lenovo A208t,3,-24,1
+lenovo,A218t,Lenovo A218t,3,-24,1
+lenovo,A228t,Lenovo A228t,3,-24,1
+lenovo,A238t,Lenovo A238t,3,-24,1
+lenovo,A2580,Lenovo A2580,3,-24,1
+lenovo,A269,Lenovo A269,3,-24,1
+lenovo,A269i,Lenovo A269i,3,-24,1
+lenovo,A278t,Lenovo A278t,3,-24,1
+lenovo,A2800-d,Lenovo A2800-d,3,-24,1
+lenovo,A2860,Lenovo A2860,3,-24,1
+lenovo,A288t,Lenovo A288t,3,-24,1
+lenovo,A298t,Lenovo A298t,3,-24,1
+lenovo,austin,Lenovo A300,3,-24,1
+lenovo,A3000,Lenovo A3000-H,3,-24,1
+lenovo,A300t,Lenovo A300t,3,-24,1
+lenovo,A305e,Lenovo A305e,3,-24,1
+lenovo,A308t,Lenovo A308t,3,-24,1
+lenovo,A316,Lenovo A316,3,-24,1
+lenovo,A316i,Lenovo A316i,3,-24,1
+lenovo,A318t,Lenovo A318t,3,-24,1
+lenovo,A319,Lenovo A319,3,-24,1
+lenovo,A320t,Lenovo A320t,3,-24,1
+lenovo,a326,Lenovo A326,3,-24,1
+lenovo,A328,Lenovo A328,3,-24,1
+lenovo,A328t,Lenovo A328t,3,-24,1
+lenovo,A3300-HV,Lenovo A3300-HV,3,-24,1
+lenovo,A3300-T,Lenovo A3300-T,3,-24,1
+lenovo,A330e,Lenovo A330e,3,-24,1
+lenovo,A338t,Lenovo A338t,3,-24,1
+lenovo,A3500,Lenovo A3500,3,-24,1
+lenovo,A3500F,Lenovo A3500-F,3,-24,1
+lenovo,A3500FL,Lenovo A3500-FL,3,-24,1
+lenovo,A3500H,Lenovo A3500-H,3,-24,1
+lenovo,A3500HV,Lenovo A3500-HV,3,-24,1
+lenovo,A355e,Lenovo A355e,3,-24,1
+lenovo,A3580,Lenovo A3580,3,-24,1
+lenovo,A358t,Lenovo A358t,3,-24,1
+lenovo,a360,Lenovo A360,3,-24,1
+lenovo,A3600-d,Lenovo A3600-d,3,-24,1
+lenovo,A3600u,Lenovo A3600u,3,-24,1
+lenovo,A360e,Lenovo A360e,3,-24,1
+lenovo,A360t,Lenovo A360t,3,-24,1
+lenovo,lenovo13_td,Lenovo A366t,3,-24,1
+lenovo,A368t,Lenovo A368t,3,-24,1
+lenovo,A369,Lenovo A369,3,-24,1
+lenovo,A369i,Lenovo A369i,3,-24,1
+lenovo,a370,Lenovo A370,3,-24,1
+lenovo,A376,Lenovo A376,3,-24,1
+lenovo,A378t,Lenovo A378t,3,-24,1
+lenovo,A3800-d,Lenovo A3800-d,3,-24,1
+lenovo,A380t,Lenovo A380t,3,-24,1
+lenovo,A3860,Lenovo A3860,3,-24,1
+lenovo,A388t,Lenovo A388t,3,-24,1
+lenovo,A390,Lenovo A390,3,-24,1
+lenovo,pxa1L88H2,Lenovo A3900,3,-24,1
+lenovo,A390,Lenovo A390_ROW,3,-24,1
+lenovo,msm7627_ea95,Lenovo A390e,3,-24,1
+lenovo,A390t,Lenovo A390t,3,-24,1
+lenovo,angus3T3,Lenovo A3910t30,3,-24,1
+lenovo,A396,Lenovo A396,3,-24,1
+lenovo,A396_TY,Lenovo A396_TY,3,-24,1
+lenovo,A398t,Lenovo A398t,3,-24,1
+lenovo,A398tp,Lenovo A398t+,3,-24,1
+lenovo,Aiken,Lenovo A399,3,-24,1
+lenovo,a59wg,Lenovo A500,3,-24,1
+lenovo,a59wg,Lenovo A500+,3,-24,1
+lenovo,a500plus,Lenovo A500+,3,-24,1
+lenovo,A5000,Lenovo A5000,3,-24,1
+lenovo,airplayw,Lenovo A5100,3,-24,1
+lenovo,A516,Lenovo A516,3,-24,1
+lenovo,A516_ROW,Lenovo A516,3,-24,1
+lenovo,lenovo73_gb,Lenovo A520,3,-24,1
+lenovo,a520_gray,Lenovo A520GRAY,3,-24,1
+lenovo,A526,Lenovo A526,3,-24,1
+lenovo,A529,Lenovo A529,3,-24,1
+lenovo,A530_msm7627a_alps,Lenovo A530,3,-24,1
+lenovo,A536,Lenovo A536,3,-24,1
+lenovo,A5500,Lenovo A5500,3,-24,1
+lenovo,A5500-F,Lenovo A5500-F,3,-24,1
+lenovo,A5500-H,Lenovo A5500-H,3,-24,1
+lenovo,A5500-HV,Lenovo A5500-HV,3,-24,1
+lenovo,A560_msm8212,Lenovo A560,3,-24,1
+lenovo,A580,Lenovo A580,3,-24,1
+lenovo,A5800-D,Lenovo A5800-D,3,-24,1
+lenovo,a60id_tel,Lenovo A60,3,-24,1
+lenovo,a60os,Lenovo A60,3,-24,1
+lenovo,a60_campus,Lenovo A60,3,-24,1
+lenovo,a60tw,Lenovo A60,3,-24,1
+lenovo,lenovo73_cu,Lenovo A60,3,-24,1
+lenovo,Android,Lenovo A60+,3,-24,1
+lenovo,A60plus,Lenovo A60+,3,-24,1
+lenovo,Kraft-A6000,Lenovo A6000,3,-24,1
+lenovo,Kraft-A6000-l,Lenovo A6000-l,3,-24,1
+lenovo,A6010,Lenovo A6010,3,-24,1
+lenovo,A6020a40,Lenovo A6020a40,3,-24,1
+lenovo,A6020a41,Lenovo A6020a41,3,-24,1
+lenovo,A6020a46,Lenovo A6020a46,3,-24,1
+lenovo,A6020l36,Lenovo A6020l36,3,-24,1
+lenovo,A6020l37,Lenovo A6020l37,3,-24,1
+lenovo,A606,Lenovo A606,3,-24,1
+lenovo,A616,Lenovo A616,3,-24,1
+lenovo,A628t,Lenovo A628t,3,-24,1
+lenovo,A630,Lenovo A630,3,-24,1
+lenovo,a65_ph_id_vn,Lenovo A65,3,-24,1
+lenovo,a65,Lenovo A65,3,-24,1
+lenovo,a65cu,Lenovo A65,3,-24,1
+lenovo,A656,Lenovo A656,3,-24,1
+lenovo,A658t,Lenovo A658t,3,-24,1
+lenovo,A660,Lenovo A660,3,-24,1
+lenovo,A6600a40,Lenovo A6600a40,3,-24,1
+lenovo,A6600d40,Lenovo A6600d40,3,-26,3
+lenovo,A668t,Lenovo A668t,3,-24,1
+lenovo,A670t,Lenovo A670t,3,-24,1
+lenovo,A678t,Lenovo A678t,3,-24,1
+lenovo,A680,Lenovo A680,3,-24,1
+lenovo,A6800,Lenovo A6800,3,-24,1
+lenovo,A680,Lenovo A680_ROW,3,-24,1
+lenovo,A688t,Lenovo A688t,3,-24,1
+lenovo,msm7627_surf,Lenovo A68e,3,-24,1
+lenovo,A690,Lenovo A690,3,-24,1
+lenovo,lenovo15_td_ics,Lenovo A698t,3,-24,1
+lenovo,A760HC,Lenovo A7-60HC,3,-24,1
+lenovo,A7000-a,Lenovo A7000-a,3,-24,1
+lenovo,A7000plus,Lenovo A7000-a,3,-24,1
+lenovo,A700e,Lenovo A700e,3,-24,1
+lenovo,A7010a48,Lenovo A7010a48,3,-24,1
+lenovo,A7020a40,Lenovo A7020a40,0,-18,1
+lenovo,A7020a48,Lenovo A7020a48,0,-18,1
+lenovo,armani,Lenovo A706,3,-24,1
+lenovo,armani_row,Lenovo A706_ROW,3,-24,1
+lenovo,A708t,Lenovo A708t,3,-24,1
+lenovo,A710e_msm7627a,Lenovo A710e,3,-24,1
+lenovo,andorrap,Lenovo A720e,3,-24,1
+lenovo,lenovo75_cu_gb,Lenovo A750,3,-24,1
+lenovo,lenovo75_cu_ics,Lenovo A750,3,-24,1
+lenovo,athenae,Lenovo A750e,3,-24,1
+lenovo,audi,Lenovo A760,3,-24,1
+lenovo,aiocu_wtfp,Lenovo A7600,3,-24,1
+lenovo,A7600,Lenovo A7600,3,-24,1
+lenovo,A7600-F,Lenovo A7600-F,3,-24,1
+lenovo,A7600-H,Lenovo A7600-H,3,-24,1
+lenovo,A7600-HV,Lenovo A7600-HV,3,-24,1
+lenovo,aiocmcc_ttp,Lenovo A7600-m,3,-24,1
+lenovo,aruba,Lenovo A765e,3,-24,1
+lenovo,A766,Lenovo A766,3,-24,1
+lenovo,airplayt,Lenovo A768t,3,-24,1
+lenovo,A7700,Lenovo A7700,3,-24,1
+lenovo,athenaep,Lenovo A770e,3,-24,1
+lenovo,A780_msm7627a,Lenovo A780,3,-24,1
+lenovo,msm7627a_ha99,Lenovo A780,3,-24,1
+lenovo,A788t,Lenovo A788t,3,-24,1
+lenovo,A789,Lenovo A789,3,-24,1
+lenovo,A798t,Lenovo A798t,3,-24,1
+lenovo,A800,Lenovo A800,3,-24,1
+lenovo,airplayep,Lenovo A805e,3,-24,1
+lenovo,A806,Lenovo A806,3,-24,1
+lenovo,A808t,Lenovo A808t,3,-24,1
+lenovo,A808t-i,Lenovo A808t-i,3,-24,1
+lenovo,airplayw,Lenovo A816,3,-24,1
+lenovo,A820,Lenovo A820,3,-24,1
+lenovo,andorra,Lenovo A820e,3,-24,1
+lenovo,A820t,Lenovo A820t,3,-24,1
+lenovo,A828t,Lenovo A828t,3,-24,1
+lenovo,A830,Lenovo A830,3,-24,1
+lenovo,A850_ROW,Lenovo A850,3,-24,1
+lenovo,A850,Lenovo A850,3,-24,1
+lenovo,A850p,Lenovo A850+,3,-24,1
+lenovo,A858,Lenovo A858,3,-24,1
+lenovo,A858t,Lenovo A858t,3,-24,1
+lenovo,A859_ROW,Lenovo A859,3,-24,1
+lenovo,artini,Lenovo A860e,3,-24,1
+lenovo,A880,Lenovo A880,3,-24,1
+lenovo,A889,Lenovo A889,3,-24,1
+lenovo,airbuse,Lenovo A890e,3,-24,1
+lenovo,A916,Lenovo A916,3,-24,1
+lenovo,A936,Lenovo A936,3,-24,1
+lenovo,A938t,Lenovo A938t,3,-24,1
+lenovo,B6000,Lenovo B6000-F,3,-24,1
+lenovo,B6000,Lenovo B6000-H,3,-24,1
+lenovo,B6000,Lenovo B6000-HV,3,-24,1
+lenovo,B8000,Lenovo B8000-F,3,-24,1
+lenovo,B8000,Lenovo B8000-H,3,-24,1
+lenovo,B8080,Lenovo B8080-F,3,-24,1
+lenovo,B8080,Lenovo B8080-H,3,-24,1
+lenovo,B8080,Lenovo B8080-HV,3,-24,1
+lenovo,reks_cheets,Lenovo Intel Braswell Chromebook,3,-24,1
+lenovo,marino_f,Lenovo K,3,-24,1
+lenovo,brady_f,Lenovo K,4,-22,1
+lenovo,K10a40,Lenovo K10a40,3,-24,1
+lenovo,K10e70,Lenovo K10e70,3,-24,1
+lenovo,apollohd_w,Lenovo K2,3,-24,1
+lenovo,Kraft-E,Lenovo K30-E,3,-24,1
+lenovo,Kraft-T,Lenovo K30-T,3,-24,1
+lenovo,Kraft-TM,Lenovo K30-TM,3,-24,1
+lenovo,Kraft-W,Lenovo K30-W,3,-24,1
+lenovo,Lenovo_K320t,Lenovo K320t,3,-24,1
+lenovo,K32c30,Lenovo K32c30,3,-24,1
+lenovo,K32c36,Lenovo K32c36,3,-24,1
+lenovo,K33a42,Lenovo K33a42,3,-29,3
+lenovo,K33a48,Lenovo K33a48,3,-27,3
+lenovo,K33b36,Lenovo K33b36,3,-27,1
+lenovo,K33b37,Lenovo K33b37,3,-27,1
+lenovo,aio_otfp,Lenovo K50-T5,3,-24,1
+lenovo,aio_3m_otfp_m,Lenovo K50-t3s,3,-24,1
+lenovo,aio_3m_otfp,Lenovo K50-t3s,3,-24,1
+lenovo,aio_otfp,Lenovo K50-t5,3,-24,1
+lenovo,aio_otfp_m,Lenovo K50-t5,3,-24,1
+lenovo,K50-t5,Lenovo K50-t5,3,-24,1
+lenovo,K50a40,Lenovo K50a40,3,-24,1
+lenovo,k5fp,Lenovo K51c78,3,-24,1
+lenovo,k5fp_m,Lenovo K51c78,3,-24,1
+lenovo,seoul,Lenovo K520,4,-20,3
+lenovo,k52_e78,Lenovo K52e78,0,-18,3
+lenovo,k52_t38,Lenovo K52t38,3,-24,1
+lenovo,k52_t58,Lenovo K52t58,0,-18,1
+lenovo,K53a48,Lenovo K53a48,5,-29,3
+lenovo,K53b36,Lenovo K53b36,5,-29,1
+lenovo,K53b37,Lenovo K53b37,5,-29,1
+lenovo,brady_f,Lenovo K8,4,-22,3
+lenovo,manning,Lenovo K8 Note,4,-26,3
+lenovo,marino_f,Lenovo K8 Plus,3,-24,1
+lenovo,mfld_pr2,Lenovo K800,3,-24,1
+lenovo,K800,Lenovo K800,3,-24,1
+lenovo,K80M,Lenovo K80M,3,-24,1
+lenovo,stuttgart,Lenovo K860,3,-24,1
+lenovo,stuttgart_row,Lenovo K860,3,-24,1
+lenovo,K860i,Lenovo K860i,3,-24,1
+lenovo,K900,Lenovo K900,3,-24,1
+lenovo,K900_ROW,Lenovo K900_ROW,3,-24,1
+lenovo,kiton,Lenovo K910,3,-24,1
+lenovo,K910L,Lenovo K910L,3,-24,1
+lenovo,kitone,Lenovo K910e,3,-24,1
+lenovo,kingdom_row,Lenovo K920,3,-24,1
+lenovo,kingdomt,Lenovo K920,3,-24,1
+lenovo,L18021,Lenovo L18021,3,-24,1
+lenovo,A5s,Lenovo L18081,3,-24,1
+lenovo,Lenovo_A6_Note,Lenovo L19041,3,-24,1
+lenovo,AK47,Lenovo L19111,3,-24,1
+lenovo,k5,Lenovo L38011,3,-24,1
+lenovo,austin2018,Lenovo L38012,0,-18,1
+lenovo,k5_cmcc,Lenovo L38021,3,-24,1
+lenovo,K5S,Lenovo L38031,3,-24,1
+lenovo,kunlun,Lenovo L38041,3,-24,1
+lenovo,K9,Lenovo L38043,3,-24,1
+lenovo,L38082,Lenovo L38082,3,-24,1
+lenovo,L38083,Lenovo L38083,3,-24,1
+lenovo,kunlun2,Lenovo L38111,3,-24,1
+lenovo,sprout,Lenovo L58041,3,-24,1
+lenovo,jd2018,Lenovo L78011,1,-21,3
+lenovo,jd2018_cmcc,Lenovo L78011,1,-21,1
+lenovo,zap,Lenovo L78031,3,-24,1
+lenovo,heart,Lenovo L78032,3,-24,1
+lenovo,zippo,Lenovo L78051,3,-24,1
+lenovo,jd2019,Lenovo L78071,3,-24,1
+lenovo,jd20,Lenovo L78121,3,-24,1
+lenovo,cream,Lenovo L79041,3,-24,1
+lenovo,Lindos2,Lenovo N300,3,-24,1
+lenovo,SmartAIO,Lenovo N308,3,-24,1
+lenovo,P1a42,Lenovo P1a41,3,-24,1
+lenovo,P1a42,Lenovo P1a42,3,-24,1
+lenovo,passionc5,Lenovo P1c58,3,-24,1
+lenovo,passion,Lenovo P1c72,3,-24,1
+lenovo,P2a42,Lenovo P2a42,3,-19,3
+lenovo,kuntao,Lenovo P2c72,3,-19,1
+lenovo,lenovo73_gb,Lenovo P70,3,-24,1
+lenovo,P70-A,Lenovo P70-A,3,-24,1
+lenovo,P70-t,Lenovo P70-t,3,-24,1
+lenovo,p700_ph,Lenovo P700,3,-24,1
+lenovo,p700,Lenovo P700,3,-24,1
+lenovo,P700i,Lenovo P700i,3,-24,1
+lenovo,P770,Lenovo P770,3,-24,1
+lenovo,P780,Lenovo P780,3,-24,1
+lenovo,P780_ROW,Lenovo P780,3,-24,1
+lenovo,P780_ROW,Lenovo P780_ROW,3,-24,1
+lenovo,P90,Lenovo P90,3,-24,1
+lenovo,PB-6505M,Lenovo PB-6505M,3,-24,1
+lenovo,PB-6505MC,Lenovo PB-6505MC,3,-24,1
+lenovo,PB-6505NC,Lenovo PB-6505NC,3,-24,1
+lenovo,PB-6505Y,Lenovo PB-6505Y,3,-24,1
+lenovo,PB1-750M,Lenovo PB1-750M,3,-24,1
+lenovo,PB1-770M,Lenovo PB1-770M,3,-24,1
+lenovo,PB1-770N,Lenovo PB1-770N,3,-24,1
+lenovo,PB1-770P,Lenovo PB1-770P,3,-24,1
+lenovo,PB2,Lenovo PB2-650M,3,-24,1
+lenovo,PB2,Lenovo PB2-650N,3,-24,1
+lenovo,PB2,Lenovo PB2-650Y,3,-24,1
+lenovo,PB2-670M,Lenovo PB2-670M,3,-24,1
+lenovo,PB2-670M1,Lenovo PB2-670M1,3,-24,1
+lenovo,PB2-670N,Lenovo PB2-670N,3,-24,1
+lenovo,PB2-670Y,Lenovo PB2-670Y,3,-24,1
+lenovo,PB2PRO,Lenovo PB2-690M,3,-24,1
+lenovo,PB2PRO,Lenovo PB2-690N,3,-24,1
+lenovo,PB2PRO,Lenovo PB2-690Y,3,-24,1
+lenovo,S1La40,Lenovo S1La40,3,-24,1
+lenovo,S1a40,Lenovo S1a40,3,-24,1
+lenovo,Lenovo_S2,Lenovo S2-38AH0,3,-24,1
+lenovo,apollo_wg,Lenovo S2-38AH0,3,-24,1
+lenovo,apollo_td,Lenovo S2-38AT0,3,-24,1
+lenovo,S5000,Lenovo S5000-F,3,-24,1
+lenovo,S5000,Lenovo S5000-H,3,-24,1
+lenovo,S560,Lenovo S560,3,-24,1
+lenovo,S580,Lenovo S580,3,-24,1
+lenovo,sisleylr,Lenovo S60-a,3,-24,1
+lenovo,sisleylt,Lenovo S60-t,3,-24,1
+lenovo,sisleylw,Lenovo S60-w,3,-24,1
+lenovo,S6000L,Lenovo S6000L-F,3,-24,1
+lenovo,S650_ROW,Lenovo S650,3,-24,1
+lenovo,S650,Lenovo S650,3,-24,1
+lenovo,S658t,Lenovo S658t,3,-24,1
+lenovo,S660,Lenovo S660,3,-24,1
+lenovo,S668t,Lenovo S668t,3,-24,1
+lenovo,seoul,Lenovo S680,4,-20,1
+lenovo,Alaska,Lenovo S686,3,-24,1
+lenovo,sicily,Lenovo S696,3,-24,1
+lenovo,S720,Lenovo S720,3,-24,1
+lenovo,S750,Lenovo S750,3,-24,1
+lenovo,apollozero_w,Lenovo S760,3,-24,1
+lenovo,S8-50LC,Lenovo S8-50LC,3,-24,1
+lenovo,shellt,Lenovo S810t,3,-24,1
+lenovo,S820_ROW,Lenovo S820,3,-24,1
+lenovo,S820,Lenovo S820,3,-24,1
+lenovo,S820_AMX_ROW,Lenovo S820,3,-24,1
+lenovo,S820_ROW,Lenovo S820_ROW,3,-24,1
+lenovo,applee,Lenovo S820e,3,-24,1
+lenovo,S850,Lenovo S850,3,-24,1
+lenovo,sichuan,Lenovo S850e,3,-24,1
+lenovo,S850t,Lenovo S850t,3,-24,1
+lenovo,shellr_s,Lenovo S856,3,-24,1
+lenovo,shellw,Lenovo S856,3,-24,1
+lenovo,shellr,Lenovo S856,3,-24,1
+lenovo,shellamx,Lenovo S856,3,-24,1
+lenovo,Selected,Lenovo S858t,3,-24,1
+lenovo,S860,Lenovo S860,3,-24,1
+lenovo,shelle,Lenovo S860e,3,-24,1
+lenovo,S868t,Lenovo S868t,3,-24,1
+lenovo,S870e,Lenovo S870e,3,-24,1
+lenovo,s880,Lenovo S880,3,-24,1
+lenovo,s880_row,Lenovo S880,3,-24,1
+lenovo,S880i,Lenovo S880i,3,-24,1
+lenovo,S890,Lenovo S890,3,-24,1
+lenovo,S898t,Lenovo S898t,3,-24,1
+lenovo,S898tp,Lenovo S898t+,3,-24,1
+lenovo,S899t,Lenovo S899t,3,-24,1
+lenovo,sisleyr,Lenovo S90-A,3,-24,1
+lenovo,sisleyr_amx,Lenovo S90-L,3,-24,1
+lenovo,sisleye,Lenovo S90-e,3,-24,1
+lenovo,sisleyt,Lenovo S90-t,3,-24,1
+lenovo,sisleyw,Lenovo S90-u,3,-24,1
+lenovo,S920,Lenovo S920,3,-24,1
+lenovo,S920_ROW,Lenovo S920,3,-24,1
+lenovo,S920_ROW,Lenovo S920_ROW,3,-24,1
+lenovo,S930_ROW,Lenovo S930,3,-24,1
+lenovo,S930,Lenovo S930,3,-24,1
+lenovo,S938t,Lenovo S938t,3,-24,1
+lenovo,S939,Lenovo S939,3,-24,1
+lenovo,S960_ROW,Lenovo S960,3,-24,1
+lenovo,S960,Lenovo S960,3,-24,1
+lenovo,S960_AMX_ROW,Lenovo S960,3,-24,1
+lenovo,S968t,Lenovo S968t,3,-24,1
+lenovo,A10-70F,Lenovo TAB 2 A10-70F,3,-24,1
+lenovo,A10-70L,Lenovo TAB 2 A10-70L,3,-24,1
+lenovo,A10-70LC,Lenovo TAB 2 A10-70LC,3,-24,1
+lenovo,A7-30H,Lenovo TAB 2 A7-30D,3,-24,1
+lenovo,A7-30HC,Lenovo TAB 2 A7-30DC,3,-24,1
+lenovo,A7-30F,Lenovo TAB 2 A7-30F,3,-24,1
+lenovo,A7-30GC,Lenovo TAB 2 A7-30GC,3,-24,1
+lenovo,A7-30H,Lenovo TAB 2 A7-30H,3,-24,1
+lenovo,A7-30HC,Lenovo TAB 2 A7-30HC,3,-24,1
+lenovo,A8-50F,Lenovo TAB 2 A8-50F,3,-24,1
+lenovo,A8-50L,Lenovo TAB 2 A8-50L,3,-24,1
+lenovo,A8-50LC,Lenovo TAB 2 A8-50LC,3,-24,1
+lenovo,S8-50F,Lenovo TAB S8-50F,3,-24,1
+lenovo,S8-50L,Lenovo TAB S8-50L,3,-24,1
+lenovo,S8-50LC,Lenovo TAB S8-50LC,3,-24,1
+lenovo,TB7104F,Lenovo TB-7104F,3,-24,1
+lenovo,TB7104I,Lenovo TB-7104I,3,-24,1
+lenovo,7304F,Lenovo TB-7304F,3,-24,1
+lenovo,TB-7304F,Lenovo TB-7304F,3,-24,1
+lenovo,7304I,Lenovo TB-7304I,3,-24,1
+lenovo,TB-7304I,Lenovo TB-7304I,3,-24,1
+lenovo,TB-7304N,Lenovo TB-7304N,3,-24,1
+lenovo,TB-7304X,Lenovo TB-7304X,3,-24,1
+lenovo,7305F,Lenovo TB-7305F,3,-24,1
+lenovo,7305I,Lenovo TB-7305I,3,-24,1
+lenovo,7305X,Lenovo TB-7305X,3,-24,1
+lenovo,TB-7504F,Lenovo TB-7504F,3,-24,1
+lenovo,TB-7504N,Lenovo TB-7504N,3,-24,1
+lenovo,TB-7504X,Lenovo TB-7504X,3,-24,1
+lenovo,TB-7703F,Lenovo TB-7703F,3,-24,1
+lenovo,TB-7703N,Lenovo TB-7703N,3,-24,1
+lenovo,TB-7703X,Lenovo TB-7703X,3,-24,1
+lenovo,TB-8304F,Lenovo TB-8304F,3,-24,1
+lenovo,TB-8304F1,Lenovo TB-8304F1,3,-24,1
+lenovo,TB-8504F,Lenovo TB-8504F,3,-24,1
+lenovo,TB-8504L,Lenovo TB-8504L,3,-24,1
+lenovo,TB-8504N,Lenovo TB-8504N,3,-24,1
+lenovo,TB-8504X,Lenovo TB-8504X,3,-24,1
+lenovo,8505F,Lenovo TB-8505F,3,-24,1
+lenovo,8505FS,Lenovo TB-8505FS,3,-24,1
+lenovo,8505N,Lenovo TB-8505N,3,-24,1
+lenovo,8505X,Lenovo TB-8505X,3,-24,1
+lenovo,8505XC,Lenovo TB-8505XC,3,-24,1
+lenovo,8505XS,Lenovo TB-8505XS,3,-24,1
+lenovo,TB-8604F,Lenovo TB-8604F,3,-24,1
+lenovo,TB-8703F,Lenovo TB-8703F,3,-24,1
+lenovo,TB-8703N,Lenovo TB-8703N,3,-24,1
+lenovo,TB-8703R,Lenovo TB-8703R,3,-24,1
+lenovo,TB-8703X,Lenovo TB-8703X,3,-24,1
+lenovo,TB-8704F,Lenovo TB-8704F,3,-24,1
+lenovo,TB-8704N,Lenovo TB-8704N,3,-24,1
+lenovo,TB-8704X,Lenovo TB-8704X,3,-24,1
+lenovo,8705F,Lenovo TB-8705F,3,-24,1
+lenovo,8705N,Lenovo TB-8705N,3,-24,1
+lenovo,8705X,Lenovo TB-8705X,3,-24,1
+lenovo,TB-8803F,Lenovo TB-8803F,3,-24,1
+lenovo,TB-8804F,Lenovo TB-8804F,3,-24,1
+lenovo,TB-8X04F,Lenovo TB-8X04F,3,-24,1
+lenovo,TB-X103F,Lenovo TB-X103F,3,-24,1
+lenovo,X104F,Lenovo TB-X104F,3,-24,1
+lenovo,X104F1,Lenovo TB-X104F1,3,-24,1
+lenovo,X104L,Lenovo TB-X104L,3,-24,1
+lenovo,X104N,Lenovo TB-X104N,3,-24,1
+lenovo,X104X,Lenovo TB-X104X,3,-24,1
+lenovo,X304F,Lenovo TB-X304F,3,-24,1
+lenovo,X304L,Lenovo TB-X304L,3,-24,1
+lenovo,X304N,Lenovo TB-X304N,3,-24,1
+lenovo,X304X,Lenovo TB-X304X,3,-24,1
+lenovo,X504F,Lenovo TB-X504F,3,-24,1
+lenovo,TB-X505F,Lenovo TB-X505F,3,-24,1
+lenovo,TB-X505L,Lenovo TB-X505L,3,-24,1
+lenovo,TB-X505N,Lenovo TB-X505N,3,-24,1
+lenovo,TB-X505X,Lenovo TB-X505X,3,-24,1
+lenovo,X605F,Lenovo TB-X605F,3,-24,1
+lenovo,TB-X605FC,Lenovo TB-X605FC,3,-24,1
+lenovo,X605L,Lenovo TB-X605L,3,-24,1
+lenovo,TB-X605LC,Lenovo TB-X605LC,3,-24,1
+lenovo,X605M,Lenovo TB-X605M,3,-24,1
+lenovo,X606F,Lenovo TB-X606F,3,-24,1
+lenovo,X606FA,Lenovo TB-X606FA,3,-24,1
+lenovo,X606M,Lenovo TB-X606M,3,-24,1
+lenovo,X606V,Lenovo TB-X606V,3,-24,1
+lenovo,X606X,Lenovo TB-X606X,3,-24,1
+lenovo,X606XA,Lenovo TB-X606XA,3,-24,1
+lenovo,X704F,Lenovo TB-X704F,3,-24,1
+lenovo,X704L,Lenovo TB-X704L,3,-24,1
+lenovo,X704N,Lenovo TB-X704N,3,-24,1
+lenovo,X704Y,Lenovo TB-X704Y,3,-24,1
+lenovo,X705F,Lenovo TB-X705F,3,-24,1
+lenovo,X705L,Lenovo TB-X705L,3,-24,1
+lenovo,X705M,Lenovo TB-X705M,3,-24,1
+lenovo,X804F,Lenovo TB-X804F,3,-24,1
+lenovo,TB2-X30F,Lenovo TB2-X30F,3,-24,1
+lenovo,TB2-X30F,Lenovo TB2-X30F_HFT,3,-24,1
+lenovo,TB2-X30F,Lenovo TB2-X30F_JLC,3,-24,1
+lenovo,TB2-X30F,Lenovo TB2-X30F_SCP,3,-24,1
+lenovo,TB2-X30F,Lenovo TB2-X30F_UK,3,-24,1
+lenovo,TB2-X30F,Lenovo TB2-X30F_YZA,3,-24,1
+lenovo,TB2-X30L,Lenovo TB2-X30L,3,-24,1
+lenovo,TB2-X30M,Lenovo TB2-X30M,3,-24,1
+lenovo,TB2-X30M,Lenovo TB2-X30M_PRC_YZ_A,3,-24,1
+lenovo,TB3-710F,Lenovo TB3-710F,3,-26,1
+lenovo,TB3-710I,Lenovo TB3-710I,3,-26,3
+lenovo,TB3-730F,Lenovo TB3-730F,3,-24,1
+lenovo,TB3-730M,Lenovo TB3-730M,3,-24,1
+lenovo,TB3-730X,Lenovo TB3-730X,3,-24,1
+lenovo,TB3-850F,Lenovo TB3-850F,3,-24,1
+lenovo,TB3-850M,Lenovo TB3-850M,3,-24,1
+lenovo,TB3-X70F,Lenovo TB3-X70F,3,-24,1
+lenovo,TB3-X70I,Lenovo TB3-X70I,3,-24,1
+lenovo,TB3-X70L,Lenovo TB3-X70L,3,-24,1
+lenovo,TB3-X70N,Lenovo TB3-X70N,3,-24,1
+lenovo,ultima_cheets,Lenovo ThinkPad 11e 3rd Gen Chromebook,3,-24,1
+lenovo,pyro_cheets,Lenovo ThinkPad 11e 4th Gen Chromebook,3,-24,1
+lenovo,sentry_cheets,Lenovo ThinkPad 13,3,-24,1
+lenovo,pyro_cheets,Lenovo Thinkpad 11e Chromebook (4th Gen)/Lenovo Thinkpad Yoga 11e Chromebook (4th Gen),3,-24,1
+lenovo,X2-AP,Lenovo X2-AP,3,-24,1
+lenovo,X2-CU,Lenovo X2-CU,3,-24,1
+lenovo,X2-EU,Lenovo X2-EU,3,-24,1
+lenovo,X2-TO,Lenovo X2-TO,3,-24,1
+lenovo,X2-TR,Lenovo X2-TR,3,-24,1
+lenovo,s7,Lenovo X2Pt5,3,-24,1
+lenovo,x3_row,Lenovo X3a40,3,-24,1
+lenovo,X3c50,Lenovo X3c50,3,-24,1
+lenovo,X3c70,Lenovo X3c70,3,-24,1
+lenovo,YOGA-A12,Lenovo YB-Q501F,3,-24,1
+lenovo,YOGABOOK12,Lenovo YB-Q501F,3,-24,1
+lenovo,YOGA-A12,Lenovo YB-Q501L,3,-24,1
+lenovo,YOGABOOK12,Lenovo YB-Q501L,3,-24,1
+lenovo,yeti,Lenovo YB1-X90F,3,-24,1
+lenovo,yeti,Lenovo YB1-X90L,3,-24,1
+lenovo,YT-X703F,Lenovo YT-X703F,3,-24,1
+lenovo,YT-X703L,Lenovo YT-X703L,3,-24,1
+lenovo,YT-X703X,Lenovo YT-X703X,3,-24,1
+lenovo,YT-X705F,Lenovo YT-X705F,3,-24,1
+lenovo,YT-X705L,Lenovo YT-X705L,3,-24,1
+lenovo,YT-X705M,Lenovo YT-X705M,3,-24,1
+lenovo,YT-X705X,Lenovo YT-X705X,3,-24,1
+lenovo,YT3-850F,Lenovo YT3-850F,3,-24,1
+lenovo,YT3-850L,Lenovo YT3-850L,3,-24,1
+lenovo,YT3-850M,Lenovo YT3-850M,3,-24,1
+lenovo,YT3-X50F,Lenovo YT3-X50F,3,-24,1
+lenovo,YT3-X50L,Lenovo YT3-X50L,3,-24,1
+lenovo,YT3-X50M,Lenovo YT3-X50M,3,-24,1
+lenovo,YT3,Lenovo YT3-X90F,3,-24,1
+lenovo,YT3,Lenovo YT3-X90L,3,-24,1
+lenovo,YT3,Lenovo YT3-X90X,3,-24,1
+lenovo,YT3,Lenovo YT3-X90Y,3,-24,1
+lenovo,YT3,Lenovo YT3-X90Z,3,-24,1
+lenovo,z2t,Lenovo Z2,3,-24,1
+lenovo,z2r,Lenovo Z2,3,-24,1
+lenovo,z2w,Lenovo Z2w,3,-24,1
+lenovo,zoom_fdd,Lenovo Z90,5,-22,1
+lenovo,zoom_tdd,Lenovo Z90-3,5,-22,3
+lenovo,zoom_fdd,Lenovo Z90-7,5,-22,1
+lenovo,zoom_row,Lenovo Z90a40,3,-24,1
+lenovo,k52_t38,Lenovo k52t38,3,-24,1
+lenovo,A1000LF,LenovoA1000L-F,3,-24,1
+lenovo,A3300-GV,LenovoA3300-GV,3,-24,1
+lenovo,A3300-H,LenovoA3300-H,3,-24,1
+lenovo,A3300-HV,LenovoA3300-HV,3,-24,1
+lenovo,LenovoA588t,LenovoA588t,3,-24,1
+lenovo,uzi,LenovoTV 32A3,3,-24,1
+lenovo,jazz,LenovoTV 40S9,3,-24,1
+lenovo,sun,LenovoTV 49E82,3,-24,1
+lenovo,bumblebee,LenovoTV 50S52,3,-24,1
+lenovo,sun,LenovoTV 55E82,3,-24,1
+lenovo,jazz,LenovoTV 58S9,3,-24,1
+lenovo,Lenovo_A2105,Lenovo_A2105,3,-24,1
+lenovo,pj_stack_acc,M123,3,-24,1
+lenovo,MD_LIFETAB_P9516,MD_LIFETAB_P9516,3,-24,1
+lenovo,E4002,MEDION E4002,3,-24,1
+lenovo,PC-TS508FAM,NEC PC-TS508FAM,3,-24,1
+lenovo,TE507FAW,PC-TE507FAW,3,-24,1
+lenovo,TB-7504F,PC-TE507JAW,3,-24,1
+lenovo,X704F,PC-TE510HAW,3,-24,1
+lenovo,PC-TS508FAM,PC-TS508FAM,3,-24,1
+lenovo,S2005A-H,S2005A-H,3,-24,1
+lenovo,msm8960,SmartTabII10,3,-24,1
+lenovo,SmartTabII7,SmartTabII7,3,-24,1
+lenovo,mi_350,Spice Mi-350,3,-24,1
+lenovo,A10_80HC,TAB A10-80HC,3,-24,1
+lenovo,TB-8504F,TB-8504F,3,-24,1
+lenovo,TB-8704V,TB-8704V,3,-24,1
+lenovo,X304F,TB-X304F,3,-24,1
+lenovo,X304N,TB-X304N,3,-24,1
+lenovo,X704A,TB-X704A,3,-24,1
+lenovo,X704N,TB-X704N,3,-24,1
+lenovo,X704V,TB-X704V,3,-24,1
+lenovo,Tab2A7-10F,Tab2A7-10F,3,-24,1
+lenovo,Tab2A7-20F,Tab2A7-20F,3,-24,1
+lenovo,ultima_cheets,ThinkPad 11e Chromebook 3rd Gen (Yoga/Clamshell),3,-24,1
+lenovo,Indigo,ThinkPad Tablet,3,-24,1
+lenovo,18382AU,ThinkPad Tablet,3,-24,1
+lenovo,ThinkVision28,ThinkVision28,3,-24,1
+lenovo,sentry_cheets,Thinkpad 13 Chromebook,3,-24,1
+lenovo,s7,VIBE X2Pt5,3,-24,1
+lenovo,vega,VR-1541F,3,-24,1
+lenovo,VRS3,VR-S3,3,-24,1
+lenovo,S6000,Vodafone Smart Tab III 10,3,-24,1
+lenovo,A3000,Vodafone Smart Tab III 7,3,-24,1
+lenovo,kungfu_m,XT1662,3,-24,1
+lenovo,XT1663,XT1663,3,-24,1
+lenovo,taidos_row,XT1700,3,-24,1
+lenovo,taido_row,XT1706,3,-24,1
+lenovo,manning,XT1902-3,4,-26,1
+lenovo,YT2,YOGA Tablet 2 Pro-1380F,3,-24,1
+lenovo,YT2,YOGA Tablet 2 Pro-1380L,3,-24,1
+lenovo,YT2,YOGA Tablet 2-1050F,3,-24,1
+lenovo,YT2,YOGA Tablet 2-1050L,3,-24,1
+lenovo,YT2,YOGA Tablet 2-1050LC,3,-24,1
+lenovo,YT2,YOGA Tablet 2-830F,3,-24,1
+lenovo,YT2,YOGA Tablet 2-830L,3,-24,1
+lenovo,YT2,YOGA Tablet 2-830LC,3,-24,1
+lenovo,ideatv_K72,ideatv K72,3,-24,1
+lenovo,ideatv_K82,ideatv K82,3,-24,1
+lenovo,msm8660_surf,ideatv K91,3,-24,1
+lenovo,ideatv_S31,ideatv S31,3,-24,1
+lenovo,ideatv_S52,ideatv S52,3,-24,1
+lenovo,ideatv_S61,ideatv S61,3,-24,1
+letv,max1_in,Le Max,4,-21,1
+letv,X3_HK,Le X507,4,-21,1
+letv,X3_HK,Le X509,4,-21,1
+letv,le_s2,Le X520,4,-21,1
+letv,le_s2_ww,Le X526,4,-21,1
+letv,le_s2_ww,Le X527,4,-21,3
+letv,L653AN_US,Max3-65,4,-21,1
+letv,L553AN_US,X3-55 Pro,4,-21,1
+letv,x600,X600,4,-21,1
+letv,DemeterDV,uMax85,4,-21,1
+letv,Le1,x600,4,-21,1
+lge,lg_10sm3tb,10sm3tb,3,-20,1
+lge,e2jps,402LG,3,-20,1
+lge,Hi3751V811,65TR3BF,3,-20,1
+lge,cv7a,801LG,3,-20,1
+lge,mmh4p-pr,802LG,3,-20,1
+lge,Hi3751V811,86TR3BF,3,-20,1
+lge,mh2lm,901LG,3,-20,1
+lge,altev2,AK815,3,-20,1
+lge,aloha,AS740,3,-20,1
+lge,l1v,AS870 4G,3,-20,1
+lge,x5,AS876,3,-20,1
+lge,g3,AS985,3,-20,1
+lge,p1,AS986,-3,-25,1
+lge,aloha,Ally,3,-20,1
+lge,aloha,Aloha,3,-20,1
+lge,DM-01G,DM-01G,3,-20,1
+lge,DM-01K,DM-01K,3,-20,1
+lge,DM-02H,DM-02H,3,-20,1
+lge,dory,G Watch,3,-20,1
+lge,lenok,G Watch R,3,-20,1
+lge,swift,GT540,3,-20,1
+lge,swift,GT540GO,3,-20,1
+lge,swift,GT540R,3,-20,1
+lge,swift,GT540f,3,-20,1
+lge,EVE,GW620,3,-20,1
+lge,x2,IS11LG,3,-20,1
+lge,mmh4p-pr,KF1919,3,-20,1
+lge,ku9500,KU9500,3,-20,1
+lge,i_dcm,L-01D,3,-20,1
+lge,geehdc,L-01E,3,-20,1
+lge,g2,L-01F,3,-20,1
+lge,L-01J,L-01J,3,-20,1
+lge,L-01K,L-01K,3,-20,1
+lge,L-01L,L-01L,3,-20,1
+lge,p2,L-02D,3,-20,1
+lge,l1_dcm,L-02E,3,-20,1
+lge,L-02K,L-02K,3,-20,1
+lge,L-03K,L-03K,3,-20,1
+lge,elini,L-04C,3,-20,1
+lge,geevl04e,L-04E,3,-20,1
+lge,l_dcm,L-05D,3,-20,1
+lge,L05E,L-05E,3,-20,1
+lge,l06c,L-06C,3,-20,1
+lge,batman_dcm,L-06D,3,-20,1
+lge,batman_dcm,L-06DJOJO,3,-20,1
+lge,L-07C,L-07C,3,-20,1
+lge,L-41A,L-41A,3,-20,1
+lge,eden,LG Android TV V4,3,-20,1
+lge,EVE,LG GW620,3,-20,1
+lge,EVE,LG GW620F,3,-20,1
+lge,EVE,LG GW620R,3,-20,1
+lge,EVE,LG GW620g,3,-20,1
+lge,cosmo,LG Google TV,3,-20,1
+lge,eden,LG Google TV G3,3,-20,1
+lge,eden,LG Google TV G3 KR,3,-20,1
+lge,EVE,LG KH5200,3,-20,1
+lge,m3s,LG Optimus Elite,3,-20,1
+lge,swordfish,LG Watch Sport,3,-20,1
+lge,angelfish,LG Watch Style,3,-20,1
+lge,nemo,LG Watch Urbane,3,-20,1
+lge,bass,LG Watch Urbane,3,-20,1
+lge,narwhal,LG Watch W7,3,-20,1
+lge,t8lte,LG-AK495,3,-20,1
+lge,lv0,LG-AS110,6,-24,3
+lge,m1,LG-AS330,3,-20,1
+lge,as680,LG-AS680,3,-20,1
+lge,m3_acg_us,LG-AS695,3,-20,1
+lge,u0_cdma,LG-AS730,3,-20,1
+lge,fx1,LG-AS780,3,-20,1
+lge,p1,LG-AS811,-3,-25,1
+lge,cayman,LG-AS840,3,-20,1
+lge,AS855,LG-AS855,3,-20,1
+lge,g3,LG-AS990,3,-20,1
+lge,p1,LG-AS991,-3,-25,1
+lge,lucye,LG-AS993,-3,-8,1
+lge,joan,LG-AS998,4,-21,1
+lge,hazel,LG-C550,3,-20,1
+lge,hazel,LG-C555,3,-20,1
+lge,muscat,LG-C660,3,-20,1
+lge,muscat,LG-C660R,3,-20,1
+lge,muscat,LG-C660h,3,-20,1
+lge,alohag_302-220,LG-C710h,3,-20,1
+lge,alohag,LG-C710h,3,-20,1
+lge,lgc729,LG-C729,3,-20,1
+lge,lgc800,LG-C800,3,-20,1
+lge,lgc800g,LG-C800G,3,-20,1
+lge,thunderc,LG-CX670,3,-20,1
+lge,luv20ss,LG-D100,3,-20,1
+lge,luv20ss,LG-D100AR,3,-20,1
+lge,luv20ds,LG-D105,3,-20,1
+lge,luv20ts,LG-D107,3,-20,1
+lge,luv30ss,LG-D120,3,-20,1
+lge,luv30ss,LG-D120AR,3,-20,1
+lge,luv30ds,LG-D125,3,-20,1
+lge,w35,LG-D150,3,-20,1
+lge,w35ds,LG-D157f,3,-20,1
+lge,w3,LG-D160,3,-20,1
+lge,w3,LG-D165,3,-20,1
+lge,w3,LG-D165AR,3,-20,1
+lge,w3ds,LG-D170,3,-20,1
+lge,w3ds,LG-D175f,3,-20,1
+lge,w3ts,LG-D180f,3,-20,1
+lge,luv50ssn,LG-D213,3,-20,1
+lge,luv50ss,LG-D213,3,-20,1
+lge,luv50ss,LG-D213AR,3,-20,1
+lge,luv50ds,LG-D221,3,-20,1
+lge,luv50ds,LG-D227,3,-20,1
+lge,w55n,LG-D280,3,-20,1
+lge,w55,LG-D280,3,-20,1
+lge,w55ds,LG-D285,3,-20,1
+lge,l70pn,LG-D290,3,-20,1
+lge,l70p,LG-D290,3,-20,1
+lge,l70p,LG-D290AR,3,-20,1
+lge,l70pds,LG-D295,3,-20,1
+lge,f70n,LG-D315,3,-20,1
+lge,f70n,LG-D315l,3,-20,1
+lge,w5n,LG-D320,3,-20,1
+lge,w5,LG-D320,3,-20,1
+lge,w5,LG-D320AR,3,-20,1
+lge,w5,LG-D321,3,-20,1
+lge,w5ds,LG-D325,3,-20,1
+lge,w5n,LG-D329,3,-20,1
+lge,luv80ss,LG-D331,3,-20,1
+lge,luv80ss,LG-D331AR,3,-20,1
+lge,luv80ds,LG-D335,3,-20,1
+lge,luv80ds,LG-D335E,3,-20,1
+lge,luv80ds,LG-D337,3,-20,1
+lge,w5ts,LG-D340f8,3,-20,1
+lge,w6,LG-D370,3,-20,1
+lge,w6,LG-D373,3,-20,1
+lge,w6,LG-D375,3,-20,1
+lge,w6,LG-D375AR,3,-20,1
+lge,w6ds,LG-D380,3,-20,1
+lge,w6ds,LG-D385,3,-20,1
+lge,e2,LG-D390,3,-20,1
+lge,e2,LG-D390AR,3,-20,1
+lge,e2n,LG-D390n,3,-20,1
+lge,e2ds,LG-D392,3,-20,1
+lge,e2nac,LG-D393,3,-20,1
+lge,w7,LG-D400,3,-20,1
+lge,w7n,LG-D400,3,-20,1
+lge,w7,LG-D405,3,-20,1
+lge,w7n,LG-D405,3,-20,1
+lge,w7dsn,LG-D410,3,-20,1
+lge,w7ds,LG-D410,3,-20,1
+lge,w7,LG-D415,3,-20,1
+lge,vfp,LG-D486,3,-20,1
+lge,f6,LG-D500,3,-20,1
+lge,f6,LG-D505,3,-20,1
+lge,fx3q,LG-D520,3,-20,1
+lge,l9ii,LG-D605,3,-20,1
+lge,g2mss,LG-D610,3,-20,1
+lge,g2mss,LG-D610AR,3,-20,1
+lge,g2mss,LG-D610TR,3,-20,1
+lge,g2mds,LG-D618,3,-20,1
+lge,g2m,LG-D620,3,-20,1
+lge,g2mv,LG-D625,3,-20,1
+lge,b2l,LG-D631,3,-20,1
+lge,luv90ss,LG-D680,3,-20,1
+lge,luv90ss,LG-D681,3,-20,1
+lge,luv90ss,LG-D682,3,-20,1
+lge,luv90ss,LG-D682TR,3,-20,1
+lge,luv90nfc,LG-D683,3,-20,1
+lge,luv90nfc,LG-D684,3,-20,1
+lge,luv90ds,LG-D685,3,-20,1
+lge,luv90ds,LG-D686,3,-20,1
+lge,b2lds,LG-D690,3,-20,1
+lge,b2ldsn,LG-D690n,3,-20,1
+lge,b2lss,LG-D693,3,-20,1
+lge,b2lss,LG-D693AR,3,-20,1
+lge,b2lss,LG-D693TR,3,-20,1
+lge,b2lssn,LG-D693n,3,-20,1
+lge,u2,LG-D700,3,-20,1
+lge,jagnm,LG-D722,3,-20,1
+lge,jagnm,LG-D722AR,3,-20,1
+lge,jagnm,LG-D722J,3,-20,1
+lge,jag3gss,LG-D723,3,-20,1
+lge,jag3gds,LG-D724,3,-20,1
+lge,jagnm,LG-D725,3,-20,1
+lge,jagnm,LG-D725PR,3,-20,1
+lge,jagdsnm,LG-D726,3,-20,1
+lge,jagnm,LG-D727,3,-20,1
+lge,jagdsnm,LG-D728,3,-20,1
+lge,jagdsnm,LG-D729,3,-20,1
+lge,g2,LG-D800,3,-20,1
+lge,g2,LG-D801,3,-20,1
+lge,g2,LG-D802,3,-20,1
+lge,g2,LG-D802T,3,-20,1
+lge,g2,LG-D802TR,3,-20,1
+lge,g2,LG-D803,3,-20,1
+lge,g2,LG-D805,3,-20,1
+lge,g2,LG-D806,3,-20,1
+lge,b1w,LG-D838,3,-20,1
+lge,g3,LG-D850,3,-20,1
+lge,g3,LG-D851,3,-20,1
+lge,g3,LG-D852,3,-20,1
+lge,g3,LG-D852G,3,-20,1
+lge,g3,LG-D855,3,-20,1
+lge,g3,LG-D856,3,-20,1
+lge,g3,LG-D857,3,-20,1
+lge,g3,LG-D858,3,-20,1
+lge,g3,LG-D858HK,3,-20,1
+lge,g3,LG-D859,3,-20,1
+lge,zee,LG-D950,3,-20,1
+lge,zee,LG-D950G,3,-20,1
+lge,zee,LG-D951,3,-20,1
+lge,zee,LG-D955,3,-20,1
+lge,zee,LG-D956,3,-20,1
+lge,zee,LG-D958,3,-20,1
+lge,zee,LG-D959,3,-20,1
+lge,e0_open_eur,LG-E400,3,-20,1
+lge,e0,LG-E400,3,-20,1
+lge,e0,LG-E400R,3,-20,1
+lge,e0,LG-E400b,3,-20,1
+lge,e0,LG-E400f,3,-20,1
+lge,e0,LG-E400g,3,-20,1
+lge,e1,LG-E405,3,-20,1
+lge,e1,LG-E405f,3,-20,1
+lge,v1,LG-E410,3,-20,1
+lge,v1,LG-E410B,3,-20,1
+lge,v1,LG-E410c,3,-20,1
+lge,v1,LG-E410f,3,-20,1
+lge,v1,LG-E410g,3,-20,1
+lge,v1,LG-E410i,3,-20,1
+lge,v1,LG-E411f,3,-20,1
+lge,v1,LG-E411g,3,-20,1
+lge,v1ds,LG-E415f,3,-20,1
+lge,v1ds,LG-E415g,3,-20,1
+lge,v1ds,LG-E420,3,-20,1
+lge,v1ds,LG-E420f,3,-20,1
+lge,vee3e,LG-E425,3,-20,1
+lge,vee3e,LG-E425c,3,-20,1
+lge,vee3e,LG-E425f,3,-20,1
+lge,vee3e,LG-E425g,3,-20,1
+lge,vee3e,LG-E425j,3,-20,1
+lge,vee3e,LG-E430,3,-20,1
+lge,vee3e,LG-E431g,3,-20,1
+lge,vee3ds,LG-E435,3,-20,1
+lge,vee3ds,LG-E435f,3,-20,1
+lge,vee3ds,LG-E435g,3,-20,1
+lge,vee3ds,LG-E435k,3,-20,1
+lge,vee4ss,LG-E440,3,-20,1
+lge,vee4ss,LG-E440f,3,-20,1
+lge,vee4ss,LG-E440g,3,-20,1
+lge,vee4ds,LG-E445,3,-20,1
+lge,vee5ss,LG-E450,3,-20,1
+lge,vee5ss,LG-E450B,3,-20,1
+lge,vee5ss,LG-E450f,3,-20,1
+lge,vee5ss,LG-E450g,3,-20,1
+lge,vee5ss,LG-E450j,3,-20,1
+lge,vee5ss,LG-E451g,3,-20,1
+lge,vee5ds,LG-E455,3,-20,1
+lge,vee5ds,LG-E455f,3,-20,1
+lge,vee5ds,LG-E455g,3,-20,1
+lge,vee5nfc,LG-E460,3,-20,1
+lge,vee5ss,LG-E460,3,-20,1
+lge,vee5nfc,LG-E460f,3,-20,1
+lge,vee4ss,LG-E465f,3,-20,1
+lge,vee4ss,LG-E465g,3,-20,1
+lge,vee4ds,LG-E467f,3,-20,1
+lge,vee4ts,LG-E470f,3,-20,1
+lge,v1ts,LG-E475f,3,-20,1
+lge,univa_tlf-es,LG-E510,3,-20,1
+lge,univa_esa-xx,LG-E510,3,-20,1
+lge,univa_bal-xxx,LG-E510,3,-20,1
+lge,univa_eur-xx,LG-E510,3,-20,1
+lge,univa_cis-xxx,LG-E510,3,-20,1
+lge,univa_open_cn,LG-E510,3,-20,1
+lge,univa_525-01,LG-E510,3,-20,1
+lge,univa_neu-xx,LG-E510,3,-20,1
+lge,univa_vdf-es,LG-E510,3,-20,1
+lge,univa_222-01,LG-E510,3,-20,1
+lge,univa_tur-xx,LG-E510,3,-20,1
+lge,univa_454-xx,LG-E510,3,-20,1
+lge,univa_open-de,LG-E510,3,-20,1
+lge,univa_525-05,LG-E510,3,-20,1
+lge,univa_228-01,LG-E510,3,-20,1
+lge,univa_arb-xx,LG-E510,3,-20,1
+lge,univa_tmo-gr,LG-E510,3,-20,1
+lge,univa_214-04,LG-E510,3,-20,1
+lge,univa_open-eu,LG-E510,3,-20,1
+lge,univa_724-05,LG-E510f,3,-20,1
+lge,univa_viv-br,LG-E510f,3,-20,1
+lge,univa_tha-xx,LG-E510f,3,-20,1
+lge,univa_clr-br,LG-E510f,3,-20,1
+lge,univa_tcl-mx,LG-E510f,3,-20,1
+lge,e510_724-XX,LG-E510f,3,-20,1
+lge,univa_open-br,LG-E510f,3,-20,1
+lge,univa_usc-mx,LG-E510g,3,-20,1
+lge,univa_ent-cl,LG-E510g,3,-20,1
+lge,univa_722-34,LG-E510g,3,-20,1
+lge,univa_ctm-xxx,LG-E510g,3,-20,1
+lge,univa_ufn-mx,LG-E510g,3,-20,1
+lge,univa_730-01,LG-E510g,3,-20,1
+lge,univa_740-01,LG-E510g,3,-20,1
+lge,univa_730-03,LG-E510g,3,-20,1
+lge,univa_ssv-xxx,LG-E510g,3,-20,1
+lge,m4,LG-E610,3,-20,1
+lge,m4,LG-E610v,3,-20,1
+lge,m4,LG-E612,3,-20,1
+lge,m4,LG-E612f,3,-20,1
+lge,m4,LG-E612g,3,-20,1
+lge,m4ds,LG-E615,3,-20,1
+lge,m4ds,LG-E615f,3,-20,1
+lge,m4,LG-E617G,3,-20,1
+lge,alessi,LG-E720,3,-20,1
+lge,alessi,LG-E720b,3,-20,1
+lge,victor,LG-E730,3,-20,1
+lge,victor,LG-E730f,3,-20,1
+lge,e739,LG-E739,3,-20,1
+lge,geeb,LG-E970,3,-20,1
+lge,geeb,LG-E971,3,-20,1
+lge,geeb,LG-E973,3,-20,1
+lge,geehrc,LG-E975,3,-20,1
+lge,geehrc,LG-E975K,3,-20,1
+lge,geehrc,LG-E975T,3,-20,1
+lge,geehdc,LG-E975w,3,-20,1
+lge,geehrc,LG-E976,3,-20,1
+lge,geehrc,LG-E977,3,-20,1
+lge,geefhd,LG-E980,3,-20,1
+lge,geefhd,LG-E980h,3,-20,1
+lge,geefhd,LG-E981h,3,-20,1
+lge,gvarfhd,LG-E985,3,-20,1
+lge,gvarfhd,LG-E985T,3,-20,1
+lge,geefhd,LG-E986,3,-20,1
+lge,geehrc,LG-E987,3,-20,1
+lge,geefhd,LG-E988,3,-20,1
+lge,geefhd,LG-E989,3,-20,1
+lge,325,LG-F100L,3,-20,1
+lge,batman_lgu,LG-F100L,3,-20,1
+lge,batman,LG-F100L,3,-20,1
+lge,lge_325_skt,LG-F100S,3,-20,1
+lge,batman,LG-F100S,3,-20,1
+lge,batman_skt,LG-F100S,3,-20,1
+lge,cayman,LG-F120K,3,-20,1
+lge,lge_120_kt,LG-F120K,3,-20,1
+lge,cayman,LG-F120L,3,-20,1
+lge,lge_120_skt,LG-F120S,3,-20,1
+lge,cayman,LG-F120S,3,-20,1
+lge,d1lkt,LG-F160K,3,-20,1
+lge,d1lu,LG-F160L,3,-20,1
+lge,d1lu,LG-F160LV,3,-20,1
+lge,d1lsk,LG-F160S,3,-20,1
+lge,geehrc,LG-F180K,3,-20,1
+lge,geehrc4g,LG-F180L,3,-20,1
+lge,geehrc,LG-F180S,3,-20,1
+lge,vu2kt,LG-F200K,3,-20,1
+lge,vu2u,LG-F200L,3,-20,1
+lge,vu2u,LG-F200LS,3,-20,1
+lge,vu2sk,LG-F200S,3,-20,1
+lge,gvfhd,LG-F220K,3,-20,1
+lge,geefhd,LG-F240K,3,-20,1
+lge,geefhd4g,LG-F240L,3,-20,1
+lge,geefhd,LG-F240S,3,-20,1
+lge,fx1sk,LG-F260S,3,-20,1
+lge,vu3,LG-F300K,3,-20,1
+lge,vu3,LG-F300L,3,-20,1
+lge,vu3,LG-F300S,3,-20,1
+lge,omega,LG-F310L,3,-20,1
+lge,omegar,LG-F310LR,3,-20,1
+lge,g2,LG-F320K,3,-20,1
+lge,g2,LG-F320L,3,-20,1
+lge,g2,LG-F320S,3,-20,1
+lge,zee,LG-F340K,3,-20,1
+lge,zee,LG-F340L,3,-20,1
+lge,zee,LG-F340S,3,-20,1
+lge,b1,LG-F350K,3,-20,1
+lge,b1,LG-F350L,3,-20,1
+lge,b1,LG-F350S,3,-20,1
+lge,f70n,LG-F370K,3,-20,1
+lge,f70n,LG-F370L,3,-20,1
+lge,f70n,LG-F370S,3,-20,1
+lge,g3,LG-F400K,3,-20,1
+lge,g3,LG-F400L,3,-20,1
+lge,g3,LG-F400S,3,-20,1
+lge,tigers,LG-F410S,3,-20,1
+lge,b2ln,LG-F430L,3,-20,1
+lge,vfpv,LG-F440L,3,-20,1
+lge,tiger6,LG-F460K,3,-20,1
+lge,tiger6,LG-F460L,3,-20,1
+lge,tiger6,LG-F460S,3,-20,1
+lge,jagn,LG-F470K,3,-20,1
+lge,jagn,LG-F470L,3,-20,1
+lge,jagn,LG-F470S,3,-20,1
+lge,vfp,LG-F480K,3,-20,1
+lge,vfp,LG-F480L,3,-20,1
+lge,vfp,LG-F480S,3,-20,1
+lge,liger,LG-F490L,3,-20,1
+lge,p1,LG-F500K,-3,-25,1
+lge,p1,LG-F500L,-3,-24,3
+lge,p1,LG-F500S,-3,-25,1
+lge,z2,LG-F510K,3,-20,1
+lge,z2,LG-F510L,3,-20,1
+lge,z2,LG-F510S,3,-20,1
+lge,aka,LG-F520K,3,-20,1
+lge,aka,LG-F520L,3,-20,1
+lge,aka,LG-F520S,3,-20,1
+lge,c70w,LG-F540K,3,-20,1
+lge,c70w,LG-F540L,3,-20,1
+lge,c70w,LG-F540S,3,-20,1
+lge,g4stylusw,LG-F560K,3,-20,1
+lge,yg,LG-F570S,3,-20,1
+lge,cf,LG-F580L,3,-20,1
+lge,l5000,LG-F590,3,-20,1
+lge,pplus,LG-F600K,3,-20,1
+lge,pplus,LG-F600L,3,-20,1
+lge,pplus,LG-F600S,3,-20,1
+lge,cf,LG-F610K,3,-20,1
+lge,cf,LG-F610S,3,-20,1
+lge,c100n,LG-F620K,3,-20,1
+lge,c100n,LG-F620L,3,-20,1
+lge,c100n,LG-F620S,3,-20,1
+lge,c90,LG-F640S,3,-20,1
+lge,k5,LG-F650K,6,-22,1
+lge,k5,LG-F650L,6,-22,1
+lge,k5,LG-F650S,6,-22,1
+lge,cfm,LG-F660L,3,-20,1
+lge,m216n,LG-F670K,3,-20,1
+lge,m216n,LG-F670L,3,-20,1
+lge,m216n,LG-F670S,3,-20,1
+lge,k7,LG-F690L,3,-20,1
+lge,k7,LG-F690S,3,-20,1
+lge,h1,LG-F700K,9,-15,1
+lge,h1,LG-F700L,9,-28,3
+lge,h1,LG-F700S,9,-15,1
+lge,ph1,LG-F720K,6,-22,1
+lge,ph1,LG-F720L,6,-22,1
+lge,ph1,LG-F720S,6,-22,1
+lge,k6b,LG-F740L,3,-20,1
+lge,mk6p,LG-F750K,3,-20,1
+lge,mk6m,LG-F770S,3,-20,1
+lge,elsa,LG-F800K,6,-3,1
+lge,elsa,LG-F800L,6,-3,1
+lge,elsa,LG-F800S,6,-3,1
+lge,bbg,LG-F820L,3,-20,1
+lge,w3voip,LG-FL40L,3,-20,1
+lge,judyln,LG-G710,3,-20,1
+lge,EVE,LG-GW620,3,-20,1
+lge,y30,LG-H220,3,-20,1
+lge,y30f,LG-H221,3,-20,1
+lge,y30f,LG-H221AR,3,-20,1
+lge,y30dsf,LG-H222,3,-20,1
+lge,my50,LG-H320,3,-20,1
+lge,my50ds,LG-H324,3,-20,1
+lge,my50ds,LG-H326,3,-20,1
+lge,c50,LG-H340,3,-21,1
+lge,c50,LG-H340AR,3,-21,1
+lge,c50,LG-H340GT,3,-21,1
+lge,c50n,LG-H340n,3,-20,1
+lge,c50ds,LG-H342,3,-20,1
+lge,c50,LG-H343,3,-21,1
+lge,c50,LG-H345,3,-21,3
+lge,cf,LG-H410,3,-20,1
+lge,my70,LG-H420,3,-20,1
+lge,my70ds,LG-H422,3,-20,1
+lge,c70,LG-H440,3,-20,1
+lge,c70,LG-H440AR,3,-20,1
+lge,c70n,LG-H440n,3,-20,1
+lge,c70ds,LG-H442,3,-20,1
+lge,c70n,LG-H443,3,-20,1
+lge,c70n,LG-H445,3,-20,1
+lge,my90,LG-H500,3,-20,1
+lge,my90ds,LG-H502,3,-20,1
+lge,mc90,LG-H520,3,-20,1
+lge,mc90ds,LG-H522,3,-20,1
+lge,c90,LG-H525,3,-20,1
+lge,c90n,LG-H525n,3,-20,1
+lge,mp1s3gds,LG-H540,3,-20,1
+lge,mp1s3gss,LG-H542,3,-20,1
+lge,g4stylusdsn,LG-H630,3,-21,1
+lge,g4stylusds,LG-H630D,3,-21,1
+lge,g4stylusn,LG-H631,3,-21,1
+lge,g4stylusn,LG-H631MX,3,-21,1
+lge,g4stylus,LG-H634,3,-21,3
+lge,g4stylusn,LG-H635,3,-21,1
+lge,g4stylusn,LG-H635A,3,-21,1
+lge,g4stylusn,LG-H636,3,-21,1
+lge,c100,LG-H650,3,-20,1
+lge,lv9n,LG-H700,3,-20,1
+lge,p1bssn,LG-H731,3,-20,1
+lge,p1bds3g,LG-H734,3,-20,1
+lge,p1bssn,LG-H735,3,-20,1
+lge,p1bdsn,LG-H736,3,-20,1
+lge,p1v,LG-H740,3,-20,1
+lge,aka,LG-H778,3,-20,1
+lge,aka,LG-H779,3,-20,1
+lge,aka,LG-H788,3,-20,1
+lge,aka,LG-H788SG,3,-20,1
+lge,aka,LG-H788TR,3,-20,1
+lge,aka,LG-H788n,3,-20,1
+lge,p1,LG-H810,-3,-25,1
+lge,p1,LG-H811,-3,-25,1
+lge,p1,LG-H812,-3,-25,1
+lge,p1,LG-H815,-3,-25,3
+lge,p1,LG-H818,-3,-25,1
+lge,p1,LG-H819,-3,-25,1
+lge,h1,LG-H820,9,-15,1
+lge,h1,LG-H820PR,9,-15,1
+lge,h1,LG-H830,9,-15,1
+lge,h1,LG-H831,9,-15,1
+lge,alicee,LG-H840,3,-20,1
+lge,alicee,LG-H845,3,-20,1
+lge,alicee,LG-H848,3,-20,1
+lge,h1,LG-H850,9,-15,1
+lge,h1,LG-H858,9,-15,1
+lge,h1,LG-H860,9,-15,1
+lge,h1,LG-H868,9,-15,1
+lge,lucye,LG-H870,-3,-8,1
+lge,lucye,LG-H870AR,-3,-8,1
+lge,lucye,LG-H870DS,-3,-8,1
+lge,lucye,LG-H870I,-3,-8,1
+lge,lucye,LG-H870S,-3,-8,1
+lge,lucye,LG-H871,-3,-8,1
+lge,lucye,LG-H871S,-3,-8,1
+lge,lucye,LG-H872,-3,-8,1
+lge,lucye,LG-H872PR,-3,-8,1
+lge,lucye,LG-H873,-3,-8,1
+lge,pplus,LG-H900,3,-20,1
+lge,pplus,LG-H900PR,3,-20,1
+lge,pplus,LG-H901,3,-20,1
+lge,elsa,LG-H910,6,-3,1
+lge,elsa,LG-H910PR,6,-3,1
+lge,elsa,LG-H915,6,-3,1
+lge,elsa,LG-H918,6,-3,1
+lge,joan,LG-H930,4,-21,1
+lge,joan,LG-H931,4,-21,1
+lge,joan,LG-H932,4,-21,1
+lge,joan,LG-H932PR,4,-21,1
+lge,joan,LG-H933,4,-21,1
+lge,z2,LG-H950,3,-20,1
+lge,z2,LG-H955,3,-20,1
+lge,z2,LG-H959,3,-20,1
+lge,pplus,LG-H960,3,-20,1
+lge,pplus,LG-H961AN,3,-20,1
+lge,pplus,LG-H961N,3,-20,1
+lge,pplus,LG-H961S,3,-20,1
+lge,pplus,LG-H962,3,-20,1
+lge,pplus,LG-H968,3,-20,1
+lge,anna,LG-H970,6,-13,1
+lge,elsa,LG-H990,6,-3,1
+lge,mme0,LG-K100,2,-23,1
+lge,mme0n,LG-K100,2,-23,3
+lge,e1q,LG-K120,3,-20,1
+lge,me1,LG-K120,3,-20,1
+lge,e1q,LG-K120GT,3,-20,1
+lge,e1q,LG-K121,3,-20,1
+lge,me1ds,LG-K130,3,-20,1
+lge,k6b,LG-K200,3,-20,1
+lge,k6p,LG-K210,3,-20,1
+lge,k6p,LG-K212,3,-20,1
+lge,mk6pn,LG-K220,3,-20,1
+lge,mk6p,LG-K220,3,-20,1
+lge,mk6m,LG-K240,3,-20,1
+lge,m1,LG-K330,3,-20,1
+lge,m1ds,LG-K332,3,-20,1
+lge,mm1vn,LG-K350,3,-20,1
+lge,mm1v,LG-K350,1,-21,3
+lge,m1v,LG-K371,3,-20,1
+lge,m1v,LG-K373,3,-20,1
+lge,m23g,LG-K410,3,-20,1
+lge,m216,LG-K420,3,-20,1
+lge,m216n,LG-K420,3,-20,1
+lge,m209,LG-K420PR,2,-22,1
+lge,m209n,LG-K425,3,-20,1
+lge,m209n,LG-K428,3,-20,1
+lge,m253n,LG-K430,2,-22,1
+lge,m253,LG-K430,2,-22,3
+lge,k6p,LG-K450,3,-20,1
+lge,k5n,LG-K500,6,-22,1
+lge,k5,LG-K500,6,-22,3
+lge,k5n,LG-K500n,6,-22,1
+lge,ph1n,LG-K520,3,-20,1
+lge,ph1,LG-K520,6,-22,1
+lge,ph2,LG-K530,3,-20,1
+lge,ph2n,LG-K535,3,-20,1
+lge,ph2,LG-K535,3,-20,1
+lge,ph2n,LG-K535n,3,-20,1
+lge,ph1,LG-K540,6,-22,3
+lge,ph2n,LG-K550,3,-20,1
+lge,ph2n,LG-K557,3,-20,1
+lge,k7,LG-K580,3,-20,1
+lge,k7n,LG-K580,3,-20,1
+lge,k7n,LG-K580Y,3,-20,1
+lge,sjr,LG-K600,3,-20,1
+lge,EVE,LG-KH5200,3,-20,1
+lge,thunder_kor-08,LG-KU3700,3,-20,1
+lge,ku3700,LG-KU3700,3,-20,1
+lge,p2,LG-KU5400,3,-20,1
+lge,ku5900,LG-KU5900,3,-20,1
+lge,black,LG-KU5900,3,-20,1
+lge,x2_450-08,LG-KU8800,3,-20,1
+lge,e0,LG-L38C,3,-20,1
+lge,m4,LG-L40G,3,-20,1
+lge,l95g,LG-L95G,3,-20,1
+lge,u0_cdma,LG-LG730,3,-20,1
+lge,LG855,LG-LG855,3,-20,1
+lge,fx1,LG-LG870,3,-20,1
+lge,mth8,LG-LK460,3,-20,1
+lge,m3s,LG-LS696,3,-20,1
+lge,ls700,LG-LS700,3,-20,1
+lge,fx3,LG-LS720,3,-20,1
+lge,sf340,LG-LS777,3,-20,1
+lge,cayman,LG-LS840,3,-20,1
+lge,LS855,LG-LS855,3,-20,1
+lge,l2s,LG-LS860,3,-20,1
+lge,geehrc4g,LG-LS970,3,-20,1
+lge,g2,LG-LS980,3,-20,1
+lge,lucye,LG-LS993,-3,-8,1
+lge,zee,LG-LS995,3,-20,1
+lge,elsa,LG-LS997,6,-3,1
+lge,joan,LG-LS998,4,-21,1
+lge,lu3000,LG-LU3000,3,-20,1
+lge,LU3000,LG-LU3000,3,-20,1
+lge,hub,LG-LU3000,3,-20,1
+lge,lu3100,LG-LU3100,3,-20,1
+lge,thunder_kor-08,LG-LU3700,3,-20,1
+lge,lu3700,LG-LU3700,3,-20,1
+lge,p2,LG-LU5400,3,-20,1
+lge,i_u,LG-LU6200,3,-20,1
+lge,msm8660_surf,LG-LU6200,3,-20,1
+lge,bssq_450-06,LG-LU6500,3,-20,1
+lge,bssq,LG-LU6500,3,-20,1
+lge,lu6800,LG-LU6800,3,-20,1
+lge,justin,LG-LU6800,3,-20,1
+lge,express,LG-LU8300,3,-20,1
+lge,thunderc,LG-LW690,3,-20,1
+lge,l0,LG-LW770,3,-20,1
+lge,lv1,LG-M150,3,-20,1
+lge,lv1,LG-M151,3,-20,1
+lge,lv1,LG-M153,3,-20,1
+lge,lv1,LG-M154,3,-20,1
+lge,lv1,LG-M160,3,-20,1
+lge,lv3,LG-M200,3,-20,1
+lge,lv3n,LG-M200,1,-22,1
+lge,lv3,LG-M210,1,-21,1
+lge,mlv5n,LG-M250,3,-22,1
+lge,mlv5,LG-M250,3,-22,3
+lge,lv517n,LG-M255,3,-20,1
+lge,lv517,LG-M257,3,-20,1
+lge,lv517,LG-M257PR,3,-22,1
+lge,mlv7,LG-M320,3,-20,1
+lge,mlv7n,LG-M320,3,-20,1
+lge,lv7,LG-M320G,3,-20,1
+lge,lv7,LG-M322,3,-20,1
+lge,lv7,LG-M327,3,-20,1
+lge,msf3n,LG-M400,3,-20,1
+lge,msf3,LG-M400,3,-20,1
+lge,sf317,LG-M430,3,-20,1
+lge,sf340n,LG-M470,3,-20,1
+lge,sf340n,LG-M470F,3,-20,1
+lge,mhn,LG-M700,3,-20,1
+lge,mh,LG-M700,3,-20,1
+lge,mhn,LG-M703,3,-20,1
+lge,lv9n,LG-M710,3,-20,1
+lge,lv9n,LG-M710ds,3,-20,1
+lge,thunderc,LG-MS690,3,-20,1
+lge,m3_mpcs_us,LG-MS695,3,-20,1
+lge,l0,LG-MS770,3,-20,1
+lge,cayman,LG-MS840,3,-20,1
+lge,l1m,LG-MS870,3,-20,1
+lge,MS910,LG-MS910,3,-20,1
+lge,pecan,LG-P350,3,-20,1
+lge,pecan,LG-P350f,3,-20,1
+lge,pecan,LG-P350g,3,-20,1
+lge,pecanV,LG-P355,3,-20,1
+lge,b6,LG-P451L,3,-20,1
+lge,e8lte,LG-P490L,3,-20,1
+lge,thunderg,LG-P500,3,-20,1
+lge,thunderg,LG-P500h,3,-20,1
+lge,thunderg,LG-P503,3,-20,1
+lge,thunderg,LG-P504,3,-20,1
+lge,thunderg,LG-P505,3,-20,1
+lge,thunderg,LG-P505CH,3,-20,1
+lge,thunderg,LG-P505R,3,-20,1
+lge,thunderg,LG-P506,3,-20,1
+lge,thunderg,LG-P509,3,-20,1
+lge,tf840,LG-P530L,3,-20,1
+lge,fx3,LG-P655H,3,-20,1
+lge,fx3,LG-P655K,3,-20,1
+lge,fx3,LG-P659,3,-20,1
+lge,fx3,LG-P659H,3,-20,1
+lge,gelato_sgp-xx,LG-P690,3,-20,1
+lge,gelato_mor-xx,LG-P690,3,-20,1
+lge,gelato_eur-xx,LG-P690,3,-20,1
+lge,gelato_262-xx,LG-P690,3,-20,1
+lge,gelato_ngr-xx,LG-P690,3,-20,1
+lge,gelato_sea-xx,LG-P690,3,-20,1
+lge,gelato_bal-xx,LG-P690,3,-20,1
+lge,gelato_win-it,LG-P690,3,-20,1
+lge,gelato_tmb-sk,LG-P690,3,-20,1
+lge,gelato_cis-xx,LG-P690,3,-20,1
+lge,gelato_tur-xx,LG-P690,3,-20,1
+lge,gelato_hkg-xx,LG-P690,3,-20,1
+lge,gelato_are-xx,LG-P690,3,-20,1
+lge,gelato_460-xx,LG-P690,3,-20,1
+lge,gelato_302-610,LG-P690b,3,-20,1
+lge,gelato_505-01,LG-P690f,3,-20,1
+lge,gelato_425-02,LG-P690f,3,-20,1
+lge,gelato_nfc_234-10,LG-P692,3,-20,1
+lge,gelato_nfc_tim-it,LG-P692,3,-20,1
+lge,gelato_nfc_530-24,LG-P692,3,-20,1
+lge,gelato_460-xx,LG-P693,3,-20,1
+lge,gelatods_ind-xxx,LG-P698,3,-20,1
+lge,gelatods_open-xx,LG-P698,3,-20,1
+lge,gelatods_bal-xxx,LG-P698,3,-20,1
+lge,gelatods_ngr-xxx,LG-P698,3,-20,1
+lge,gelatods_are-xxx,LG-P698,3,-20,1
+lge,gelatods_cis-xxx,LG-P698,3,-20,1
+lge,gelatods_sea-xxx,LG-P698,3,-20,1
+lge,gelatods_open-br,LG-P698f,3,-20,1
+lge,gelatods_tha-xxx,LG-P698f,3,-20,1
+lge,u0,LG-P700,3,-20,1
+lge,u0,LG-P705,3,-20,1
+lge,u0,LG-P705f,3,-20,1
+lge,u0,LG-P705g,3,-20,1
+lge,u0,LG-P708g,3,-20,1
+lge,vee7e,LG-P710,3,-20,1
+lge,vee7e,LG-P712,3,-20,1
+lge,vee7e,LG-P713,3,-20,1
+lge,vee7e,LG-P713GO,3,-20,1
+lge,vee7e,LG-P713TR,3,-20,1
+lge,vee7e,LG-P714,3,-20,1
+lge,vee7ds,LG-P715,3,-20,1
+lge,vee7ds,LG-P716,3,-20,1
+lge,cx2,LG-P720,3,-20,1
+lge,cx2,LG-P720h,3,-20,1
+lge,cx2,LG-P725,3,-20,1
+lge,b5,LG-P755L,3,-20,1
+lge,u2,LG-P760,3,-20,1
+lge,u2,LG-P765,3,-20,1
+lge,u2,LG-P768,3,-20,1
+lge,u2,LG-P769,3,-20,1
+lge,u2,LG-P778,3,-20,1
+lge,altev2,LG-P815L,3,-20,1
+lge,l1a,LG-P870,3,-20,1
+lge,l1e,LG-P870h,3,-20,1
+lge,l1e,LG-P875,3,-20,1
+lge,l1e,LG-P875h,3,-20,1
+lge,x3,LG-P880,3,-20,1
+lge,x3,LG-P880g,3,-20,1
+lge,vu10,LG-P895,3,-20,1
+lge,vu10,LG-P895qb,3,-20,1
+lge,cosmopolitan,LG-P920,3,-20,1
+lge,cosmo_OPT-XXX,LG-P920,3,-20,1
+lge,cosmo_MEA-XXX,LG-P920,3,-20,1
+lge,cosmo_466-92,LG-P920,3,-20,1
+lge,cosmo_OPEN-CN,LG-P920,3,-20,1
+lge,cosmo_MOR-XXX,LG-P920,3,-20,1
+lge,cosmo_H3G-XXX,LG-P920,3,-20,1
+lge,cosmo_CIS-XXX,LG-P920,3,-20,1
+lge,cosmo_VDF-XXX,LG-P920,3,-20,1
+lge,cosmo_525-01,LG-P920,3,-20,1
+lge,cosmo_515-XXX,LG-P920,3,-20,1
+lge,cosmo_505-XXX,LG-P920,3,-20,1
+lge,cosmo_TMO-XXX,LG-P920,3,-20,1
+lge,cosmo_525-05,LG-P920,3,-20,1
+lge,p920,LG-P920,3,-20,1
+lge,cosmo_BAL-XXX,LG-P920,3,-20,1
+lge,cosmo_EUR-XXX,LG-P920,3,-20,1
+lge,cosmo_454-XXX,LG-P920,3,-20,1
+lge,cosmo_268-06,LG-P920,3,-20,1
+lge,cosmo_ESA-XXX,LG-P920,3,-20,1
+lge,cosmo_tcl-mx,LG-P920h,3,-20,1
+lge,cosmo_viv-br,LG-P920h,3,-20,1
+lge,cosmo_724-05,LG-P920h,3,-20,1
+lge,cosmo_724-xxx,LG-P920h,3,-20,1
+lge,cosmo_724-02,LG-P920h,3,-20,1
+lge,p920,LG-P920h,3,-20,1
+lge,cosmopolitan,LG-P925,3,-20,1
+lge,p925,LG-P925,3,-20,1
+lge,cosmo_310-410,LG-P925,3,-20,1
+lge,p925g,LG-P925g,3,-20,1
+lge,cosmopolitan,LG-P925g,3,-20,1
+lge,cosmo_302-720,LG-P925g,3,-20,1
+lge,lgp930,LG-P930,3,-20,1
+lge,lgp935,LG-P935,3,-20,1
+lge,iproj,LG-P936,3,-20,1
+lge,p940,LG-P940,3,-20,1
+lge,p2,LG-P940,3,-20,1
+lge,p2,LG-P940h,3,-20,1
+lge,bproj_262-XXX,LG-P970,3,-20,1
+lge,bproj_208-01,LG-P970,3,-20,1
+lge,bproj_222-88,LG-P970,3,-20,1
+lge,bproj_ARE-XXX,LG-P970,3,-20,1
+lge,bproj_232-05,LG-P970,3,-20,1
+lge,bproj_BAL-xxx,LG-P970,3,-20,1
+lge,bproj_530-XXX,LG-P970,3,-20,1
+lge,bproj_214-03,LG-P970,3,-20,1
+lge,LGP970,LG-P970,3,-20,1
+lge,bproj_214-07,LG-P970,3,-20,1
+lge,blackg,LG-P970,3,-20,1
+lge,bproj_260-03,LG-P970,3,-20,1
+lge,bproj_OPEN-CN,LG-P970,3,-20,1
+lge,bproj_CIS-xxx,LG-P970,3,-20,1
+lge,bproj_228-03,LG-P970,3,-20,1
+lge,bproj_EUR-XXX,LG-P970,3,-20,1
+lge,bproj_226-10,LG-P970,3,-20,1
+lge,lgp970,LG-P970,3,-20,1
+lge,bproj_234-33,LG-P970,3,-20,1
+lge,bproj_sea-xxx,LG-P970,3,-20,1
+lge,bproj_VDF-XXX,LG-P970,3,-20,1
+lge,bproj_231-01,LG-P970,3,-20,1
+lge,bproj_454-xxx,LG-P970,3,-20,1
+lge,bproj_302-220,LG-P970g,3,-20,1
+lge,lgp970,LG-P970g,3,-20,1
+lge,bproj_724-xxx,LG-P970h,3,-20,1
+lge,lgp970,LG-P970h,3,-20,1
+lge,bproj_334-020,LG-P970h,3,-20,1
+lge,blackg,LG-P970h,3,-20,1
+lge,p990_214-01,LG-P990,3,-20,1
+lge,p990_219-10,LG-P990,3,-20,1
+lge,p990_234-xx,LG-P990,3,-20,1
+lge,p990_525-05,LG-P990,3,-20,1
+lge,p990_226-01,LG-P990,3,-20,1
+lge,p990_466-xxx,LG-P990,3,-20,1
+lge,p990_CIS-xxx,LG-P990,3,-20,1
+lge,p990_esa-xxx,LG-P990,3,-20,1
+lge,p990_EUR-xx,LG-P990,3,-20,1
+lge,p990,LG-P990,3,-20,1
+lge,p990_454-xxx,LG-P990,3,-20,1
+lge,p990_208-10,LG-P990,3,-20,1
+lge,star,LG-P990,3,-20,1
+lge,p990_262-xx,LG-P990,3,-20,1
+lge,p990_505-xxx,LG-P990,3,-20,1
+lge,p990_BAL-xxx,LG-P990,3,-20,1
+lge,p990_466-92,LG-P990,3,-20,1
+lge,p990_228-01,LG-P990,3,-20,1
+lge,p990_525-01,LG-P990,3,-20,1
+lge,p990_262-02,LG-P990,3,-20,1
+lge,p990,LG-P990H,3,-20,1
+lge,p990h_730-03,LG-P990h,3,-20,1
+lge,p990h_716-10,LG-P990h,3,-20,1
+lge,p990h_334-020,LG-P990h,3,-20,1
+lge,p990h_SSV-xxx,LG-P990h,3,-20,1
+lge,p990,LG-P990h,3,-20,1
+lge,p990h_730-01,LG-P990h,3,-20,1
+lge,p990h_724-05,LG-P990h,3,-20,1
+lge,p990h,LG-P990h,3,-20,1
+lge,p990h_722-34,LG-P990h,3,-20,1
+lge,p990h_CTM-xxx,LG-P990h,3,-20,1
+lge,p990hN,LG-P990hN,3,-20,1
+lge,star,LG-P990hN,3,-20,1
+lge,p993,LG-P993,3,-20,1
+lge,p999,LG-P999,3,-20,1
+lge,mcv7a,LG-Q710AL,3,-20,1
+lge,mcv7a,LG-Q710PL,3,-20,1
+lge,mcv150,LG-SP200,3,-20,1
+lge,mlv7,LG-SP320,3,-20,1
+lge,su370,LG-SU370,3,-20,1
+lge,thunder_kor-05,LG-SU370,3,-20,1
+lge,p2,LG-SU540,3,-20,1
+lge,i_skt,LG-SU640,3,-20,1
+lge,star,LG-SU660,3,-20,1
+lge,star_450-05,LG-SU660,3,-20,1
+lge,su660,LG-SU660,3,-20,1
+lge,cosmo_450-05,LG-SU760,3,-20,1
+lge,cosmopolitan,LG-SU760,3,-20,1
+lge,su760,LG-SU760,3,-20,1
+lge,cx2,LG-SU870,3,-20,1
+lge,x2_450-05,LG-SU880,3,-20,1
+lge,x2,LG-SU880,3,-20,1
+lge,u0,LG-T280,3,-20,1
+lge,vfp3g,LG-T480K,3,-20,1
+lge,vfp3g,LG-T480S,3,-20,1
+lge,my90,LG-T540,3,-20,1
+lge,lv517,LG-TP260,3,-20,1
+lge,sf340n,LG-TP450,3,-20,1
+lge,t8lte,LG-UK495,3,-20,1
+lge,mlv7,LG-US601,3,-20,1
+lge,thunderc,LG-US670,3,-20,1
+lge,mhn,LG-US700,3,-20,1
+lge,lv9,LG-US701,3,-20,1
+lge,u0_cdma,LG-US730,3,-20,1
+lge,fx1,LG-US780,3,-20,1
+lge,elsa,LG-US996,6,-3,1
+lge,joan,LG-US998,4,-21,1
+lge,e7wifi,LG-V400,3,-20,1
+lge,e7wifi,LG-V400S1,3,-20,1
+lge,e7wifi,LG-V400Y1,3,-20,1
+lge,e7wifi,LG-V400Y7,3,-20,1
+lge,e7lte,LG-V410,3,-20,1
+lge,e7lte,LG-V411,3,-20,1
+lge,b6,LG-V425,3,-20,1
+lge,b6,LG-V426,3,-20,1
+lge,e8wifi,LG-V480,3,-20,1
+lge,e8lte,LG-V490,3,-20,1
+lge,t8lte,LG-V495,3,-20,1
+lge,t8lte,LG-V496,3,-20,1
+lge,t8lte,LG-V497,3,-20,1
+lge,t8wifi,LG-V498,3,-20,1
+lge,t8wifi,LG-V498S1,3,-20,1
+lge,t8wifi,LG-V498S2,3,-20,1
+lge,t8lte,LG-V499,3,-20,1
+lge,awifi,LG-V500,3,-20,1
+lge,awifi070u,LG-V507L,3,-20,1
+lge,palman,LG-V510,3,-20,1
+lge,b3,LG-V520,3,-20,1
+lge,b3,LG-V521,3,-20,1
+lge,b3,LG-V522,3,-20,1
+lge,b3,LG-V525,3,-20,1
+lge,b3,LG-V525S1,3,-20,1
+lge,b3,LG-V525S3,3,-20,1
+lge,tf840,LG-V530,3,-20,1
+lge,tf840,LG-V533,3,-20,1
+lge,t8wi7u,LG-V607L,3,-20,1
+lge,e9wifi,LG-V700,3,-20,1
+lge,e9wifin,LG-V700WJ,3,-20,1
+lge,e9wifin,LG-V700n,3,-20,1
+lge,b5,LG-V755,3,-20,1
+lge,v900asia,LG-V900,3,-20,1
+lge,v900,LG-V900,3,-20,1
+lge,v900aus,LG-V900,3,-20,1
+lge,v901tr,LG-V901,3,-20,1
+lge,v901ar,LG-V901,3,-20,1
+lge,v901kr,LG-V901,3,-20,1
+lge,v901twn,LG-V901,3,-20,1
+lge,v905r,LG-V905R,3,-20,1
+lge,v909,LG-V909,3,-20,1
+lge,v909mkt,LG-V909,3,-20,1
+lge,t1lte,LG-V930,3,-20,1
+lge,t1lte,LG-V935,3,-20,1
+lge,t1lte,LG-V935T,3,-20,1
+lge,t1wifi,LG-V940,3,-20,1
+lge,t1wifin,LG-V940n,3,-20,1
+lge,e9lte,LG-VK700,3,-20,1
+lge,m3s,LG-VM696,3,-20,1
+lge,VM701,LG-VM701,3,-20,1
+lge,e0v,LG-VS410PP,3,-20,1
+lge,w5c,LG-VS450PP,3,-20,1
+lge,VS700,LG-VS700,3,-20,1
+lge,VS700,LG-VS700PP,3,-20,1
+lge,lo_2,LG-X130g,3,-20,1
+lge,lo_2_ds,LG-X132,3,-20,1
+lge,lo_1,LG-X135,3,-20,1
+lge,lo_1,LG-X137,3,-20,1
+lge,lo_1,LG-X140,3,-20,1
+lge,lo_1,LG-X145,3,-20,1
+lge,lo_1,LG-X147,3,-20,1
+lge,v10,LG-X150,3,-20,1
+lge,v10,LG-X155,3,-20,1
+lge,v10,LG-X160,3,-20,1
+lge,v10,LG-X165g,3,-20,1
+lge,v10,LG-X170fTV,3,-20,1
+lge,v10,LG-X170g,3,-20,1
+lge,d2,LG-X180g,3,-20,1
+lge,d2,LG-X190,3,-20,1
+lge,m13g,LG-X210,3,-20,1
+lge,d3,LG-X220,3,-20,1
+lge,mlv1,LG-X230,2,-23,3
+lge,mlv1,LG-X230YK,2,-23,1
+lge,mlv3,LG-X240,1,-22,3
+lge,th10,LG-X760,3,-20,1
+lge,th10,LG-X760E,3,-20,1
+lge,th10,LG-X760W,3,-20,1
+lge,w5,LGAS323,3,-20,1
+lge,m1v,LGAS375,1,-21,1
+lge,h1,LGAS992,9,-15,1
+lge,z2,LGAS995,3,-20,1
+lge,k5,LGK500J,6,-22,1
+lge,lv1,LGL157BL,3,-20,1
+lge,lv1,LGL158VL,3,-20,1
+lge,y25,LGL15G,3,-20,1
+lge,lv7,LGL163BL,3,-20,1
+lge,lv7,LGL164VL,3,-20,1
+lge,y25c,LGL16C,3,-20,1
+lge,y30t,LGL17AG,3,-20,1
+lge,y30tc,LGL18VC,3,-20,1
+lge,geehdc,LGL21,3,-20,1
+lge,y50,LGL21G,3,-20,1
+lge,g2,LGL22,3,-20,1
+lge,y50c,LGL22C,3,-20,1
+lge,zee,LGL23,3,-20,1
+lge,g3,LGL24,3,-20,1
+lge,fx3,LGL25L,3,-20,1
+lge,f70,LGL31L,3,-20,1
+lge,mh5lm-8m,LGL322DL,3,-20,1
+lge,c50,LGL33L,3,-21,1
+lge,w3c,LGL34C,3,-20,1
+lge,e0,LGL35G,3,-20,1
+lge,l4ii_cdma,LGL39C,3,-20,1
+lge,w5c,LGL41C,3,-20,1
+lge,mh4,LGL423DL,3,-20,1
+lge,e1q,LGL43AL,3,-20,1
+lge,e1q,LGL44VL,3,-20,1
+lge,mdh10lm,LGL455DL,3,-20,1
+lge,lgl45c,LGL45C,3,-20,1
+lge,lv0,LGL48VL,6,-24,1
+lge,m1,LGL51AL,3,-20,1
+lge,m1,LGL52VL,3,-20,1
+lge,k6b,LGL53BL,3,-20,1
+lge,lgl55c,LGL55C,3,-20,1
+lge,k6b,LGL56VL,3,-20,1
+lge,lv1,LGL57BL,3,-20,1
+lge,lv1,LGL58VL,3,-20,1
+lge,lv517,LGL59BL,3,-20,1
+lge,m209,LGL61AL,3,-20,1
+lge,m209,LGL62VL,3,-20,1
+lge,lv7,LGL63BL,3,-20,1
+lge,lv7,LGL64VL,3,-20,1
+lge,cv7as,LGL722DL,3,-20,1
+lge,lgl75c,LGL75C,3,-20,1
+lge,ph1,LGL81AL,6,-22,1
+lge,ph1,LGL82VL,6,-22,1
+lge,sf317,LGL83BL,3,-20,1
+lge,sf317,LGL84VL,3,-20,1
+lge,LGL85C,LGL85C,3,-20,1
+lge,u0_cdma,LGL86C,3,-20,1
+lge,u0,LGL96G,3,-20,1
+lge,e7iilte,LGLK430,2,-18,3
+lge,me0,LGLS450,5,-24,3
+lge,w5c,LGLS620,3,-20,1
+lge,e2nas,LGLS660,3,-20,1
+lge,c50,LGLS665,3,-21,1
+lge,m1,LGLS675,3,-20,1
+lge,k6b,LGLS676,3,-20,1
+lge,x5,LGLS740,3,-20,1
+lge,c90nas,LGLS751,3,-20,1
+lge,mk6p55,LGLS755,3,-20,1
+lge,g4stylusc,LGLS770,3,-21,1
+lge,ph1,LGLS775,6,-22,1
+lge,jagc,LGLS885,3,-20,1
+lge,g3,LGLS990,3,-20,1
+lge,p1,LGLS991,-3,-25,1
+lge,h1,LGLS992,9,-15,1
+lge,z2,LGLS996,3,-20,1
+lge,lucye,LGM-G600K,-3,-8,1
+lge,lucye,LGM-G600L,-3,-8,1
+lge,lucye,LGM-G600S,-3,-8,1
+lge,lv3n,LGM-K120K,3,-20,1
+lge,lv3n,LGM-K120L,3,-20,1
+lge,lv3n,LGM-K120S,3,-20,1
+lge,mlv5n,LGM-K121K,3,-20,1
+lge,mlv5n,LGM-K121L,3,-20,1
+lge,mlv5n,LGM-K121S,3,-20,1
+lge,joan,LGM-V300K,4,-21,1
+lge,joan,LGM-V300L,4,-21,3
+lge,joan,LGM-V300S,4,-21,1
+lge,cf2,LGM-X100L,3,-20,1
+lge,cf2,LGM-X100S,3,-20,1
+lge,mlv5n,LGM-X301K,3,-20,1
+lge,mlv5n,LGM-X301L,3,-20,1
+lge,mlv5n,LGM-X301S,3,-20,1
+lge,mlv7n,LGM-X320K,3,-20,1
+lge,mlv7n,LGM-X320L,3,-20,1
+lge,mlv7n,LGM-X320S,3,-20,1
+lge,mlv5n,LGM-X401L,3,-20,1
+lge,mlv5n,LGM-X401S,3,-20,1
+lge,mhn,LGM-X600K,3,-20,1
+lge,mhn,LGM-X600L,3,-20,1
+lge,mhn,LGM-X600S,3,-20,1
+lge,anna,LGM-X800K,6,-13,1
+lge,anna,LGM-X800L,6,-13,3
+lge,lv517,LGMP260,3,-20,1
+lge,sf340n,LGMP450,3,-20,1
+lge,lv3,LGMS210,3,-20,1
+lge,w5,LGMS323,3,-20,1
+lge,m1,LGMS330,3,-20,1
+lge,c50,LGMS345,3,-21,1
+lge,e2nam,LGMS395,3,-20,1
+lge,m209n,LGMS428,3,-20,1
+lge,f6,LGMS500,3,-20,1
+lge,ph2n,LGMS550,3,-20,1
+lge,g4stylusn,LGMS631,3,-21,1
+lge,fx3,LGMS659,3,-20,1
+lge,u2,LGMS769,3,-20,1
+lge,cf,LGS01,3,-20,1
+lge,k5,LGS02,6,-22,1
+lge,e8lte,LGT01,3,-20,1
+lge,b6,LGT02,3,-20,1
+lge,b3,LGT31,3,-20,1
+lge,b5,LGT32,3,-20,1
+lge,e7lte,LGUK410,3,-20,1
+lge,b5,LGUK750,3,-20,1
+lge,t1lte,LGUK932,3,-20,1
+lge,lv0,LGUS110,6,-24,1
+lge,lv3,LGUS215,1,-22,1
+lge,m1v,LGUS375,1,-21,1
+lge,c70,LGUS550,3,-20,1
+lge,k6p,LGUS610,3,-20,1
+lge,g3,LGUS990,3,-20,1
+lge,p1,LGUS991,-4,-25,3
+lge,h1,LGUS992,9,-15,1
+lge,z2,LGUS995,3,-20,1
+lge,lucye,LGUS997,-3,-8,1
+lge,g3,LGV31,3,-20,1
+lge,p1,LGV32,-3,-25,1
+lge,JSG,LGV33,3,-20,1
+lge,elsa,LGV34,6,-3,1
+lge,joan,LGV35,4,-21,1
+lge,cv1,LGV36,4,-18,1
+lge,judyln,LM-G710,3,-20,1
+lge,judyln,LM-G710N,3,-20,1
+lge,judyln,LM-G710VM,3,-20,1
+lge,betalm,LM-G810,3,-20,1
+lge,alphalm,LM-G820,3,-20,1
+lge,alphaamz,LM-G820,3,-20,1
+lge,alphaplus,LM-G820N,3,-20,1
+lge,mh2lm,LM-G850,3,-20,1
+lge,caymanlm,LM-G900,3,-20,1
+lge,caymanlm,LM-G900N,3,-20,1
+lge,mdh10lm,LM-K400,3,-20,1
+lge,mdh15lm,LM-K410,3,-20,1
+lge,mdh35lm,LM-K510,3,-20,1
+lge,mdh30lm,LM-Q510N,3,-20,1
+lge,cv5a,LM-Q610(FGN),3,-20,1
+lge,mcv5a,LM-Q610.FG,3,-20,1
+lge,mcv5a,LM-Q610.FGN,3,-20,1
+lge,mcv5a,LM-Q617.FGN,3,-20,1
+lge,cv5a,LM-Q617.FGN,3,-20,1
+lge,mdh40lm,LM-Q630,3,-20,1
+lge,mdh40lm,LM-Q630N,3,-20,1
+lge,cv7a,LM-Q710(FGN),3,-20,1
+lge,mcv7a,LM-Q710.FG,3,-20,1
+lge,cv7a,LM-Q710.FG,3,-20,1
+lge,cv7a,LM-Q710.FGN,3,-20,1
+lge,mcv7a,LM-Q710.FGN,3,-20,1
+lge,cv7a,LM-Q710XM,3,-20,1
+lge,cv7as,LM-Q720,3,-20,1
+lge,cv7as-pr,LM-Q720,3,-20,1
+lge,cv5an,LM-Q725K,3,-20,1
+lge,cv5an,LM-Q725L,3,-20,1
+lge,cv5an,LM-Q725S,3,-20,1
+lge,cv5an,LM-Q727K,3,-20,1
+lge,cv5an,LM-Q727L,3,-20,1
+lge,cv5an,LM-Q727S,3,-20,1
+lge,cv7an,LM-Q815K,6,-13,1
+lge,cv7an,LM-Q815L,6,-13,1
+lge,cv7an,LM-Q815S,6,-13,1
+lge,falcon,LM-Q850,3,-20,1
+lge,lucye,LM-Q850K,-3,-8,1
+lge,lucye,LM-Q850L,-3,-8,1
+lge,lucye,LM-Q850S,-3,-8,1
+lge,phoenix_sprout,LM-Q910,4,-24,3
+lge,falcon,LM-Q925K,3,-20,1
+lge,falcon,LM-Q925L,3,-20,1
+lge,falcon,LM-Q925S,3,-20,1
+lge,phoenix_sprout,LM-Q927L,4,-24,1
+lge,tf10,LM-T600,3,-20,1
+lge,tf10,LM-T600L,3,-20,1
+lge,tf10w,LM-T605,3,-20,1
+lge,judyp,LM-V350,3,-20,1
+lge,judyp,LM-V350N,3,-20,1
+lge,judypn,LM-V405,3,-20,1
+lge,judypn,LM-V409N,3,-20,1
+lge,flashlm,LM-V450,3,-20,1
+lge,flashlmdd,LM-V500,3,-20,1
+lge,flashlmdd,LM-V500N,3,-20,1
+lge,flashlm,LM-V500XM,3,-20,1
+lge,mh2lm,LM-V510N,3,-20,1
+lge,flashsignaturelm,LM-V520N,3,-20,1
+lge,timelm,LM-V600,3,-20,1
+lge,timelm,LM-V600N,3,-20,1
+lge,mmh6lm,LM-X120,3,-20,1
+lge,cv1,LM-X21(G),4,-18,1
+lge,cv109,LM-X210,3,-20,1
+lge,cv1,LM-X210,4,-18,3
+lge,mcv150,LM-X210,4,-18,1
+lge,cv1,LM-X210(G),4,-18,1
+lge,cv1,LM-X210APM,4,-18,1
+lge,cv1,LM-X210CM,4,-18,1
+lge,cv1,LM-X210CMR,4,-18,1
+lge,cv109,LM-X210K,3,-20,1
+lge,cv109,LM-X210L,3,-20,1
+lge,Neo2ALP,LM-X210LMW,3,-20,1
+lge,cv109,LM-X210S,3,-20,1
+lge,cv1,LM-X210VPP,4,-18,1
+lge,cv1,LM-X212(G),4,-18,1
+lge,cv1s,LM-X220,3,-20,1
+lge,mh5lm,LM-X220N,3,-20,1
+lge,mcv1s,LM-X220PM,3,-20,1
+lge,mcv1s,LM-X220QMA,3,-20,1
+lge,mh5lm,LM-X320,3,-20,1
+lge,mh5lm-8m,LM-X320,3,-20,1
+lge,mmh5lm,LM-X320,3,-20,1
+lge,cv3,LM-X410(FG),3,-20,1
+lge,mcv3,LM-X410(FN),3,-20,1
+lge,mcv3,LM-X410.F,3,-20,1
+lge,cv3,LM-X410.F,3,-20,1
+lge,cv3,LM-X410.FG,3,-20,1
+lge,cv3,LM-X410.FGN,3,-20,1
+lge,mcv3,LM-X410.FN,3,-20,1
+lge,cv3n,LM-X410K,3,-20,1
+lge,cv3n,LM-X410L,3,-20,1
+lge,mcv3,LM-X410PM,3,-20,1
+lge,cv3n,LM-X410S,3,-20,1
+lge,cv3,LM-X410UM,3,-20,1
+lge,cv3n,LM-X415K,3,-20,1
+lge,cv3n,LM-X415L,3,-20,1
+lge,cv3n,LM-X415S,3,-20,1
+lge,mh4x,LM-X420,3,-20,1
+lge,mh4-pr,LM-X420,3,-20,1
+lge,mmh4x,LM-X420,3,-20,1
+lge,mh4,LM-X420,3,-20,1
+lge,mmh4,LM-X420,3,-20,1
+lge,mmh4,LM-X420N,3,-20,1
+lge,mmh55lm,LM-X430,3,-20,1
+lge,LM-X440IM,LM-X440IM,3,-20,1
+lge,LM-X440ZM,LM-X440ZM,3,-20,1
+lge,LM-X440ZMW,LM-X440ZMW,3,-20,1
+lge,mlv7,LM-X510(FG),3,-20,1
+lge,mlv7,LM-X510.FG,3,-20,1
+lge,mlv7n,LM-X510K,3,-20,1
+lge,mlv7n,LM-X510L,3,-20,1
+lge,mlv7n,LM-X510S,3,-20,1
+lge,lv7,LM-X510WM,3,-20,1
+lge,mmh4p-pr,LM-X520,3,-20,1
+lge,mmh4p,LM-X525,3,-20,1
+lge,mmh45lm,LM-X540,3,-20,1
+lge,Neo4LM,LM-X600IM,3,-20,1
+lge,mmh4p,LM-X625N,3,-20,1
+lge,cv1,LML211BL,4,-18,1
+lge,cv1,LML212VL,4,-18,1
+lge,cv3,LML413DL,3,-20,1
+lge,cv3,LML414DL,3,-20,1
+lge,cv7a,LML713DL,3,-20,1
+lge,LMX130IM,LMX130IM,3,-20,1
+lge,thunderc,LS670,3,-20,1
+lge,lu2300,LU2300,3,-20,1
+lge,mako,Nexus 4,3,-20,1
+lge,hammerhead,Nexus 5,3,-20,1
+lge,bullhead,Nexus 5X,-6,-25,3
+lge,m1v,RS500,1,-21,1
+lge,lv517,RS501,3,-20,1
+lge,pplus,RS987,3,-20,1
+lge,h1,RS988,8,-3,3
+lge,su950,SU950,3,-20,1
+lge,aloha,US740,3,-20,1
+lge,envt2,USCC-US760,3,-20,1
+lge,US855,USCC-US855,3,-20,1
+lge,e7lte,VK410,3,-20,1
+lge,e9lte,VK700,3,-20,1
+lge,altev,VK810 4G,3,-20,1
+lge,altev2,VK815,3,-20,1
+lge,thunderc,VM670,3,-20,1
+lge,w3c,VS415PP,3,-20,1
+lge,e1q,VS425,3,-20,1
+lge,e1q,VS425PP,3,-20,1
+lge,m1v,VS500,3,-20,1
+lge,m1v,VS500PP,3,-20,1
+lge,lv517,VS501,3,-20,1
+lge,envt2,VS761,3,-20,1
+lge,e2nav,VS810PP,3,-20,1
+lge,c50,VS820,3,-21,1
+lge,mph1,VS835,3,-20,1
+lge,cayman,VS840 4G,3,-20,1
+lge,cayman,VS840PP,3,-20,1
+lge,l1v,VS870 4G,3,-20,1
+lge,x5,VS876,3,-20,1
+lge,x10,VS880,3,-20,1
+lge,x10,VS880PP,3,-20,1
+lge,fx3q,VS890 4G,3,-20,1
+lge,bryce,VS910 4G,3,-20,1
+lge,i_vzw,VS920 4G,3,-20,1
+lge,VS920,VS920 4G,3,-20,1
+lge,d1lv,VS930 4G,3,-20,1
+lge,batman_vzw,VS950 4G,3,-20,1
+lge,g2,VS980 4G,3,-20,1
+lge,g3,VS985 4G,3,-20,1
+lge,p1,VS986,-3,-25,1
+lge,h1,VS987,9,-15,1
+lge,lucye,VS988,-3,-8,3
+lge,pplus,VS990,3,-20,1
+lge,elsa,VS995,6,-3,3
+lge,joan,VS996,4,-21,1
+lge,thunderc,Vortex,3,-20,1
+lge,b6,WM-LG8200,3,-20,1
+lge,phoenix_sprout,X5-LG,4,-24,1
+lge,envt2,enV Pro,3,-20,1
+lge,envt2,enV Touch2,3,-20,1
+lge,SE_TF,ref_SCTF,3,-20,1
+lge,thunderc,thunderc,3,-20,1
+meizu,15,15,5,-5,1
+meizu,15Lite,15 Lite,5,-5,1
+meizu,15Plus,15 Plus,5,-5,1
+meizu,16,16,5,-5,1
+meizu,16X,16 X,5,-5,1
+meizu,meizu16T,16T,5,-5,1
+meizu,16s,16s,5,-5,1
+meizu,meizu16sPro,16s Pro,5,-5,1
+meizu,16th,16th,5,-5,1
+meizu,16thPlus,16th Plus,5,-5,1
+meizu,M15,M15,5,-5,1
+meizu,M1813,M1813,5,-5,1
+meizu,M1816,M1816,5,-5,1
+meizu,M1822,M1822,5,-5,1
+meizu,M1852,M1852,5,-5,1
+meizu,meizu_M6,M6,5,-5,1
+meizu,M6Note,M6 Note,5,-5,1
+meizu,MeizuM6T,M6T,5,-5,1
+meizu,MeizuS6,M712C,5,-5,1
+meizu,M712C,M712C,5,-5,1
+meizu,MeizuE3,MEIZU E3,5,-5,1
+meizu,meizu_M6,MEIZU M6,5,-5,1
+meizu,mx4,MX4,5,-5,3
+meizu,Meizu6T,Meizu 6T,5,-5,1
+meizu,MeizuM6s,Meizu M6s,5,-5,1
+meizu,MeizuM8c,Meizu M8c,5,-5,1
+meizu,MeizuS6,Meizu S6,5,-5,1
+meizu,MeizumbluS6,Meizu mblu S6,5,-5,1
+meizu,Note9,Note9,5,-5,1
+meizu,PRO7S,PRO 7,5,-5,1
+meizu,PRO7Plus,PRO 7 Plus,5,-5,1
+meizu,PRO7H,PRO 7-H,5,-5,1
+meizu,PRO7S,PRO 7-S,5,-5,1
+meizu,meizu16Xs,meizu 16Xs,5,-5,1
+meizu,meizu17,meizu 17,5,-5,1
+meizu,meizu17Pro,meizu 17 Pro,5,-5,1
+meizu,meizuC9,meizu C9,5,-5,1
+meizu,meizuC9pro,meizu C9 pro,5,-5,1
+meizu,meizuM10,meizu M10,5,-5,1
+meizu,meizuM8,meizu M8,5,-5,1
+meizu,M8lite,meizu M8 lite,5,-5,1
+meizu,X8,meizu X8,5,-5,1
+meizu,meizunote8,meizu note8,5,-5,1
+meizu,meizunote9,meizu note9,5,-5,1
+motorola,scorpion_mini_t,201M,4,-23,1
+motorola,smq_t,201M,4,-23,1
+motorola,umts_lucky,A1680,4,-23,1
+motorola,umts_sholes,A853,4,-23,1
+motorola,miler,A854,4,-23,1
+motorola,umts_milestone2,A953,4,-23,1
+motorola,cdma_droid2,A955,4,-23,1
+motorola,cdma_targa,DROID BIONIC,4,-23,1
+motorola,cdma_venus2,DROID PRO,4,-23,1
+motorola,cdma_venus2,DROID Pro,4,-23,1
+motorola,cdma_spyder,DROID RAZR,4,-23,1
+motorola,vanquish,DROID RAZR HD,4,-23,1
+motorola,daytona,DROID X2,4,-23,1
+motorola,cdma_droid2,DROID2,4,-23,1
+motorola,cdma_droid2we,DROID2 GLOBAL,4,-23,1
+motorola,cdma_solana,DROID3,4,-23,1
+motorola,cdma_maserati,DROID4,4,-23,1
+motorola,cdma_shadow,DROIDX,4,-23,1
+motorola,calgary,Devour,4,-23,1
+motorola,sholes,Droid,4,-23,1
+motorola,shibuya,FlipkartTV,4,-23,1
+motorola,cdma_spyder,IS12M,4,-23,1
+motorola,sunfire,ISW11M,4,-23,1
+motorola,pokerp,Lenovo K10,4,-23,1
+motorola,fiji,Lenovo K11,4,-23,1
+motorola,blackjack,Lenovo K11 Power,4,-23,1
+motorola,morr,MB200,4,-23,1
+motorola,morrison,MB200,4,-23,1
+motorola,motus,MB300,4,-23,1
+motorola,zeppelin,MB501,4,-23,1
+motorola,zepp,MB501,4,-23,1
+motorola,umts_basil,MB502,4,-23,1
+motorola,umts_sage,MB508,4,-23,1
+motorola,umts_ruth,MB511,4,-23,1
+motorola,umts_kobe,MB520,4,-23,1
+motorola,umts_jordan,MB525,4,-23,1
+motorola,umts_jordan,MB526,4,-23,1
+motorola,umts_begonia,MB610,4,-23,1
+motorola,umts_begonia,MB611,4,-23,1
+motorola,cdma_kronos,MB612,4,-23,1
+motorola,umts_elway,MB632,4,-23,1
+motorola,cdma_shadow,MB810,4,-23,1
+motorola,sunfire,MB855,4,-23,1
+motorola,olympus,MB860,4,-23,1
+motorola,olympus,MB861,4,-23,1
+motorola,edison,MB865,4,-23,1
+motorola,qinara,MB886,4,-23,1
+motorola,zeppelin,ME501,4,-23,1
+motorola,umts_ruth,ME511,4,-23,1
+motorola,umts_jordan,ME525,4,-23,1
+motorola,umts_jordan,ME525+,4,-23,1
+motorola,motus,ME600,4,-23,1
+motorola,umts_elway,ME632,4,-23,1
+motorola,umts_milestone2,ME722,4,-23,1
+motorola,cdma_shadow,ME811,4,-23,1
+motorola,olympus,ME860,4,-23,1
+motorola,umts_solana,ME863,4,-23,1
+motorola,edison,ME865,4,-23,1
+motorola,cdma_solana,MILESTONE3,4,-23,1
+motorola,Triumph,MOTWX435KT,4,-23,1
+motorola,TAHITI,MT620,4,-23,1
+motorola,graham_wifi,MZ505,4,-23,1
+motorola,Graham,MZ505,4,-23,1
+motorola,umts_everest,MZ601,4,-23,1
+motorola,umts_hubble,MZ601,4,-23,1
+motorola,wifi_hubble,MZ604,4,-23,1
+motorola,umts_hubble,MZ605,4,-23,1
+motorola,wifi_hubble,MZ606,4,-23,1
+motorola,fleming,MZ607,4,-23,1
+motorola,fleming,MZ608,4,-23,1
+motorola,fleming,MZ609,4,-23,1
+motorola,pasteur,MZ616,4,-23,1
+motorola,pasteur,MZ617,4,-23,1
+motorola,umts_sholes,Milestone,4,-23,1
+motorola,A853,Milestone,4,-23,1
+motorola,cdma_venus2,Milestone PLUS,4,-23,1
+motorola,cdma_shadow,Milestone X,4,-23,1
+motorola,daytona,Milestone X2,4,-23,1
+motorola,sholest,Milestone XT720,4,-23,1
+motorola,smelt,Moto 360,4,-23,1
+motorola,mola,Moto 360,4,-23,1
+motorola,minnow,Moto 360,4,-23,1
+motorola,carp,Moto 360,4,-23,1
+motorola,watson,Moto C,4,-23,1
+motorola,namath,Moto C,4,-23,1
+motorola,panell_dt,Moto C Plus,4,-23,1
+motorola,panell_s,Moto C Plus,4,-23,1
+motorola,panell_dl,Moto C Plus,4,-23,1
+motorola,panell_d,Moto C Plus,4,-23,1
+motorola,rjames_f,Moto E,3,-18,1
+motorola,rhannah,Moto E,4,-23,1
+motorola,pettyl,Moto E,1,-27,1
+motorola,nora_8917_n,Moto E,4,-23,1
+motorola,nora_8917,Moto E,4,-23,1
+motorola,ahannah,Moto E,4,-23,1
+motorola,hannah,Moto E,4,-23,1
+motorola,woods_fn,Moto E (4),4,-23,1
+motorola,perry,Moto E (4),4,-23,1
+motorola,sperry,Moto E (4),4,-23,1
+motorola,perry_f,Moto E (4),4,-23,1
+motorola,woods_f,Moto E (4),4,-23,1
+motorola,nicklaus_f,Moto E (4) Plus,4,-23,1
+motorola,owens,Moto E (4) Plus,4,-23,1
+motorola,nicklaus_fn,Moto E (4) Plus,4,-23,1
+motorola,athene,Moto G (4),4,-23,1
+motorola,sanders_nt,Moto G (4),4,-19,1
+motorola,sanders_n,Moto G (4),4,-19,1
+motorola,athene_f,Moto G (4),0,-17,3
+motorola,potter_n,Moto G (4),6,-20,1
+motorola,athene_t,Moto G (4),4,-23,1
+motorola,cedric,Moto G (5),3,-19,3
+motorola,potter_nt,Moto G (5) Plus,3,-19,1
+motorola,potter,Moto G (5) Plus,3,-19,3
+motorola,evert_n,Moto G (5) Plus,4,-23,1
+motorola,potter_n,Moto G (5) Plus,6,-20,3
+motorola,montana,Moto G (5S),4,-23,1
+motorola,montana_n,Moto G (5S),4,-23,1
+motorola,sanders_n,Moto G (5S) Plus,4,-19,1
+motorola,sanders,Moto G (5S) Plus,4,-19,3
+motorola,sanders_nt,Moto G (5S) Plus,4,-19,1
+motorola,aljeter,Moto G Play,4,-23,1
+motorola,harpia,Moto G Play,5,-23,3
+motorola,jeter,Moto G Play,3,-20,1
+motorola,aljeter_n,Moto G Play,4,-23,1
+motorola,harpia_t,Moto G Play,5,-22,1
+motorola,harpia_n,Moto G Play,4,-23,1
+motorola,lux_uds,Moto X Play,4,-23,1
+motorola,lux,Moto X Play,4,-23,1
+motorola,shamu_t,Moto X Pro,4,-23,1
+motorola,messi,Moto Z (2),4,-26,1
+motorola,nash,Moto Z (2),4,-23,1
+motorola,albus,Moto Z2 Play,3,-18,3
+motorola,beckham,Moto Z3 Play,4,-23,1
+motorola,foles,Moto Z3 Play,10,-34,1
+motorola,umts_milestone2,MotoA953,4,-23,1
+motorola,otus_ds,MotoE2,4,-23,1
+motorola,surnia_cdma,MotoE2,4,-23,1
+motorola,otus,MotoE2,4,-23,1
+motorola,surnia_uds,MotoE2(4G-LTE),4,-23,1
+motorola,surnia_cdma,MotoE2(4G-LTE),4,-23,1
+motorola,surnia_umts,MotoE2(4G-LTE),4,-23,1
+motorola,surnia_udstv,MotoE2(4G-LTE),4,-23,1
+motorola,osprey_udstv,MotoG3,5,-21,1
+motorola,osprey_ud2,MotoG3,5,-21,1
+motorola,osprey_u2,MotoG3,5,-21,1
+motorola,osprey_uds,MotoG3,5,-21,3
+motorola,osprey_umts,MotoG3,5,-21,1
+motorola,osprey_cdma,MotoG3,5,-21,1
+motorola,merlin,MotoG3,4,-23,1
+motorola,merlin,MotoG3-TE,4,-23,1
+motorola,umts_ruth,MotoMB511,4,-23,1
+motorola,cdma_shadow,MotoroiX,4,-23,1
+motorola,sunfire,Motorola Electrify,4,-23,1
+motorola,ironmaxct_cdma,Motorola MOT-XT681,4,-23,1
+motorola,cdma_spyder,Motorola RAZR MAXX,4,-23,1
+motorola,rubicon,Motorola Titanium,4,-23,1
+motorola,sholest,Motorola XT720,4,-23,1
+motorola,XT502,Motorola-XT502,4,-23,1
+motorola,Motorola_HS1,Motorola_HS1,4,-23,1
+motorola,iDEN,Motorola_i1,4,-23,1
+motorola,shamu,Nexus 6,10,-29,3
+motorola,vanquish_u,RAZR HD,4,-23,1
+motorola,rubicon,Titanium,4,-23,1
+motorola,cdma_ciena,WX442,4,-23,1
+motorola,cdma_ciena,WX445,4,-23,1
+motorola,pasteur,XOOM 2,4,-23,1
+motorola,fleming,XOOM 2 ME,4,-23,1
+motorola,otus,XT0000,4,-23,1
+motorola,falcon_umts,XT1002,4,-23,1
+motorola,falcon_umts,XT1003,4,-23,1
+motorola,falcon_umts,XT1008,4,-23,1
+motorola,condor_cdma,XT1019,4,-23,1
+motorola,lux_uds,XT1021,4,-23,1
+motorola,condor_umts,XT1021,4,-23,1
+motorola,otus_ds,XT1021,4,-23,1
+motorola,lux,XT1021,4,-23,1
+motorola,condor_umtsds,XT1022,4,-23,1
+motorola,condor_umts,XT1023,4,-23,1
+motorola,condor_udstv,XT1025,4,-23,1
+motorola,falcon_cdma,XT1028,4,-23,1
+motorola,obakem,XT1030,4,-23,1
+motorola,falcon_cdma,XT1031,4,-23,1
+motorola,falcon_umts,XT1032,4,-23,1
+motorola,falcon_umtsds,XT1033,4,-23,1
+motorola,falcon_umts,XT1034,4,-23,1
+motorola,peregrine,XT1039,4,-23,1
+motorola,peregrine,XT1040,4,-23,1
+motorola,peregrine,XT1042,4,-23,1
+motorola,peregrine,XT1045,4,-23,1
+motorola,ghost,XT1049,4,-23,1
+motorola,ghost,XT1050,4,-23,1
+motorola,ghost,XT1052,4,-23,1
+motorola,ghost,XT1053,4,-23,1
+motorola,ghost,XT1055,4,-23,1
+motorola,ghost,XT1056,4,-23,1
+motorola,ghost,XT1058,4,-23,1
+motorola,ghost,XT1060,4,-23,1
+motorola,thea_umtsds,XT1063,4,-23,1
+motorola,titan_umts,XT1063,4,-23,1
+motorola,titan_umts,XT1064,4,-23,1
+motorola,titan_umtsds,XT1068,4,-23,1
+motorola,titan_udstv,XT1069,4,-23,1
+motorola,thea,XT1072,4,-23,1
+motorola,thea_ds,XT1077,4,-23,1
+motorola,thea_umtsds,XT1078,4,-23,1
+motorola,thea_ds,XT1079,4,-23,1
+motorola,obake,XT1080,4,-23,1
+motorola,obake-maxx,XT1080,4,-23,1
+motorola,victara,XT1085,4,-23,1
+motorola,victara,XT1092,4,-23,1
+motorola,victara,XT1093,4,-23,1
+motorola,victara,XT1094,4,-23,1
+motorola,victara,XT1095,4,-23,1
+motorola,victara,XT1096,4,-23,1
+motorola,victara,XT1097,4,-23,1
+motorola,victara,XT1098,4,-23,1
+motorola,quark_umts,XT1225,4,-23,1
+motorola,quark,XT1250,4,-23,1
+motorola,quark,XT1254,4,-23,1
+motorola,surnia_cdma,XT1526,4,-23,1
+motorola,surnia_cdma,XT1528,4,-23,1
+motorola,surnia_cdma,XT1528O,4,-23,1
+motorola,lux,XT1562,4,-23,1
+motorola,lux_uds,XT1562,4,-23,1
+motorola,lux,XT1563,4,-23,1
+motorola,lux_uds,XT1563,4,-23,1
+motorola,addison,XT1563,5,-19,1
+motorola,lux,XT1564,4,-23,1
+motorola,lux,XT1565,4,-23,1
+motorola,clark_ds,XT1570,4,-23,1
+motorola,clark,XT1572,0,-30,1
+motorola,clark_ds,XT1572,4,-23,1
+motorola,clark,XT1575,0,-30,3
+motorola,kinzie_uds,XT1580,4,-23,1
+motorola,kinzie,XT1580,4,-23,1
+motorola,kinzie_uds,XT1581,4,-23,1
+motorola,kinzie,XT1585,4,-23,1
+motorola,harpia,XT1609,5,-22,3
+motorola,addison,XT1635-01,5,-19,3
+motorola,addison,XT1635-02,5,-19,1
+motorola,addison,XT1635-03,5,-19,1
+motorola,griffin,XT1650,-3,-26,3
+motorola,griffin,XT1650-05,-3,-26,1
+motorola,taidos_row,XT1700,4,-23,1
+motorola,taido_row,XT1706,8,-27,3
+motorola,albus,XT1710-02,3,-18,1
+motorola,albus,XT1710-08,3,-18,1
+motorola,albus,XT1710-11,3,-18,1
+motorola,namath,XT1754,4,-23,1
+motorola,namath,XT1755,4,-23,1
+motorola,nash,XT1789-05,4,-23,1
+motorola,payton,XT1789-05,2,-23,1
+motorola,ali_n,XT1790,4,-23,1
+motorola,montana,XT1799-1,4,-23,1
+motorola,montana_n,XT1799-2,4,-23,1
+motorola,ahannah,XT1924-9,4,-23,1
+motorola,ali,XT1925-10,4,-23,1
+motorola,messi,XT1929-15,4,-26,1
+motorola,deen,XT1941-2,4,-23,1
+motorola,chef,XT1942-1,4,-23,1
+motorola,robusta,XT1943-1,4,-23,1
+motorola,lake,XT1965-6,4,-23,1
+motorola,kane,XT1970-5,4,-23,1
+motorola,sesame,XT300,4,-23,1
+motorola,cdma_ciena,XT301,4,-23,1
+motorola,silversmart_umts,XT303,4,-23,1
+motorola,silversmart_umts,XT305,4,-23,1
+motorola,XT311,XT311,4,-23,1
+motorola,XT316,XT316,4,-23,1
+motorola,dominoq_umts,XT316,4,-23,1
+motorola,XT317,XT317,4,-23,1
+motorola,XT319,XT319,4,-23,1
+motorola,TinBoost,XT320,4,-23,1
+motorola,tinboost_umts,XT320,4,-23,1
+motorola,TinBoost,XT321,4,-23,1
+motorola,tinboost_umts,XT321,4,-23,1
+motorola,argonmini_umts,XT389,4,-23,1
+motorola,XT389,XT389,4,-23,1
+motorola,argonmini_umts,XT390,4,-23,1
+motorola,XT390,XT390,4,-23,1
+motorola,XT530,XT530,4,-23,1
+motorola,XT531,XT531,4,-23,1
+motorola,XT532,XT532,4,-23,1
+motorola,tinboostplus_umts,XT535,4,-23,1
+motorola,XT535,XT535,4,-23,1
+motorola,ArgonSpin,XT550,4,-23,1
+motorola,argonspin_umts,XT550,4,-23,1
+motorola,tinboostplus_cdma,XT555C,4,-23,1
+motorola,tinboostplus_cdma,XT556,4,-23,1
+motorola,tinboostplus_cdma,XT557,4,-23,1
+motorola,XT560,XT560,4,-23,1
+motorola,tinq_umts,XT560,4,-23,1
+motorola,cdma_pax,XT603,4,-23,1
+motorola,umts_jorian,XT605,4,-23,1
+motorola,cdma_venus2,XT610,4,-23,1
+motorola,umts_venus2,XT610,4,-23,1
+motorola,XT611,XT611,4,-23,1
+motorola,XT615,XT615,4,-23,1
+motorola,ironmax_umts,XT615,4,-23,1
+motorola,umts_primus,XT621,4,-23,1
+motorola,umts_irock,XT626,4,-23,1
+motorola,umts_irock,XT627,4,-23,1
+motorola,XT682,XT682,4,-23,1
+motorola,ironmax_umts,XT685,4,-23,1
+motorola,ironmaxtv_umts,XT687,4,-23,1
+motorola,umts_sholes,XT701,4,-23,1
+motorola,choles,XT701,4,-23,1
+motorola,umts_sholes,XT702,4,-23,1
+motorola,choi,XT711,4,-23,1
+motorola,sholest,XT720,4,-23,1
+motorola,umts_sholes,XT720,4,-23,1
+motorola,titanium,XT800,4,-23,1
+motorola,cg_tita2,XT800+,4,-23,1
+motorola,ttu_skt,XT800W,4,-23,1
+motorola,qilin,XT806,4,-23,1
+motorola,condor_cdma,XT830C,4,-23,1
+motorola,umts_solana,XT860,4,-23,1
+motorola,cdma_yangtze,XT881,4,-23,1
+motorola,swordfish,XT882,4,-23,1
+motorola,umts_yangtze,XT885,4,-23,1
+motorola,umts_yangtze,XT886,4,-23,1
+motorola,smi,XT890,4,-23,1
+motorola,asanti_c,XT897,4,-23,1
+motorola,asanti_c,XT897S,4,-23,1
+motorola,solstice,XT901,4,-23,1
+motorola,scorpion_mini_u,XT905,4,-23,1
+motorola,smq_u,XT905,4,-23,1
+motorola,scorpion_mini,XT907,4,-23,1
+motorola,smq,XT907,4,-23,1
+motorola,umts_spyder,XT910,4,-23,1
+motorola,umts_spyder,XT910K,4,-23,1
+motorola,umts_spyder,XT910S,4,-23,1
+motorola,hawk35_umts,XT914,4,-23,1
+motorola,hawk35_umts,XT915,4,-23,1
+motorola,hawk35_umts,XT916,4,-23,1
+motorola,hawk35_umts,XT918,4,-23,1
+motorola,hawk40_umts,XT919,4,-23,1
+motorola,hawk40_umts,XT920,4,-23,1
+motorola,vanquish_u,XT925,4,-23,1
+motorola,falcon_cdma,XT937C,4,-23,1
+motorola,falcon_umts,XT939G,4,-23,1
+motorola,wingray,Xoom,4,-23,1
+motorola,stingray,Xoom,4,-23,1
+motorola,calgary,calgary,4,-23,1
+motorola,destino,i867,4,-23,1
+motorola,fawnridge,i940,4,-23,1
+motorola,morrison,morrison,4,-23,1
+motorola,ginna,moto e,4,-23,1
+motorola,pokerp,moto e(6) plus,4,-23,1
+motorola,pokerp,moto e(6s),4,-23,1
+motorola,nora_8917,moto e5,4,-23,1
+motorola,nora_8917_n,moto e5,4,-23,1
+motorola,nora,moto e5 (XT1920DL),4,-23,1
+motorola,james,moto e5 cruise,4,-23,1
+motorola,rjames_go,moto e5 go,4,-23,1
+motorola,pettyl,moto e5 play,1,-27,3
+motorola,rjames_f,moto e5 play,3,-18,3
+motorola,james,moto e5 play,2,-22,1
+motorola,hannah,moto e5 plus,4,-23,1
+motorola,rhannah,moto e5 plus,4,-23,1
+motorola,ahannah,moto e5 plus,4,-23,1
+motorola,hannah,moto e5 supra,4,-23,1
+motorola,fiji,moto e6,4,-23,1
+motorola,surfna,moto e6,4,-23,1
+motorola,surfna,moto e6 (XT2005DL),4,-23,1
+motorola,bali,moto e6 play,4,-23,1
+motorola,fiji,moto e6s,4,-23,1
+motorola,rav,moto g fast,4,-23,1
+motorola,sofia,moto g power,4,-23,1
+motorola,sofia,moto g power (XT2041DL),4,-23,1
+motorola,sofiap,moto g stylus,4,-23,1
+motorola,ali_n,moto g(6),4,-23,1
+motorola,river,moto g(6),3,-18,1
+motorola,channel,moto g(6),4,-23,1
+motorola,ali,moto g(6),4,-23,1
+motorola,surfna,moto g(6),4,-23,1
+motorola,ali,moto g(6) (XT1925DL),4,-23,1
+motorola,aljeter_n,moto g(6) play,4,-23,1
+motorola,aljeter,moto g(6) play,4,-23,1
+motorola,ocean,moto g(6) play,4,-23,1
+motorola,jeter,moto g(6) play,3,-20,3
+motorola,lake_n,moto g(6) plus,4,-23,1
+motorola,evert,moto g(6) plus,4,-23,1
+motorola,evert_n,moto g(6) plus,4,-23,1
+motorola,evert_nt,moto g(6) plus,4,-23,1
+motorola,river_n,moto g(7),3,-18,1
+motorola,doha,moto g(7),4,-23,1
+motorola,river,moto g(7),3,-18,3
+motorola,channel,moto g(7) optimo (XT1952DL),4,-23,1
+motorola,ocean,moto g(7) optimo maxx(XT1955DL),4,-23,1
+motorola,lima,moto g(7) play,4,-23,1
+motorola,channel,moto g(7) play,4,-23,1
+motorola,lake_n,moto g(7) plus,4,-23,1
+motorola,ocean_n,moto g(7) power,4,-23,1
+motorola,ocean,moto g(7) power,4,-23,1
+motorola,ocean_t,moto g(7) power,4,-23,1
+motorola,ocean,moto g(7) supra,4,-23,1
+motorola,rav,moto g(8),4,-23,1
+motorola,lima,moto g(8) play,4,-23,1
+motorola,doha_n,moto g(8) plus,4,-23,1
+motorola,doha,moto g(8) plus,4,-23,1
+motorola,sofiar,moto g(8) power,4,-23,1
+motorola,blackjack,moto g(8) power lite,4,-23,1
+motorola,blackjack,moto g8 power lite,4,-23,1
+motorola,chef_sprout,moto x4,2,-22,1
+motorola,payton_sprout,moto x4,2,-23,1
+motorola,payton,moto x4,2,-23,3
+motorola,messi,moto z3,4,-26,3
+motorola,foles,moto z4,10,-34,3
+motorola,parker,moto z4,4,-23,1
+motorola,racer,motorola edge,4,-23,1
+motorola,burton,motorola edge plus,4,-23,1
+motorola,deen_sprout,motorola one,4,-21,3
+motorola,troika,motorola one action,4,-23,1
+motorola,troika_sprout,motorola one action,4,-23,1
+motorola,def,motorola one hyper,4,-23,1
+motorola,lima,motorola one macro,4,-23,1
+motorola,chef_sprout,motorola one power,2,-22,3
+motorola,kane_sprout,motorola one vision,4,-23,1
+motorola,doha_n,motorola one vision plus,4,-23,1
+motorola,parker,motorola one zoom,4,-23,1
+motorola,olson,motorola razr,4,-23,1
+motorola,titan_umtsds,titan_niibr_ds,4,-23,1
+motorola,titan_udstv,titan_retbr_dstv,4,-23,1
+motorola,umts_sholes,umts,4,-23,1
+motorola,umts_jordan,unknown,4,-23,1
+nokia,Nokia_N1,N1,5,-23,1
+nokia,NBL,Nebula,5,-23,1
+nokia,FRT,Nokia 1,2,-24,3
+nokia,ANT,Nokia 1 Plus,5,-23,1
+nokia,DRX,Nokia 1.3,5,-23,1
+nokia,E1M,Nokia 2,5,-23,1
+nokia,EVW,Nokia 2 V,5,-23,1
+nokia,E2M,Nokia 2.1,2,-29,3
+nokia,WSP_sprout,Nokia 2.2,5,-23,1
+nokia,IRM_sprout,Nokia 2.3,5,-23,1
+nokia,DPL_VZW,Nokia 3 V,5,-23,1
+nokia,ES2N_sprout,Nokia 3.1,5,-24,1
+nokia,ES2_sprout,Nokia 3.1,5,-24,3
+nokia,EAG,Nokia 3.1 A,5,-23,1
+nokia,EAG,Nokia 3.1 C,5,-23,1
+nokia,ROO,Nokia 3.1 Plus,5,-23,1
+nokia,ROON_sprout,Nokia 3.1 Plus,5,-23,1
+nokia,RHD,Nokia 3.1 Plus,5,-23,1
+nokia,ROO_sprout,Nokia 3.1 Plus,5,-23,1
+nokia,DPL_sprout,Nokia 3.2,5,-23,1
+nokia,PAN_sprout,Nokia 4.2,5,-23,1
+nokia,CO2N_sprout,Nokia 5.1,5,-23,1
+nokia,CO2_sprout,Nokia 5.1,5,-23,1
+nokia,PDA_sprout,Nokia 5.1 Plus,5,-23,1
+nokia,CAP,Nokia 5.3,5,-23,1
+nokia,CAP_sprout,Nokia 5.3,5,-23,1
+nokia,PL2_sprout,Nokia 6.1,5,-23,1
+nokia,PL2,Nokia 6.1,7,-26,1
+nokia,DRG_sprout,Nokia 6.1 Plus,6,-26,3
+nokia,SLDA_sprout,Nokia 6.2,5,-23,1
+nokia,SLD_sprout,Nokia 6.2,5,-23,1
+nokia,B2N_sprout,Nokia 7 plus,5,-23,3
+nokia,B2N,Nokia 7 plus,5,-23,1
+nokia,CTL_sprout,Nokia 7.1,6,-26,3
+nokia,DDVA_sprout,Nokia 7.2,3,-8,1
+nokia,DDV_sprout,Nokia 7.2,3,-8,3
+nokia,A1N,Nokia 8 Sirocco,10,-30,1
+nokia,A1N_sprout,Nokia 8 Sirocco,10,-30,3
+nokia,PNX_sprout,Nokia 8.1,5,-23,1
+nokia,PNXN,Nokia 8.1,5,-23,1
+nokia,AOP_sprout,Nokia 9,5,-23,1
+nokia,AOP,Nokia 9,5,-23,1
+nokia,RKU,Nokia C1,5,-23,1
+nokia,NBL,Nokia C2,5,-23,1
+nokia,PDA,Nokia X5,5,-23,1
+nokia,DRG,Nokia X6,5,-23,1
+nokia,PNX,Nokia X7,5,-23,1
+nokia,TAS,Nokia X71,5,-23,1
+nokia,D1C,TA-1000,5,-21,1
+nokia,D1C,TA-1003,5,-21,1
+nokia,NB1,TA-1004,5,-23,1
+nokia,NB1,TA-1012,5,-23,1
+nokia,NE1,TA-1020,5,-23,1
+nokia,PLE,TA-1021,2,-17,1
+nokia,ND1,TA-1024,5,-23,1
+nokia,PLE,TA-1025,2,-17,3
+nokia,ND1,TA-1027,5,-23,1
+nokia,NE1,TA-1028,5,-23,1
+nokia,NE1,TA-1032,5,-23,1
+nokia,PLE,TA-1033,2,-17,1
+nokia,NE1,TA-1038,5,-23,1
+nokia,PLE,TA-1039,2,-17,1
+nokia,C1N,TA-1041,5,-23,1
+nokia,ND1,TA-1044,5,-23,1
+nokia,NB1,TA-1052,5,-23,1
+nokia,ND1,TA-1053,5,-23,1
+nokia,PL2,TA-1054,7,-26,3
+oneplus,A0001,A0001,4,-25,1
+oneplus,OnePlus7,GM1905,4,-25,1
+oneplus,OnePlus7ProTMO,GM1915,4,-25,1
+oneplus,OnePlus7Pro,GM1917,4,-25,1
+oneplus,OnePlus7ProNR,GM1920,4,-25,1
+oneplus,OP7ProNRSpr,GM1925,4,-25,1
+oneplus,OnePlus7T,HD1905,4,-25,1
+oneplus,OnePlus7TTMO,HD1907,4,-25,1
+oneplus,OnePlus7TPro,HD1913,4,-25,1
+oneplus,OnePlus7TProNR,HD1925,4,-25,1
+oneplus,OnePlus8,IN2013,4,-25,1
+oneplus,OnePlus8TMO,IN2017,4,-25,1
+oneplus,OnePlus8VZW,IN2019,4,-25,1
+oneplus,OnePlus8Pro,IN2023,4,-25,1
+oneplus,OnePlus2,ONE A2003,4,-25,1
+oneplus,OnePlus,ONE E1003,4,-25,1
+oneplus,OnePlus3,ONEPLUS A3000,4,-25,1
+oneplus,OnePlus3T,ONEPLUS A3000,4,-25,1
+oneplus,OnePlus5,ONEPLUS A5000,6,-25,3
+oneplus,OnePlus5T,ONEPLUS A5010,3,-22,3
+oneplus,OnePlus6,ONEPLUS A6000,4,-26,3
+oneplus,OnePlus6,ONEPLUS A6003,4,-29,3
+oneplus,OnePlus6TSingle,ONEPLUS A6013,1,-21,1
+oneplus,OnePlus6T,ONEPLUS A6013,1,-21,3
+oneplus,A0001,One,4,-25,1
+oneplus,Oneplus_Dosa_IN,Oneplus_Dosa_IN,4,-25,1
+orbic,R370H,R370L,5,-26,1
+orbic,Orbic-RC506LT,RC506LT,5,-26,1
+orbic,RC555L,RC555L,5,-26,3
+razer,pearlyn,Forge,5,-25,1
+razer,cheryl,Phone,7,-26,3
+razer,cheryl_ckh,Phone,5,-25,1
+razer,aura,Phone 2,3,-24,3
+razer,linus,Phone 2,3,-24,1
+razer,bolt,Phone 2,3,-24,1
+samsung,403SC,403SC,5,-24,1
+samsung,404SC,404SC,4,-23,1
+samsung,SGH_T939,Behold II,5,-24,1
+samsung,gd1,EK-GC100,5,-24,1
+samsung,gd1can,EK-GC100,5,-24,1
+samsung,gd1wifi,EK-GC110,5,-24,1
+samsung,gd1wifiany,EK-GC110,5,-24,1
+samsung,gd1ltevzw,EK-GC120,5,-24,1
+samsung,sf2wifi,EK-GC200,5,-24,1
+samsung,u0lte,EK-GN100,5,-24,1
+samsung,u0lte,EK-GN120,5,-24,1
+samsung,u0lte,EK-GN120A,5,-24,1
+samsung,u0lteue,EK-GN120A,5,-24,1
+samsung,gd1ktt,EK-KC100K,5,-24,1
+samsung,gd1skt,EK-KC100S,5,-24,1
+samsung,gd1ltektt,EK-KC120K,5,-24,1
+samsung,gd1ltelgt,EK-KC120L,5,-24,1
+samsung,gd1lteskt,EK-KC120S,5,-24,1
+samsung,zanin,GT-B5330,5,-24,1
+samsung,zanin,GT-B5330B,5,-24,1
+samsung,zanin,GT-B5330L,5,-24,1
+samsung,GT-B5510,GT-B5510,5,-24,1
+samsung,GT-B5510B,GT-B5510B,5,-24,1
+samsung,GT-B5510L,GT-B5510L,5,-24,1
+samsung,GT-B5512,GT-B5512,5,-24,1
+samsung,GT-B5512B,GT-B5512B,5,-24,1
+samsung,GT-B7510,GT-B7510,5,-24,1
+samsung,GT-B7510B,GT-B7510B,5,-24,1
+samsung,GT-B7510L,GT-B7510L,5,-24,1
+samsung,lucas,GT-B7810,5,-24,1
+samsung,GT-B9062,GT-B9062,5,-24,1
+samsung,GT-B9120,GT-B9120,5,-24,1
+samsung,spcwifiany,GT-B9150,5,-24,1
+samsung,spcwifi,GT-B9150,5,-24,1
+samsung,ironcmcc,GT-B9388,5,-24,1
+samsung,GT-I5500,GT-I5500,5,-24,1
+samsung,GT-I5500B,GT-I5500B,5,-24,1
+samsung,GT-I5500L,GT-I5500L,5,-24,1
+samsung,GT-I5500M,GT-I5500M,5,-24,1
+samsung,GT-I5503,GT-I5503,5,-24,1
+samsung,GT-I5503T,GT-I5503T,5,-24,1
+samsung,GT-I5508,GT-I5508,5,-24,1
+samsung,GT-I5510,GT-I5510,5,-24,1
+samsung,GT-I5510L,GT-I5510L,5,-24,1
+samsung,GT-I5510M,GT-I5510M,5,-24,1
+samsung,GT-I5510T,GT-I5510T,5,-24,1
+samsung,spica,GT-I5700,5,-24,1
+samsung,GT-I5700,GT-I5700,5,-24,1
+samsung,GT-I5700,GT-I5700L,5,-24,1
+samsung,spica,GT-I5700L,5,-24,1
+samsung,GT-I5700L,GT-I5700L,5,-24,1
+samsung,spica,GT-I5700R,5,-24,1
+samsung,GT-I5700,GT-I5700R,5,-24,1
+samsung,GT-I5800,GT-I5800,5,-24,1
+samsung,GT-I5800D,GT-I5800D,5,-24,1
+samsung,GT-I5800L,GT-I5800L,5,-24,1
+samsung,GT-I5800,GT-I5800L,5,-24,1
+samsung,GT-I5801,GT-I5801,5,-24,1
+samsung,GT-I8150,GT-I8150,5,-24,1
+samsung,GT-I8150B,GT-I8150B,5,-24,1
+samsung,GT-I8150T,GT-I8150T,5,-24,1
+samsung,GT-I8160,GT-I8160,5,-24,1
+samsung,GT-I8160L,GT-I8160L,5,-24,1
+samsung,GT-I8160P,GT-I8160P,5,-24,1
+samsung,golden,GT-I8190,5,-24,1
+samsung,golden,GT-I8190L,5,-24,1
+samsung,golden,GT-I8190N,5,-24,1
+samsung,golden,GT-I8190T,5,-24,1
+samsung,goldenvess3g,GT-I8200,5,-24,1
+samsung,goldenve3g,GT-I8200L,5,-24,1
+samsung,goldenve3g,GT-I8200N,5,-24,1
+samsung,goldenvess3g,GT-I8200Q,5,-24,1
+samsung,GT-I8250,GT-I8250,5,-24,1
+samsung,vastoicmcc,GT-I8258,5,-24,1
+samsung,arubaslimss,GT-I8260,5,-24,1
+samsung,arubaslimss,GT-I8260E,5,-24,1
+samsung,arubaslimss,GT-I8260L,5,-24,1
+samsung,arubaslim,GT-I8262,5,-24,1
+samsung,arubaslim,GT-I8262B,5,-24,1
+samsung,aruba3gchn,GT-I8262D,5,-24,1
+samsung,aruba3gcmcc,GT-I8268,5,-24,1
+samsung,GT-I8530,GT-I8530,5,-24,1
+samsung,delos3gss,GT-I8550E,5,-24,1
+samsung,delos3gss,GT-I8550L,5,-24,1
+samsung,delos3geur,GT-I8552,5,-24,1
+samsung,delos3gchn,GT-I8552,5,-24,1
+samsung,delos3geur,GT-I8552B,5,-24,1
+samsung,delos3gcmcc,GT-I8558,5,-24,1
+samsung,cane3g,GT-I8580,5,-24,1
+samsung,expresslte,GT-I8730,5,-24,1
+samsung,expresslte,GT-I8730T,5,-24,1
+samsung,GT-I9000,GT-I9000,5,-24,1
+samsung,GT-I9000B,GT-I9000B,5,-24,1
+samsung,GT-I9000M,GT-I9000M,5,-24,1
+samsung,GT-I9000T,GT-I9000T,5,-24,1
+samsung,GT-I9001,GT-I9001,5,-24,1
+samsung,GT-I9003,GT-I9003,5,-24,1
+samsung,GT-I9003L,GT-I9003L,5,-24,1
+samsung,GT-I9008L,GT-I9008L,5,-24,1
+samsung,GT-I9010,GT-I9010,5,-24,1
+samsung,GT-I9018,GT-I9018,5,-24,1
+samsung,GT-I9050,GT-I9050,5,-24,1
+samsung,baffinlite,GT-I9060,5,-24,1
+samsung,grandneove3g,GT-I9060C,5,-24,1
+samsung,grandneove3g,GT-I9060I,5,-24,1
+samsung,baffinlite,GT-I9060L,5,-24,1
+samsung,grandneove3g,GT-I9060M,5,-24,1
+samsung,baffinlitedtv,GT-I9063T,5,-24,1
+samsung,GT-I9070,GT-I9070,5,-24,1
+samsung,GT-I9070P,GT-I9070P,5,-24,1
+samsung,baffinss,GT-I9080E,5,-24,1
+samsung,baffinss,GT-I9080L,5,-24,1
+samsung,baffin,GT-I9082,5,-24,1
+samsung,baffinlite,GT-I9082C,5,-24,1
+samsung,baffin,GT-I9082L,5,-24,1
+samsung,baffin,GT-I9082i,5,-24,1
+samsung,GT-I9100,GT-I9100,5,-24,1
+samsung,GT-I9100G,GT-I9100G,5,-24,1
+samsung,GT-I9100M,GT-I9100M,5,-24,1
+samsung,GT-I9100P,GT-I9100P,5,-24,1
+samsung,GT-I9100T,GT-I9100T,5,-24,1
+samsung,GT-I9103,GT-I9103,5,-24,1
+samsung,s2ve,GT-I9105,5,-24,1
+samsung,s2vep,GT-I9105P,5,-24,1
+samsung,GT-I9108,GT-I9108,5,-24,1
+samsung,t1cmcc,GT-I9108,5,-24,1
+samsung,baffinrd,GT-I9118,5,-24,1
+samsung,baffincmcc,GT-I9128,5,-24,1
+samsung,baffinvetd3g,GT-I9128E,5,-24,1
+samsung,baffinvetd3g,GT-I9128I,5,-24,1
+samsung,baffincmcc,GT-I9128V,5,-24,1
+samsung,craterss,GT-I9150,5,-24,1
+samsung,crater,GT-I9152,5,-24,1
+samsung,craterq3g,GT-I9152P,5,-24,1
+samsung,cratertd3g,GT-I9158,5,-24,1
+samsung,craterq3g,GT-I9158P,5,-24,1
+samsung,megapluslte,GT-I9158V,5,-24,1
+samsung,baffinq3g,GT-I9168,5,-24,1
+samsung,baffinq3g,GT-I9168I,5,-24,1
+samsung,serrano3g,GT-I9190,5,-24,1
+samsung,serranods,GT-I9192,5,-24,1
+samsung,serranove3g,GT-I9192I,5,-24,1
+samsung,serranolte,GT-I9195,5,-24,1
+samsung,serranovelte,GT-I9195I,5,-24,1
+samsung,serranolte,GT-I9195L,5,-24,1
+samsung,serranolte,GT-I9195T,5,-24,1
+samsung,serranolte,GT-I9195X,5,-24,1
+samsung,serranolte,GT-I9197,5,-24,1
+samsung,melius3g,GT-I9200,5,-24,1
+samsung,meliuslte,GT-I9205,5,-24,1
+samsung,melius3g,GT-I9208,5,-24,1
+samsung,GT-I9210,GT-I9210,5,-24,1
+samsung,GT-I9210T,GT-I9210T,5,-24,1
+samsung,GT-I9220,GT-I9220,5,-24,1
+samsung,GT-I9228,GT-I9228,5,-24,1
+samsung,ks02lte,GT-I9230,5,-24,1
+samsung,ks02lte,GT-I9235,5,-24,1
+samsung,superior,GT-I9260,5,-24,1
+samsung,superiorchn,GT-I9260,5,-24,1
+samsung,superiorcmcc,GT-I9268,5,-24,1
+samsung,jactivelte,GT-I9295,5,-24,1
+samsung,m0,GT-I9300,5,-24,1
+samsung,m0chn,GT-I9300,5,-24,1
+samsung,s3ve3gdsdd,GT-I9300I,5,-24,1
+samsung,s3ve3gds,GT-I9300I,5,-24,1
+samsung,s3ve3g,GT-I9300I,5,-24,1
+samsung,s3ve3gdd,GT-I9300I,5,-24,1
+samsung,m0,GT-I9300T,5,-24,1
+samsung,s3ve3g,GT-I9301I,5,-24,1
+samsung,s3ve3g,GT-I9301Q,5,-24,1
+samsung,m3,GT-I9305,5,-24,1
+samsung,m3,GT-I9305N,5,-24,1
+samsung,m3,GT-I9305T,5,-24,1
+samsung,m0cmcc,GT-I9308,5,-24,1
+samsung,s3ve3g,GT-I9308I,5,-24,1
+samsung,ja3g,GT-I9500,5,-24,1
+samsung,ja3gchnduos,GT-I9502,5,-24,1
+samsung,jflte,GT-I9505,5,-24,1
+samsung,jgedlte,GT-I9505G,5,-24,1
+samsung,jfwifi,GT-I9505X,5,-24,1
+samsung,ks01lte,GT-I9506,5,-24,1
+samsung,jftdd,GT-I9507,5,-24,1
+samsung,jftdd,GT-I9507V,5,-24,1
+samsung,jflte,GT-I9508,5,-24,1
+samsung,jflte,GT-I9508C,5,-24,1
+samsung,jsglte,GT-I9508V,5,-24,1
+samsung,jfvelte,GT-I9515,5,-24,1
+samsung,jfvelte,GT-I9515L,5,-24,1
+samsung,kona3g,GT-N5100,5,-24,1
+samsung,kona3g,GT-N5105,5,-24,1
+samsung,konawifi,GT-N5110,5,-24,1
+samsung,konalte,GT-N5120,5,-24,1
+samsung,GT-N7000,GT-N7000,5,-24,1
+samsung,GT-N7000B,GT-N7000B,5,-24,1
+samsung,GT-N7005,GT-N7005,5,-24,1
+samsung,t03gchn,GT-N7100,5,-24,1
+samsung,t03g,GT-N7100,5,-24,1
+samsung,t03g,GT-N7100T,5,-24,1
+samsung,t03gchnduos,GT-N7102,5,-24,1
+samsung,t03gcuduos,GT-N7102,5,-24,1
+samsung,t03gcuduos,GT-N7102i,5,-24,1
+samsung,t03gchnduos,GT-N7102i,5,-24,1
+samsung,t0lte,GT-N7105,5,-24,1
+samsung,t0lte,GT-N7105T,5,-24,1
+samsung,t03gcmcc,GT-N7108,5,-24,1
+samsung,t0ltecmcc,GT-N7108D,5,-24,1
+samsung,p4noterf,GT-N8000,5,-24,1
+samsung,p4noterf,GT-N8005,5,-24,1
+samsung,p4notewifiww,GT-N8010,5,-24,1
+samsung,p4notewifi,GT-N8013,5,-24,1
+samsung,p4notelte,GT-N8020,5,-24,1
+samsung,GT-P1000,GT-P1000,5,-24,1
+samsung,GT-P1000L,GT-P1000L,5,-24,1
+samsung,GT-P1000M,GT-P1000M,5,-24,1
+samsung,GT-P1000N,GT-P1000N,5,-24,1
+samsung,GT-P1000R,GT-P1000R,5,-24,1
+samsung,GT-P1000T,GT-P1000T,5,-24,1
+samsung,GT-P1010,GT-P1010,5,-24,1
+samsung,GT-P1013,GT-P1013,5,-24,1
+samsung,espressorf,GT-P3100,5,-24,1
+samsung,espressorf,GT-P3100B,5,-24,1
+samsung,espressorf,GT-P3105,5,-24,1
+samsung,espressorfcmcc,GT-P3108,5,-24,1
+samsung,espressowifi,GT-P3110,5,-24,1
+samsung,espressowifi,GT-P3113,5,-24,1
+samsung,espresso10rf,GT-P5100,5,-24,1
+samsung,espresso10wifi,GT-P5110,5,-24,1
+samsung,espresso10wifi,GT-P5113,5,-24,1
+samsung,santos103g,GT-P5200,5,-24,1
+samsung,santos10wifi,GT-P5210,5,-24,1
+samsung,santos10wifi,GT-P5210XD1,5,-24,1
+samsung,santos10lte,GT-P5220,5,-24,1
+samsung,GT-P6200,GT-P6200,5,-24,1
+samsung,GT-P6200L,GT-P6200L,5,-24,1
+samsung,GT-P6201,GT-P6201,5,-24,1
+samsung,GT-P6210,GT-P6210,5,-24,1
+samsung,GT-P6211,GT-P6211,5,-24,1
+samsung,GT-P6800,GT-P6800,5,-24,1
+samsung,GT-P6810,GT-P6810,5,-24,1
+samsung,p3,GT-P7100,5,-24,1
+samsung,GT-P7300,GT-P7300,5,-24,1
+samsung,GT-P7300B,GT-P7300B,5,-24,1
+samsung,GT-P7310,GT-P7310,5,-24,1
+samsung,GT-P7320,GT-P7320,5,-24,1
+samsung,GT-P7320T,GT-P7320T,5,-24,1
+samsung,GT-P7500,GT-P7500,5,-24,1
+samsung,GT-P7500D,GT-P7500D,5,-24,1
+samsung,GT-P7500M,GT-P7500M,5,-24,1
+samsung,GT-P7500R,GT-P7500R,5,-24,1
+samsung,GT-P7500V,GT-P7500V,5,-24,1
+samsung,GT-P7501,GT-P7501,5,-24,1
+samsung,GT-P7503,GT-P7503,5,-24,1
+samsung,GT-P7510,GT-P7510,5,-24,1
+samsung,GT-P7511,GT-P7511,5,-24,1
+samsung,mintss,GT-S5280,5,-24,1
+samsung,mint,GT-S5282,5,-24,1
+samsung,mintts,GT-S5283B,5,-24,1
+samsung,GT-S5300,GT-S5300,5,-24,1
+samsung,GT-S5300B,GT-S5300B,5,-24,1
+samsung,GT-S5300L,GT-S5300L,5,-24,1
+samsung,coriplus,GT-S5301,5,-24,1
+samsung,coriplus,GT-S5301B,5,-24,1
+samsung,coriplus,GT-S5301L,5,-24,1
+samsung,GT-S5302,GT-S5302,5,-24,1
+samsung,GT-S5302B,GT-S5302B,5,-24,1
+samsung,coriplusds,GT-S5303,5,-24,1
+samsung,coriplusds,GT-S5303B,5,-24,1
+samsung,corsicass,GT-S5310,5,-24,1
+samsung,corsicass,GT-S5310B,5,-24,1
+samsung,corsicave3g,GT-S5310C,5,-24,1
+samsung,corsicass,GT-S5310E,5,-24,1
+samsung,corsicass,GT-S5310G,5,-24,1
+samsung,corsicave3g,GT-S5310I,5,-24,1
+samsung,corsicass,GT-S5310L,5,-24,1
+samsung,corsicave3g,GT-S5310M,5,-24,1
+samsung,corsicave3g,GT-S5310N,5,-24,1
+samsung,corsicass,GT-S5310T,5,-24,1
+samsung,corsica,GT-S5312,5,-24,1
+samsung,corsica,GT-S5312B,5,-24,1
+samsung,corsicaveds3gvj,GT-S5312C,5,-24,1
+samsung,corsica,GT-S5312L,5,-24,1
+samsung,corsicaveds3gvj,GT-S5312M,5,-24,1
+samsung,GT-S5360,GT-S5360,5,-24,1
+samsung,GT-S5360B,GT-S5360B,5,-24,1
+samsung,GT-S5360L,GT-S5360L,5,-24,1
+samsung,GT-S5360T,GT-S5360T,5,-24,1
+samsung,GT-S5363,GT-S5363,5,-24,1
+samsung,GT-S5367,GT-S5367,5,-24,1
+samsung,GT-S5368,GT-S5368,5,-24,1
+samsung,GT-S5369,GT-S5369,5,-24,1
+samsung,GT-S5570,GT-S5570,5,-24,1
+samsung,GT-S5570B,GT-S5570B,5,-24,1
+samsung,GT-S5570I,GT-S5570I,5,-24,1
+samsung,GT-S5570L,GT-S5570L,5,-24,1
+samsung,GT-S5578,GT-S5578,5,-24,1
+samsung,GT-S5660,GT-S5660,5,-24,1
+samsung,GT-S5660B,GT-S5660B,5,-24,1
+samsung,GT-S5660L,GT-S5660L,5,-24,1
+samsung,GT-S5660M,GT-S5660M,5,-24,1
+samsung,GT-S5660V,GT-S5660V,5,-24,1
+samsung,GT-S5670,GT-S5670,5,-24,1
+samsung,GT-S5670B,GT-S5670B,5,-24,1
+samsung,GT-S5670L,GT-S5670L,5,-24,1
+samsung,GT-S5690,GT-S5690,5,-24,1
+samsung,GT-S5690L,GT-S5690L,5,-24,1
+samsung,GT-S5690M,GT-S5690M,5,-24,1
+samsung,GT-S5690R,GT-S5690R,5,-24,1
+samsung,GT-S5698,GT-S5698,5,-24,1
+samsung,GT-S5820,GT-S5820,5,-24,1
+samsung,GT-S5830,GT-S5830,5,-24,1
+samsung,GT-S5830B,GT-S5830B,5,-24,1
+samsung,GT-S5830C,GT-S5830C,5,-24,1
+samsung,GT-S5830D,GT-S5830D,5,-24,1
+samsung,GT-S5830F,GT-S5830F,5,-24,1
+samsung,GT-S5830G,GT-S5830G,5,-24,1
+samsung,GT-S5830L,GT-S5830L,5,-24,1
+samsung,GT-S5830M,GT-S5830M,5,-24,1
+samsung,GT-S5830T,GT-S5830T,5,-24,1
+samsung,GT-S5830V,GT-S5830V,5,-24,1
+samsung,GT-S5830i,GT-S5830i,5,-24,1
+samsung,GT-S5831i,GT-S5831i,5,-24,1
+samsung,GT-S5838,GT-S5838,5,-24,1
+samsung,GT-S5839i,GT-S5839i,5,-24,1
+samsung,ivoryss,GT-S6010,5,-24,1
+samsung,ivoryss,GT-S6010L,5,-24,1
+samsung,ivory,GT-S6012,5,-24,1
+samsung,ivory,GT-S6012B,5,-24,1
+samsung,GT-S6102,GT-S6102,5,-24,1
+samsung,GT-S6102B,GT-S6102B,5,-24,1
+samsung,GT-S6102E,GT-S6102E,5,-24,1
+samsung,GT-S6108,GT-S6108,5,-24,1
+samsung,royvedtv,GT-S6293T,5,-24,1
+samsung,royssvedtv,GT-S6293T,5,-24,1
+samsung,royss,GT-S6310,5,-24,1
+samsung,royss,GT-S6310B,5,-24,1
+samsung,royss,GT-S6310L,5,-24,1
+samsung,royssnfc,GT-S6310N,5,-24,1
+samsung,royss,GT-S6310T,5,-24,1
+samsung,roy,GT-S6312,5,-24,1
+samsung,royssdtv,GT-S6313T,5,-24,1
+samsung,roydtv,GT-S6313T,5,-24,1
+samsung,GT-S6352,GT-S6352,5,-24,1
+samsung,GT-S6358,GT-S6358,5,-24,1
+samsung,GT-S6500,GT-S6500,5,-24,1
+samsung,GT-S6500D,GT-S6500D,5,-24,1
+samsung,GT-S6500L,GT-S6500L,5,-24,1
+samsung,GT-S6500T,GT-S6500T,5,-24,1
+samsung,nevisvess,GT-S6790,5,-24,1
+samsung,nevisvess,GT-S6790E,5,-24,1
+samsung,nevisvess,GT-S6790L,5,-24,1
+samsung,nevisnvess,GT-S6790N,5,-24,1
+samsung,nevisw,GT-S6792L,5,-24,1
+samsung,GT-S6800,GT-S6800,5,-24,1
+samsung,GT-S6802,GT-S6802,5,-24,1
+samsung,GT-S6802B,GT-S6802B,5,-24,1
+samsung,nevis,GT-S6810,5,-24,1
+samsung,nevis,GT-S6810B,5,-24,1
+samsung,nevis,GT-S6810E,5,-24,1
+samsung,nevis,GT-S6810L,5,-24,1
+samsung,nevisp,GT-S6810M,5,-24,1
+samsung,nevisp,GT-S6810P,5,-24,1
+samsung,nevisds,GT-S6812,5,-24,1
+samsung,nevisds,GT-S6812B,5,-24,1
+samsung,nevisw,GT-S6812C,5,-24,1
+samsung,nevis3g,GT-S6812i,5,-24,1
+samsung,nevis3gcmcc,GT-S6818,5,-24,1
+samsung,nevis3gcmcc,GT-S6818V,5,-24,1
+samsung,logan2g,GT-S7262,5,-24,1
+samsung,logan,GT-S7270,5,-24,1
+samsung,logan,GT-S7270L,5,-24,1
+samsung,logands,GT-S7272,5,-24,1
+samsung,loganlite3g,GT-S7272C,5,-24,1
+samsung,logandsdtv,GT-S7273T,5,-24,1
+samsung,loganlte,GT-S7275,5,-24,1
+samsung,loganrelte,GT-S7275B,5,-24,1
+samsung,loganrelte,GT-S7275R,5,-24,1
+samsung,loganrelte,GT-S7275T,5,-24,1
+samsung,loganrelte,GT-S7275Y,5,-24,1
+samsung,logan3gcmcc,GT-S7278,5,-24,1
+samsung,loganu3gcmcc,GT-S7278U,5,-24,1
+samsung,kylevess,GT-S7390,5,-24,1
+samsung,kyleve,GT-S7390,5,-24,1
+samsung,kylevess,GT-S7390E,5,-24,1
+samsung,kylevess,GT-S7390G,5,-24,1
+samsung,kylevess,GT-S7390L,5,-24,1
+samsung,kyleve,GT-S7392,5,-24,1
+samsung,kyleve,GT-S7392L,5,-24,1
+samsung,GT-S7500,GT-S7500,5,-24,1
+samsung,GT-S7500L,GT-S7500L,5,-24,1
+samsung,GT-S7500T,GT-S7500T,5,-24,1
+samsung,GT-S7500W,GT-S7500W,5,-24,1
+samsung,GT-S7508,GT-S7508,5,-24,1
+samsung,kylessopen,GT-S7560,5,-24,1
+samsung,kylessopen,GT-S7560M,5,-24,1
+samsung,kylechn,GT-S7562,5,-24,1
+samsung,kyleopen,GT-S7562,5,-24,1
+samsung,kyleve,GT-S7562C,5,-24,1
+samsung,kyleopen,GT-S7562L,5,-24,1
+samsung,kyleichn,GT-S7562i,5,-24,1
+samsung,kyleichn,GT-S7566,5,-24,1
+samsung,kyletdcmcc,GT-S7568,5,-24,1
+samsung,kyleve3gcmcc,GT-S7568I,5,-24,1
+samsung,kylepluschn,GT-S7572,5,-24,1
+samsung,kylepro,GT-S7580,5,-24,1
+samsung,kylepro,GT-S7580E,5,-24,1
+samsung,kylepro,GT-S7580L,5,-24,1
+samsung,kyleprods,GT-S7582,5,-24,1
+samsung,kyleprods,GT-S7582L,5,-24,1
+samsung,kylepro,GT-S7583T,5,-24,1
+samsung,skomer,GT-S7710,5,-24,1
+samsung,skomer,GT-S7710L,5,-24,1
+samsung,garda3gcmcc,GT-S7898,5,-24,1
+samsung,gardave3gcmcc,GT-S7898I,5,-24,1
+samsung,spica,GT-i5700,5,-24,1
+samsung,toro,Galaxy Nexus,5,-24,1
+samsung,toroplus,Galaxy Nexus,5,-24,1
+samsung,maguro,Galaxy Nexus,5,-24,1
+samsung,maguro,Galaxy X,5,-24,1
+samsung,sprat,Gear Live,5,-24,1
+samsung,d2dcm,Gravity,5,-24,1
+samsung,m3dcm,GravityQuad,5,-24,1
+samsung,ISW11SC,ISW11SC,5,-24,1
+samsung,manta,Nexus 10,5,-24,1
+samsung,crespo,Nexus S,5,-24,1
+samsung,crespo4g,Nexus S 4G,5,-24,1
+samsung,gd1att,SAMSUNG-EK-GC100,5,-24,1
+samsung,serranovolteatt,SAMSUNG-SGH-I257,5,-24,1
+samsung,t0lteatt,SAMSUNG-SGH-I317,5,-24,1
+samsung,jflteatt,SAMSUNG-SGH-I337,5,-24,1
+samsung,jflteaio,SAMSUNG-SGH-I337Z,5,-24,1
+samsung,kyleatt,SAMSUNG-SGH-I407,5,-24,1
+samsung,expressatt,SAMSUNG-SGH-I437,5,-24,1
+samsung,expressatt,SAMSUNG-SGH-I437P,5,-24,1
+samsung,expressziglteatt,SAMSUNG-SGH-I437Z,5,-24,1
+samsung,konalteatt,SAMSUNG-SGH-I467,5,-24,1
+samsung,espresso10att,SAMSUNG-SGH-I497,5,-24,1
+samsung,meliuslteatt,SAMSUNG-SGH-I527,5,-24,1
+samsung,jactivelteatt,SAMSUNG-SGH-I537,5,-24,1
+samsung,comancheatt,SAMSUNG-SGH-I547,5,-24,1
+samsung,SGH-I577,SAMSUNG-SGH-I577,5,-24,1
+samsung,SGH-I717,SAMSUNG-SGH-I717,5,-24,1
+samsung,SGH-I727,SAMSUNG-SGH-I727,5,-24,1
+samsung,d2att,SAMSUNG-SGH-I747,5,-24,1
+samsung,d2aio,SAMSUNG-SGH-I747Z,5,-24,1
+samsung,SGH-I777,SAMSUNG-SGH-I777,5,-24,1
+samsung,SGH-I827,SAMSUNG-SGH-I827,5,-24,1
+samsung,SGH-I847,SAMSUNG-SGH-I847,5,-24,1
+samsung,SGH-I857,SAMSUNG-SGH-I857,5,-24,1
+samsung,SGH-I896,SAMSUNG-SGH-I896,5,-24,1
+samsung,SGH-I897,SAMSUNG-SGH-I897,5,-24,1
+samsung,SGH-I927,SAMSUNG-SGH-I927,5,-24,1
+samsung,SGH-I927R,SAMSUNG-SGH-I927R,5,-24,1
+samsung,SGH-I957,SAMSUNG-SGH-I957,5,-24,1
+samsung,SGH-I957D,SAMSUNG-SGH-I957D,5,-24,1
+samsung,SGH-I957M,SAMSUNG-SGH-I957M,5,-24,1
+samsung,SGH-I957R,SAMSUNG-SGH-I957R,5,-24,1
+samsung,SGH-I997,SAMSUNG-SGH-I997,5,-24,1
+samsung,SGH-I997R,SAMSUNG-SGH-I997R,5,-24,1
+samsung,mprojectlteatt,SAMSUNG-SM-C105A,5,-24,1
+samsung,coreprimelteaio,SAMSUNG-SM-G360AZ,5,-24,1
+samsung,grandprimelteatt,SAMSUNG-SM-G530A,5,-24,1
+samsung,grandprimelteaio,SAMSUNG-SM-G530AZ,5,-24,1
+samsung,goldenlteatt,SAMSUNG-SM-G730A,5,-24,1
+samsung,mega2lteatt,SAMSUNG-SM-G750A,5,-24,1
+samsung,kminilteatt,SAMSUNG-SM-G800A,5,-24,1
+samsung,slteatt,SAMSUNG-SM-G850A,17,-33,1
+samsung,klteattactive,SAMSUNG-SM-G870A,5,-24,1
+samsung,marinelteatt,SAMSUNG-SM-G890A,5,-24,1
+samsung,poseidonlteatt,SAMSUNG-SM-G891A,4,-27,3
+samsung,klteatt,SAMSUNG-SM-G900A,9,-23,3
+samsung,klteaio,SAMSUNG-SM-G900AZ,11,-23,1
+samsung,zeroflteatt,SAMSUNG-SM-G920A,8,-24,1
+samsung,zeroflteaio,SAMSUNG-SM-G920AZ,8,-24,1
+samsung,zerolteatt,SAMSUNG-SM-G925A,4,-23,1
+samsung,zenlteatt,SAMSUNG-SM-G928A,5,-24,1
+samsung,heroqlteatt,SAMSUNG-SM-G930A,10,-33,1
+samsung,heroqlteaio,SAMSUNG-SM-G930AZ,11,-33,3
+samsung,hero2qlteatt,SAMSUNG-SM-G935A,10,-33,3
+samsung,j1xlteatt,SAMSUNG-SM-J120A,6,-22,1
+samsung,j1xlteaio,SAMSUNG-SM-J120AZ,6,-22,1
+samsung,j3xlteatt,SAMSUNG-SM-J320A,1,-17,1
+samsung,j3xlteaio,SAMSUNG-SM-J320AZ,1,-17,1
+samsung,j3xlteaio,SAMSUNG-SM-J321AZ,1,-17,1
+samsung,j3popelteaio,SAMSUNG-SM-J326AZ,5,-24,1
+samsung,j3popelteatt,SAMSUNG-SM-J327A,5,-24,1
+samsung,j3popelteaio,SAMSUNG-SM-J327AZ,5,-24,1
+samsung,j7popelteatt,SAMSUNG-SM-J727A,4,-18,1
+samsung,j7popelteaio,SAMSUNG-SM-J727AZ,4,-18,1
+samsung,hlteatt,SAMSUNG-SM-N900A,5,-24,1
+samsung,trlteatt,SAMSUNG-SM-N910A,11,-31,1
+samsung,tblteatt,SAMSUNG-SM-N915A,7,-24,1
+samsung,noblelteatt,SAMSUNG-SM-N920A,5,-29,1
+samsung,graceqlteatt,SAMSUNG-SM-N930A,5,-24,1
+samsung,viennalteatt,SAMSUNG-SM-P907A,5,-24,1
+samsung,lt02lteatt,SAMSUNG-SM-T217A,5,-24,1
+samsung,milletlteatt,SAMSUNG-SM-T337A,5,-24,1
+samsung,gteslteatt,SAMSUNG-SM-T377A,5,-24,1
+samsung,matisselteatt,SAMSUNG-SM-T537A,5,-24,1
+samsung,gvlteatt,SAMSUNG-SM-T677A,5,-24,1
+samsung,klimtlteatt,SAMSUNG-SM-T707A,5,-24,1
+samsung,chagalllteatt,SAMSUNG-SM-T807A,5,-24,1
+samsung,gts210lteatt,SAMSUNG-SM-T817A,5,-24,1
+samsung,gts210velteatt,SAMSUNG-SM-T818A,5,-24,1
+samsung,SC-01C,SC-01C,5,-24,1
+samsung,SC-01D,SC-01D,5,-24,1
+samsung,SC-01E,SC-01E,5,-24,1
+samsung,SC-01F,SC-01F,5,-24,1
+samsung,SC-01G,SC-01G,7,-24,1
+samsung,SC-01H,SC-01H,5,-24,1
+samsung,SC-01J,SC-01J,5,-24,1
+samsung,SC-01K,SC-01K,8,-25,1
+samsung,SC-01L,SC-01L,7,-26,1
+samsung,SC-01M,SC-01M,5,-24,1
+samsung,SC-02B,SC-02B,5,-24,1
+samsung,SC-02C,SC-02C,5,-24,1
+samsung,SC-02D,SC-02D,5,-24,1
+samsung,t0ltedcm,SC-02E,5,-24,1
+samsung,SC-02E,SC-02E,5,-24,1
+samsung,SC-02F,SC-02F,5,-24,1
+samsung,SC-02G,SC-02G,5,-24,1
+samsung,SC-02H,SC-02H,9,-31,1
+samsung,SC-02J,SC-02J,11,-31,3
+samsung,SC-02K,SC-02K,11,-29,3
+samsung,SC-02L,SC-02L,5,-23,3
+samsung,SC-02M,SC-02M,5,-24,1
+samsung,SC-03D,SC-03D,5,-24,1
+samsung,m3dcm,SC-03E,5,-24,1
+samsung,SC-03E,SC-03E,5,-24,1
+samsung,SC-03G,SC-03G,5,-24,1
+samsung,SC-03J,SC-03J,9,-25,1
+samsung,SC-03K,SC-03K,15,-34,3
+samsung,SC-03L,SC-03L,5,-24,1
+samsung,SC-04E,SC-04E,5,-24,1
+samsung,SC-04F,SC-04F,11,-23,1
+samsung,SC-04G,SC-04G,4,-23,1
+samsung,SC-04J,SC-04J,5,-24,1
+samsung,SC-04L,SC-04L,1,-26,1
+samsung,SC-05D,SC-05D,5,-24,1
+samsung,SC-05G,SC-05G,8,-24,1
+samsung,SC-05L,SC-05L,5,-24,1
+samsung,d2dcm,SC-06D,5,-24,1
+samsung,SC-51A,SC-51A,5,-24,1
+samsung,SC-52A,SC-52A,5,-24,1
+samsung,SCG01,SCG01,5,-24,1
+samsung,SCG02,SCG02,5,-24,1
+samsung,SCH-I100,SCH-I100,5,-24,1
+samsung,SCH-I110,SCH-I110,5,-24,1
+samsung,jaspervzw,SCH-I200,5,-24,1
+samsung,jaspervzw,SCH-I200PP,5,-24,1
+samsung,SCH-I339,SCH-I339,5,-24,1
+samsung,SCH-I400,SCH-I400,5,-24,1
+samsung,SCH-I405,SCH-I405,5,-24,1
+samsung,SCH-I405U,SCH-I405U,5,-24,1
+samsung,aegis2vzw,SCH-I415,5,-24,1
+samsung,godivaltevzw,SCH-I425,5,-24,1
+samsung,serranoltevzw,SCH-I435,5,-24,1
+samsung,serranoltelra,SCH-I435L,5,-24,1
+samsung,SCH-I500,SCH-I500,5,-24,1
+samsung,SCH-I509,SCH-I509,5,-24,1
+samsung,SCH-I509U,SCH-I509U,5,-24,1
+samsung,SCH-I510,SCH-I510,5,-24,1
+samsung,SCH-I519,SCH-I519,5,-24,1
+samsung,d2vzw,SCH-I535,5,-24,1
+samsung,d2vzw,SCH-I535PP,5,-24,1
+samsung,jfltevzw,SCH-I545,5,-24,1
+samsung,jfltelra,SCH-I545L,5,-24,1
+samsung,jfltevzwpp,SCH-I545PP,5,-24,1
+samsung,SCH-I559,SCH-I559,5,-24,1
+samsung,SCH-I589,SCH-I589,5,-24,1
+samsung,t0ltevzw,SCH-I605,5,-24,1
+samsung,SCH-I619,SCH-I619,5,-24,1
+samsung,SCH-I629,SCH-I629,5,-24,1
+samsung,SCH-I639,SCH-I639,5,-24,1
+samsung,SCH-I659,SCH-I659,5,-24,1
+samsung,logan,SCH-I679,5,-24,1
+samsung,SCH-I699,SCH-I699,5,-24,1
+samsung,kylevectc,SCH-I699I,5,-24,1
+samsung,espressovzw,SCH-I705,5,-24,1
+samsung,kyleplusctc,SCH-I739,5,-24,1
+samsung,infinite3gduosctc,SCH-I759,5,-24,1
+samsung,SCH-I779,SCH-I779,5,-24,1
+samsung,SCH-I800,SCH-I800,5,-24,1
+samsung,SCH-I815,SCH-I815,5,-24,1
+samsung,aruba3gduosctc,SCH-I829,5,-24,1
+samsung,delos3gduosctc,SCH-I869,5,-24,1
+samsung,baffin3gduosctc,SCH-I879,5,-24,1
+samsung,baffinq3gduosctc,SCH-I879E,5,-24,1
+samsung,SCH-I905,SCH-I905,5,-24,1
+samsung,espresso10vzw,SCH-I915,5,-24,1
+samsung,SCH-I919U,SCH-I919U,5,-24,1
+samsung,p4noteltevzw,SCH-I925,5,-24,1
+samsung,p4notelteusc,SCH-I925U,5,-24,1
+samsung,m0apt,SCH-I939,5,-24,1
+samsung,m0ctc,SCH-I939,5,-24,1
+samsung,m0ctcduos,SCH-I939D,5,-24,1
+samsung,ja3gduosctc,SCH-I959,5,-24,1
+samsung,d2spi,SCH-L710,5,-24,1
+samsung,SCH-M828C,SCH-M828C,5,-24,1
+samsung,t03gctc,SCH-N719,5,-24,1
+samsung,crater3gctc,SCH-P709,5,-24,1
+samsung,melius3gduosctc,SCH-P729,5,-24,1
+samsung,SCH-P739,SCH-P739,5,-24,1
+samsung,d2cri,SCH-R530C,5,-24,1
+samsung,d2mtr,SCH-R530M,5,-24,1
+samsung,d2usc,SCH-R530U,5,-24,1
+samsung,d2xar,SCH-R530X,5,-24,1
+samsung,SCH-R680,SCH-R680,5,-24,1
+samsung,SCH-R720,SCH-R720,5,-24,1
+samsung,SCH-R730,SCH-R730,5,-24,1
+samsung,amazing3gcri,SCH-R740C,5,-24,1
+samsung,SCH-R760,SCH-R760,5,-24,1
+samsung,SCH-R760X,SCH-R760X,5,-24,1
+samsung,SCH-R820,SCH-R820,5,-24,1
+samsung,infiniteusc,SCH-R830,5,-24,1
+samsung,goghcri,SCH-R830C,5,-24,1
+samsung,SCH-R880,SCH-R880,5,-24,1
+samsung,serranolteusc,SCH-R890,5,-24,1
+samsung,SCH-R910,SCH-R910,5,-24,1
+samsung,SCH-R915,SCH-R915,5,-24,1
+samsung,SCH-R920,SCH-R920,5,-24,1
+samsung,SCH-R930,SCH-R930,5,-24,1
+samsung,SCH-R940,SCH-R940,5,-24,1
+samsung,t0lteusc,SCH-R950,5,-24,1
+samsung,meliuslteusc,SCH-R960,5,-24,1
+samsung,jflteusc,SCH-R970,5,-24,1
+samsung,jfltecri,SCH-R970C,5,-24,1
+samsung,jfltecsp,SCH-R970X,5,-24,1
+samsung,SCH-S720C,SCH-S720C,5,-24,1
+samsung,amazingtrfcd,SCH-S735C,5,-24,1
+samsung,amazing3gtrf,SCH-S738C,5,-24,1
+samsung,SCH-S950C,SCH-S950C,5,-24,1
+samsung,d2tfnspr,SCH-S960L,5,-24,1
+samsung,d2tfnvzw,SCH-S968C,5,-24,1
+samsung,m0grandectc,SCH-W2013,5,-24,1
+samsung,hennessy3gduosctc,SCH-W789,5,-24,1
+samsung,SCH-W899,SCH-W899,5,-24,1
+samsung,m0grandectc,SCH-W9913,5,-24,1
+samsung,SCH-W999,SCH-W999,5,-24,1
+samsung,SCH-i509,SCH-i509,5,-24,1
+samsung,SCH-i559,SCH-i559,5,-24,1
+samsung,SCH-I559,SCH-i559,5,-24,1
+samsung,SCH-i569,SCH-i569,5,-24,1
+samsung,SCH-i579,SCH-i579,5,-24,1
+samsung,SCH-I579,SCH-i579,5,-24,1
+samsung,SCH-i589,SCH-i589,5,-24,1
+samsung,SCH-I589,SCH-i589,5,-24,1
+samsung,espressovzw,SCH-i705,5,-24,1
+samsung,SCH-i809,SCH-i809,5,-24,1
+samsung,SCH-i889,SCH-i889,5,-24,1
+samsung,SCH-i909,SCH-i909,5,-24,1
+samsung,SCH-i919,SCH-i919,5,-24,1
+samsung,SCH-i929,SCH-i929,5,-24,1
+samsung,SCL21,SCL21,5,-24,1
+samsung,SCL22,SCL22,5,-24,1
+samsung,SCL23,SCL23,11,-23,1
+samsung,SCL24,SCL24,7,-24,1
+samsung,SCT21,SCT21,5,-24,1
+samsung,SCV31,SCV31,4,-23,1
+samsung,SCV32,SCV32,5,-24,1
+samsung,SCV33,SCV33,7,-29,3
+samsung,SCV34,SCV34,5,-24,1
+samsung,SCV35,SCV35,9,-25,1
+samsung,SCV36,SCV36,9,-24,3
+samsung,SCV37,SCV37,8,-25,1
+samsung,SCV38,SCV38,7,-25,1
+samsung,SCV39,SCV39,9,-27,1
+samsung,SCV40,SCV40,7,-26,1
+samsung,SCV41,SCV41,5,-24,1
+samsung,SCV42,SCV42,1,-26,1
+samsung,SCV43,SCV43,5,-24,1
+samsung,SCV43-j,SCV43-j,5,-24,1
+samsung,SCV43-u,SCV43-u,5,-24,1
+samsung,SCV44,SCV44,5,-24,1
+samsung,SCV45,SCV45,5,-24,1
+samsung,SCV46,SCV46,5,-24,1
+samsung,SCV46,SCV46-j,5,-24,1
+samsung,SCV46,SCV46-u,5,-24,1
+samsung,SCV47,SCV47,5,-24,1
+samsung,serranoltebmc,SGH-I257M,5,-24,1
+samsung,t0ltecan,SGH-I317M,5,-24,1
+samsung,jfltecan,SGH-I337M,5,-24,1
+samsung,konaltecan,SGH-I467M,5,-24,1
+samsung,espresso10can,SGH-I497,5,-24,1
+samsung,meliusltecan,SGH-I527M,5,-24,1
+samsung,jactivelteatt,SGH-I537,5,-24,1
+samsung,comanchecan,SGH-I547C,5,-24,1
+samsung,SGH-I717,SGH-I717,5,-24,1
+samsung,SGH-I717D,SGH-I717D,5,-24,1
+samsung,SGH-I717M,SGH-I717M,5,-24,1
+samsung,SGH-I717R,SGH-I717R,5,-24,1
+samsung,SGH-I727,SGH-I727,5,-24,1
+samsung,SGH-I727R,SGH-I727R,5,-24,1
+samsung,d2can,SGH-I747M,5,-24,1
+samsung,c1att,SGH-I748,5,-24,1
+samsung,SGH-I757M,SGH-I757M,5,-24,1
+samsung,SGH-I827D,SGH-I827D,5,-24,1
+samsung,SGH-I896,SGH-I896,5,-24,1
+samsung,SGH-I927,SGH-I927,5,-24,1
+samsung,SGH-I957D,SGH-I957D,5,-24,1
+samsung,SGH-I957M,SGH-I957M,5,-24,1
+samsung,SGH-I957R,SGH-I957R,5,-24,1
+samsung,SGH-I987,SGH-I987,5,-24,1
+samsung,meliuslteMetroPCS,SGH-M819N,5,-24,1
+samsung,jfltetmo,SGH-M919,5,-24,1
+samsung,jflteMetroPCS,SGH-M919N,5,-24,1
+samsung,jfltecan,SGH-M919V,5,-24,1
+samsung,graceqltedcm,SGH-N037,5,-24,1
+samsung,hltejs01tw,SGH-N075T,5,-24,1
+samsung,amazingtrf,SGH-S730G,5,-24,1
+samsung,amazingtrf,SGH-S730M,5,-24,1
+samsung,SGH-S959G,SGH-S959G,5,-24,1
+samsung,jfltetfntmo,SGH-S970G,5,-24,1
+samsung,gardaltetmo,SGH-T399,5,-24,1
+samsung,gardalteMetroPCS,SGH-T399N,5,-24,1
+samsung,SGH-T499,SGH-T499,5,-24,1
+samsung,SGH-T499V,SGH-T499V,5,-24,1
+samsung,SGH-T499Y,SGH-T499Y,5,-24,1
+samsung,SGH-T589,SGH-T589,5,-24,1
+samsung,SGH-T589R,SGH-T589R,5,-24,1
+samsung,SGH-T589W,SGH-T589W,5,-24,1
+samsung,codinatmo,SGH-T599,5,-24,1
+samsung,codinaMetroPCS,SGH-T599N,5,-24,1
+samsung,codinavid,SGH-T599V,5,-24,1
+samsung,SGH-T679,SGH-T679,5,-24,1
+samsung,SGH-T679M,SGH-T679M,5,-24,1
+samsung,apexqtmo,SGH-T699,5,-24,1
+samsung,SGH-T759,SGH-T759,5,-24,1
+samsung,SGH-T769,SGH-T769,5,-24,1
+samsung,espresso10tmo,SGH-T779,5,-24,1
+samsung,SGH-T839,SGH-T839,5,-24,1
+samsung,SGH-T849,SGH-T849,5,-24,1
+samsung,SGH-T859,SGH-T859,5,-24,1
+samsung,SGH-T869,SGH-T869,5,-24,1
+samsung,SGH-T879,SGH-T879,5,-24,1
+samsung,t0ltetmo,SGH-T889,5,-24,1
+samsung,t0ltecan,SGH-T889V,5,-24,1
+samsung,SGH-T959,SGH-T959,5,-24,1
+samsung,SGH-T959D,SGH-T959D,5,-24,1
+samsung,SGH-T959P,SGH-T959P,5,-24,1
+samsung,SGH-T959V,SGH-T959V,5,-24,1
+samsung,SGH-T959W,SGH-T959W,5,-24,1
+samsung,SGH-T989,SGH-T989,5,-24,1
+samsung,SGH-T989D,SGH-T989D,5,-24,1
+samsung,d2tmo,SGH-T999,5,-24,1
+samsung,d2ltetmo,SGH-T999L,5,-24,1
+samsung,d2lteMetroPCS,SGH-T999N,5,-24,1
+samsung,d2can,SGH-T999V,5,-24,1
+samsung,SHV-E110S,SHV-E110S,5,-24,1
+samsung,SHV-E120K,SHV-E120K,5,-24,1
+samsung,SHV-E120L,SHV-E120L,5,-24,1
+samsung,SHV-E120S,SHV-E120S,5,-24,1
+samsung,SHV-E140K,SHV-E140K,5,-24,1
+samsung,SHV-E140L,SHV-E140L,5,-24,1
+samsung,SHV-E140S,SHV-E140S,5,-24,1
+samsung,SHV-E150S,SHV-E150S,5,-24,1
+samsung,SHV-E160K,SHV-E160K,5,-24,1
+samsung,SHV-E160L,SHV-E160L,5,-24,1
+samsung,SHV-E160S,SHV-E160S,5,-24,1
+samsung,jaguark,SHV-E170K,5,-24,1
+samsung,jaguarl,SHV-E170L,5,-24,1
+samsung,jaguars,SHV-E170S,5,-24,1
+samsung,c1ktt,SHV-E210K,5,-24,1
+samsung,c1lgt,SHV-E210L,5,-24,1
+samsung,c1skt,SHV-E210S,5,-24,1
+samsung,superiorlteskt,SHV-E220S,5,-24,1
+samsung,p4noteltektt,SHV-E230K,5,-24,1
+samsung,p4noteltelgt,SHV-E230L,5,-24,1
+samsung,p4notelteskt,SHV-E230S,5,-24,1
+samsung,t0ltektt,SHV-E250K,5,-24,1
+samsung,t0ltelgt,SHV-E250L,5,-24,1
+samsung,t0lteskt,SHV-E250S,5,-24,1
+samsung,baffinltektt,SHV-E270K,5,-24,1
+samsung,baffinltelgt,SHV-E270L,5,-24,1
+samsung,baffinlteskt,SHV-E270S,5,-24,1
+samsung,baffinvektt,SHV-E275K,5,-24,1
+samsung,baffinveskt,SHV-E275S,5,-24,1
+samsung,jaltektt,SHV-E300K,5,-24,1
+samsung,jaltelgt,SHV-E300L,5,-24,1
+samsung,jalteskt,SHV-E300S,5,-24,1
+samsung,meliusltektt,SHV-E310K,5,-24,1
+samsung,meliusltelgt,SHV-E310L,5,-24,1
+samsung,meliuslteskt,SHV-E310S,5,-24,1
+samsung,ks01ltektt,SHV-E330K,5,-24,1
+samsung,ks01ltelgt,SHV-E330L,5,-24,1
+samsung,ks01lteskt,SHV-E330S,5,-24,1
+samsung,serranoltekx,SHV-E370D,5,-24,1
+samsung,serranoltektt,SHV-E370K,5,-24,1
+samsung,ks02ltektt,SHV-E400K,5,-24,1
+samsung,ks02lteskt,SHV-E400S,5,-24,1
+samsung,jactivelteskt,SHV-E470S,5,-24,1
+samsung,delosltelgt,SHV-E500L,5,-24,1
+samsung,deloslteskt,SHV-E500S,5,-24,1
+samsung,archer,SHW-M100S,5,-24,1
+samsung,SHW-M110S,SHW-M110S,5,-24,1
+samsung,SHW-M115S,SHW-M115S,5,-24,1
+samsung,SHW-M130K,SHW-M130K,5,-24,1
+samsung,SHW-M130L,SHW-M130L,5,-24,1
+samsung,SHW-M135K,SHW-M135K,5,-24,1
+samsung,SHW-M135L,SHW-M135L,5,-24,1
+samsung,SHW-M180K,SHW-M180K,5,-24,1
+samsung,SHW-M180L,SHW-M180L,5,-24,1
+samsung,SHW-M180S,SHW-M180S,5,-24,1
+samsung,SHW-M180W,SHW-M180W,5,-24,1
+samsung,SHW-M190S,SHW-M190S,5,-24,1
+samsung,SHW-M220L,SHW-M220L,5,-24,1
+samsung,SHW-M240S,SHW-M240S,5,-24,1
+samsung,SHW-M250K,SHW-M250K,5,-24,1
+samsung,SHW-M250L,SHW-M250L,5,-24,1
+samsung,SHW-M250S,SHW-M250S,5,-24,1
+samsung,SHW-M290K,SHW-M290K,5,-24,1
+samsung,SHW-M290S,SHW-M290S,5,-24,1
+samsung,SHW-M300W,SHW-M300W,5,-24,1
+samsung,SHW-M305W,SHW-M305W,5,-24,1
+samsung,SHW-M340D,SHW-M340D,5,-24,1
+samsung,SHW-M340K,SHW-M340K,5,-24,1
+samsung,SHW-M340L,SHW-M340L,5,-24,1
+samsung,SHW-M340S,SHW-M340S,5,-24,1
+samsung,SHW-M380K,SHW-M380K,5,-24,1
+samsung,SHW-M380S,SHW-M380S,5,-24,1
+samsung,SHW-M380W,SHW-M380W,5,-24,1
+samsung,SHW-M430W,SHW-M430W,5,-24,1
+samsung,m0skt,SHW-M440S,5,-24,1
+samsung,SHW-M460D,SHW-M460D,5,-24,1
+samsung,p4noterfktt,SHW-M480K,5,-24,1
+samsung,p4noterfskt,SHW-M480S,5,-24,1
+samsung,p4notewifiany,SHW-M480W,5,-24,1
+samsung,p4notewifiktt,SHW-M485W,5,-24,1
+samsung,p4notewifi43241any,SHW-M486W,5,-24,1
+samsung,konawifiany,SHW-M500W,5,-24,1
+samsung,cane3gskt,SHW-M570S,5,-24,1
+samsung,arubaslimss,SHW-M580D,5,-24,1
+samsung,arubaslimss,SHW-M585D,5,-24,1
+samsung,a01q,SM-A015A,5,-24,1
+samsung,a01q,SM-A015AZ,5,-24,1
+samsung,a01q,SM-A015F,5,-24,1
+samsung,a01q,SM-A015G,5,-24,1
+samsung,a01q,SM-A015M,5,-24,1
+samsung,a01q,SM-A015T1,5,-24,1
+samsung,a01q,SM-A015V,5,-24,1
+samsung,a10ekx,SM-A102N,5,-24,1
+samsung,a10e,SM-A102U,5,-24,1
+samsung,a10e,SM-A102U1,5,-24,1
+samsung,a10e,SM-A102W,5,-24,1
+samsung,a10,SM-A105F,6,-25,1
+samsung,a10,SM-A105FN,6,-25,3
+samsung,a10,SM-A105G,6,-25,1
+samsung,a10,SM-A105M,6,-25,1
+samsung,a10,SM-A105N,6,-25,1
+samsung,a10s,SM-A107F,5,-24,1
+samsung,a10s,SM-A107M,5,-24,1
+samsung,a11q,SM-A115A,5,-24,1
+samsung,a11q,SM-A115AZ,5,-24,1
+samsung,a11q,SM-A115F,5,-24,1
+samsung,a11q,SM-A115M,5,-24,1
+samsung,a11q,SM-A115U,5,-24,1
+samsung,a20e,SM-A202F,5,-24,1
+samsung,a20e,SM-A202K,5,-24,1
+samsung,a20,SM-A205F,5,-24,1
+samsung,a20,SM-A205FN,5,-24,1
+samsung,a20,SM-A205G,5,-24,1
+samsung,a20,SM-A205GN,5,-24,1
+samsung,a20,SM-A205S,5,-24,1
+samsung,a20p,SM-A205U,5,-24,1
+samsung,a20p,SM-A205U1,5,-24,1
+samsung,a20,SM-A205W,5,-24,1
+samsung,a20,SM-A205YN,5,-24,1
+samsung,a20s,SM-A2070,5,-24,1
+samsung,a20s,SM-A207F,5,-24,1
+samsung,a20s,SM-A207M,5,-24,1
+samsung,a21s,SM-A217F,5,-24,1
+samsung,a21s,SM-A217M,5,-24,1
+samsung,a21s,SM-A217N,5,-24,1
+samsung,a2corelte,SM-A260F,5,-24,1
+samsung,a2corelte,SM-A260G,5,-24,1
+samsung,a3ltezh,SM-A3000,6,-23,1
+samsung,a3ltechn,SM-A3000,6,-23,1
+samsung,a3ltectc,SM-A3009,6,-23,1
+samsung,a3lteslk,SM-A300F,6,-23,1
+samsung,a3lte,SM-A300F,6,-23,1
+samsung,a3ulte,SM-A300FU,6,-23,3
+samsung,a3ltedd,SM-A300G,6,-23,1
+samsung,a33g,SM-A300H,6,-23,1
+samsung,a3lte,SM-A300M,6,-23,1
+samsung,a3ltechn,SM-A300X,6,-23,1
+samsung,a3ulte,SM-A300XU,6,-23,1
+samsung,a3lte,SM-A300XZ,6,-23,1
+samsung,a3ulte,SM-A300Y,6,-23,1
+samsung,a3ltezt,SM-A300YZ,6,-23,1
+samsung,a3lte,SM-A300YZ,6,-23,1
+samsung,a30c,SM-A3050,5,-24,1
+samsung,a30c,SM-A3051,5,-24,1
+samsung,a30c,SM-A3058,5,-24,1
+samsung,a30,SM-A305F,5,-24,1
+samsung,a30,SM-A305FN,5,-24,1
+samsung,a30,SM-A305G,5,-24,1
+samsung,a30,SM-A305GN,5,-24,1
+samsung,a30,SM-A305GT,5,-24,1
+samsung,a30,SM-A305N,5,-24,1
+samsung,a30,SM-A305YN,5,-24,1
+samsung,a30s,SM-A307FN,5,-24,1
+samsung,a30s,SM-A307G,5,-24,1
+samsung,a30s,SM-A307GN,5,-24,1
+samsung,a30s,SM-A307GT,5,-24,1
+samsung,a3xelte,SM-A310F,5,-24,1
+samsung,a3xelte,SM-A310M,5,-24,1
+samsung,a3xeltekx,SM-A310N0,5,-24,1
+samsung,a3xelte,SM-A310X,5,-24,1
+samsung,a3xelte,SM-A310Y,5,-24,1
+samsung,a31,SM-A315F,5,-24,1
+samsung,a31,SM-A315G,5,-24,1
+samsung,a31,SM-A315N,5,-24,1
+samsung,a3y17lte,SM-A320F,-10,-23,1
+samsung,a3y17lte,SM-A320FL,-10,-23,3
+samsung,a3y17lte,SM-A320X,-10,-23,1
+samsung,a3y17lte,SM-A320Y,-10,-23,1
+samsung,a40,SM-A405FM,5,-24,1
+samsung,a40,SM-A405FN,5,-24,1
+samsung,a40,SM-A405S,5,-24,1
+samsung,a41,SM-A415F,5,-24,1
+samsung,a5ltezh,SM-A5000,5,-24,1
+samsung,a5ltechn,SM-A5000,5,-24,1
+samsung,a5ltectc,SM-A5009,5,-24,1
+samsung,a5lte,SM-A500F,5,-24,1
+samsung,a5ulteskt,SM-A500F1,5,-24,1
+samsung,a5ulte,SM-A500FU,5,-24,1
+samsung,a5lte,SM-A500G,5,-24,1
+samsung,a53g,SM-A500H,5,-24,1
+samsung,a5ultektt,SM-A500K,5,-24,1
+samsung,a5ultelgt,SM-A500L,5,-24,1
+samsung,a5lte,SM-A500M,5,-24,1
+samsung,a5ulteskt,SM-A500S,5,-24,1
+samsung,a5ultebmc,SM-A500W,5,-24,1
+samsung,a5ltechn,SM-A500X,5,-24,1
+samsung,a5lte,SM-A500XZ,5,-24,1
+samsung,a5ulte,SM-A500Y,5,-24,1
+samsung,a5ltezt,SM-A500YZ,5,-24,1
+samsung,a50,SM-A505F,5,-24,1
+samsung,a50,SM-A505FM,5,-24,1
+samsung,a50,SM-A505FN,5,-24,1
+samsung,a50,SM-A505G,5,-24,1
+samsung,a50,SM-A505GN,5,-24,1
+samsung,a50,SM-A505GT,5,-24,1
+samsung,a50,SM-A505N,5,-24,1
+samsung,a50,SM-A505U,5,-24,1
+samsung,a50,SM-A505U1,5,-24,1
+samsung,a50,SM-A505W,5,-24,1
+samsung,a50,SM-A505YN,5,-24,1
+samsung,a50s,SM-A5070,5,-24,1
+samsung,a50s,SM-A507FN,5,-24,1
+samsung,a5xltechn,SM-A5100,5,-1,1
+samsung,a5xltechn,SM-A5100X,5,-1,1
+samsung,a5xeltecmcc,SM-A5108,5,-1,1
+samsung,a5xelte,SM-A510F,6,-2,3
+samsung,a5xeltektt,SM-A510K,5,-1,1
+samsung,a5xeltelgt,SM-A510L,5,-1,1
+samsung,a5xelte,SM-A510M,3,-1,3
+samsung,a5xelteskt,SM-A510S,5,-1,1
+samsung,a5xelte,SM-A510X,5,-1,1
+samsung,a5xltechn,SM-A510XZ,5,-1,1
+samsung,a5xeltextc,SM-A510Y,5,-1,1
+samsung,a5xelte,SM-A510Y,5,-1,1
+samsung,a51,SM-A515F,5,-24,1
+samsung,a51,SM-A515U,5,-24,1
+samsung,a51,SM-A515U1,5,-24,1
+samsung,a51,SM-A515W,5,-24,1
+samsung,a51x,SM-A5160,5,-24,1
+samsung,a51x,SM-A516B,5,-24,1
+samsung,a51x,SM-A516N,5,-24,1
+samsung,a5y17lte,SM-A520F,5,-24,1
+samsung,a5y17ltektt,SM-A520K,5,-24,1
+samsung,a5y17ltelgt,SM-A520L,5,-24,1
+samsung,a5y17lteskt,SM-A520S,5,-24,1
+samsung,a5y17ltecan,SM-A520W,5,-24,1
+samsung,a5y17lte,SM-A520X,5,-24,1
+samsung,jackpotlte,SM-A530F,5,-24,1
+samsung,jackpotlteks,SM-A530N,5,-24,1
+samsung,jackpotltecan,SM-A530W,5,-24,1
+samsung,jackpotlte,SM-A530X,5,-24,1
+samsung,a6elteatt,SM-A600A,5,-24,1
+samsung,a6elteaio,SM-A600AZ,5,-24,1
+samsung,a6lte,SM-A600F,5,-24,1
+samsung,a6lte,SM-A600FN,5,-24,1
+samsung,a6lte,SM-A600G,5,-24,1
+samsung,a6lte,SM-A600GN,5,-24,1
+samsung,a6lteks,SM-A600N,5,-24,1
+samsung,a6eltespr,SM-A600P,5,-24,1
+samsung,a6eltetmo,SM-A600T,5,-24,1
+samsung,a6eltemtr,SM-A600T1,5,-24,1
+samsung,a6elteue,SM-A600U,5,-24,1
+samsung,a6pltechn,SM-A6050,5,-24,1
+samsung,a6pltecmcc,SM-A6058,5,-24,1
+samsung,a6plte,SM-A605F,5,-24,1
+samsung,a6plte,SM-A605FN,5,-24,1
+samsung,a6plte,SM-A605G,5,-24,1
+samsung,a6plte,SM-A605GN,5,-24,1
+samsung,a6pltektt,SM-A605K,5,-24,1
+samsung,a6pltechn,SM-A605XC,5,-24,1
+samsung,a60q,SM-A6060,5,-24,1
+samsung,a60q,SM-A606Y,5,-24,1
+samsung,a7ltechn,SM-A7000,5,-24,1
+samsung,a7ltectc,SM-A7009,5,-24,1
+samsung,a7alte,SM-A700F,5,-24,1
+samsung,a7lte,SM-A700FD,5,-24,1
+samsung,a73g,SM-A700H,5,-24,1
+samsung,a7ltektt,SM-A700K,5,-24,1
+samsung,a7ltelgt,SM-A700L,5,-24,1
+samsung,a7lteskt,SM-A700S,5,-24,1
+samsung,a7lte,SM-A700X,5,-24,1
+samsung,a7ltechn,SM-A700YD,5,-24,1
+samsung,a70q,SM-A7050,5,-24,1
+samsung,a70q,SM-A705F,5,-24,1
+samsung,a70q,SM-A705FN,5,-24,1
+samsung,a70q,SM-A705GM,5,-24,1
+samsung,a70q,SM-A705MN,5,-24,1
+samsung,a70q,SM-A705U,5,-24,1
+samsung,a70q,SM-A705W,5,-24,1
+samsung,a70q,SM-A705YN,5,-24,1
+samsung,a70s,SM-A7070,5,-24,1
+samsung,a70s,SM-A707F,5,-24,1
+samsung,a7xltechn,SM-A7100,5,-5,1
+samsung,a7xeltecmcc,SM-A7108,5,-5,1
+samsung,a7xelte,SM-A710F,5,-5,3
+samsung,a7xeltektt,SM-A710K,5,-5,1
+samsung,a7xeltelgt,SM-A710L,5,-5,1
+samsung,a7xelte,SM-A710M,5,-5,1
+samsung,a7xelteskt,SM-A710S,5,-5,1
+samsung,a7xelte,SM-A710X,5,-5,1
+samsung,a7xltechn,SM-A710XZ,5,-5,1
+samsung,a7xeltextc,SM-A710Y,5,-5,1
+samsung,a71,SM-A715F,5,-24,1
+samsung,a71,SM-A715W,5,-24,1
+samsung,a71x,SM-A7160,5,-24,1
+samsung,a71x,SM-A716B,5,-24,1
+samsung,a71x,SM-A716S,5,-24,1
+samsung,a71xq,SM-A716U,5,-24,1
+samsung,a7y17lte,SM-A720F,5,-24,1
+samsung,a7y17lteskt,SM-A720S,5,-24,1
+samsung,jackpot2lte,SM-A730F,5,-24,1
+samsung,jackpot2lte,SM-A730X,5,-24,1
+samsung,a7y18ve,SM-A750C,5,-24,1
+samsung,a7y18lte,SM-A750F,6,-23,1
+samsung,a7y18lte,SM-A750FN,6,-23,1
+samsung,a7y18lte,SM-A750G,6,-23,1
+samsung,a7y18lte,SM-A750GN,6,-23,3
+samsung,a7y18lteks,SM-A750N,6,-23,1
+samsung,a8ltechn,SM-A8000,5,-24,1
+samsung,a8elte,SM-A800F,5,-24,1
+samsung,a8hplte,SM-A800I,5,-24,1
+samsung,a8hplte,SM-A800IZ,5,-24,1
+samsung,a8elteskt,SM-A800S,5,-24,1
+samsung,a8ltechn,SM-A800X,5,-24,1
+samsung,a8elte,SM-A800YZ,5,-24,1
+samsung,r1q,SM-A8050,5,-24,1
+samsung,r1q,SM-A805F,5,-24,1
+samsung,r1q,SM-A805N,5,-24,1
+samsung,a8xelte,SM-A810F,5,-24,1
+samsung,a8xelteskt,SM-A810S,5,-24,1
+samsung,a8xelte,SM-A810YZ,5,-24,1
+samsung,a9xltechn,SM-A9000,5,-24,1
+samsung,r3q,SM-A9080,5,-24,1
+samsung,r3q,SM-A908B,5,-24,1
+samsung,r3q,SM-A908N,5,-24,1
+samsung,a9xproltechn,SM-A9100,5,-24,1
+samsung,a9xproltesea,SM-A910F,5,-24,1
+samsung,a9y18qltechn,SM-A9200,5,-24,3
+samsung,a9y18qlte,SM-A920F,4,-21,3
+samsung,a9y18qltekx,SM-A920N,4,-21,1
+samsung,mproject3g,SM-C101,5,-24,1
+samsung,mprojectqlte,SM-C105,5,-24,1
+samsung,mprojectltektt,SM-C105K,5,-24,1
+samsung,mprojectltelgt,SM-C105L,5,-24,1
+samsung,mprojectlteskt,SM-C105S,5,-24,1
+samsung,m2a3g,SM-C111,5,-24,1
+samsung,m2a3g,SM-C111M,5,-24,1
+samsung,m2alte,SM-C115,5,-24,1
+samsung,m2altelgt,SM-C115L,5,-24,1
+samsung,m2alte,SM-C115M,5,-24,1
+samsung,m2altecan,SM-C115W,5,-24,1
+samsung,c5ltechn,SM-C5000,5,-24,1
+samsung,c5pltechn,SM-C5000,5,-24,1
+samsung,c5ltechn,SM-C500X,5,-24,1
+samsung,c5proltechn,SM-C5010,9,-26,3
+samsung,c5proltechn,SM-C5018,9,-26,1
+samsung,c7ltechn,SM-C7000,5,-24,1
+samsung,c7ltechn,SM-C700X,5,-24,1
+samsung,c7proltechn,SM-C7010,5,-24,1
+samsung,c7proltechn,SM-C7018,5,-24,1
+samsung,c7prolte,SM-C701F,5,-24,1
+samsung,c7proltechn,SM-C701X,5,-24,1
+samsung,jadeltechn,SM-C7100,8,-26,3
+samsung,jadeltecmcc,SM-C7108,8,-26,1
+samsung,jadelte,SM-C710F,5,-24,1
+samsung,jadeltechn,SM-C710X,8,-26,1
+samsung,c9ltechn,SM-C9000,5,-24,1
+samsung,c9ltechn,SM-C9008,5,-24,1
+samsung,c9lte,SM-C900F,5,-24,1
+samsung,c9ltechn,SM-C900X,5,-24,1
+samsung,c9lte,SM-C900Y,5,-24,1
+samsung,e5lte,SM-E500F,5,-24,1
+samsung,e53g,SM-E500H,5,-24,1
+samsung,e5lte,SM-E500M,5,-24,1
+samsung,e5ltetw,SM-E500YZ,5,-24,1
+samsung,e7ltehktw,SM-E7000,5,-24,1
+samsung,e7ltechn,SM-E7000,5,-24,1
+samsung,e7ltectc,SM-E7009,5,-24,1
+samsung,e7lte,SM-E700F,5,-24,1
+samsung,e73g,SM-E700H,5,-24,1
+samsung,e7lte,SM-E700M,5,-24,1
+samsung,bloomq,SM-F7000,5,-24,1
+samsung,bloomq,SM-F700F,5,-24,1
+samsung,bloomq,SM-F700N,5,-24,1
+samsung,bloomq,SM-F700U,5,-24,1
+samsung,bloomq,SM-F700U1,5,-24,1
+samsung,bloomq,SM-F700W,5,-24,1
+samsung,winner,SM-F9000,5,-24,1
+samsung,winner,SM-F900F,5,-24,1
+samsung,winner,SM-F900U,5,-24,1
+samsung,winner,SM-F900U1,5,-24,1
+samsung,winner,SM-F900W,5,-24,1
+samsung,winner,SM-F907B,5,-24,1
+samsung,winner,SM-F907N,5,-24,1
+samsung,pocket23g,SM-G110B,5,-24,1
+samsung,pocket2ss3g,SM-G110H,5,-24,1
+samsung,pocket23g,SM-G110M,5,-24,1
+samsung,young23gdtv,SM-G130BT,5,-24,1
+samsung,young2ve3g,SM-G130BU,5,-24,1
+samsung,young2ds2g,SM-G130E,5,-24,1
+samsung,young23g,SM-G130H,5,-24,1
+samsung,young2nfc3g,SM-G130HN,5,-24,1
+samsung,young23g,SM-G130M,5,-24,1
+samsung,young23g,SM-G130U,5,-24,1
+samsung,novelltekx,SM-G150N0,5,-24,1
+samsung,novelltektt,SM-G150NK,5,-24,1
+samsung,novelltelgt,SM-G150NL,5,-24,1
+samsung,novellteskt,SM-G150NS,5,-24,1
+samsung,novel3gskt,SM-G155S,5,-24,1
+samsung,eliteltechn,SM-G1600,5,-24,1
+samsung,eliteltekx,SM-G160N,5,-24,1
+samsung,elitexltechn,SM-G1650,5,-24,1
+samsung,elitexlte,SM-G1650,6,-30,3
+samsung,elite3gkx,SM-G165N,5,-24,1
+samsung,heatnfc3g,SM-G310HN,5,-24,1
+samsung,heat3gou,SM-G310R5,5,-24,1
+samsung,vivalto,SM-G3139D,5,-24,1
+samsung,vivaltolte,SM-G313F,5,-24,1
+samsung,vivalto3g,SM-G313H,5,-24,1
+samsung,vivaltonfc3g,SM-G313HN,5,-24,1
+samsung,vivaltods5m,SM-G313HU,5,-24,1
+samsung,vivaltods5m,SM-G313HY,5,-24,1
+samsung,vivalto3gvn,SM-G313HZ,5,-24,1
+samsung,vivaltods5m,SM-G313M,5,-24,1
+samsung,vivalto3g,SM-G313ML,5,-24,1
+samsung,vivaltolte,SM-G313MU,5,-24,1
+samsung,vivaltods5m,SM-G313MY,5,-24,1
+samsung,vivalto3g,SM-G313U,5,-24,1
+samsung,vivalto3mve3g,SM-G316H,5,-24,1
+samsung,vivalto5mve3g,SM-G316HU,5,-24,1
+samsung,vivalto5mve3g,SM-G316M,5,-24,1
+samsung,vivalto3mve3gltn,SM-G316ML,5,-24,1
+samsung,vivalto5mve3g,SM-G316MY,5,-24,1
+samsung,vivalto3mve3gltn,SM-G316U,5,-24,1
+samsung,vivalto3mveml3g,SM-G318H,5,-24,1
+samsung,vivalto3mveml3gsea,SM-G318HZ,5,-24,1
+samsung,vivalto3mveml3g,SM-G318ML,5,-24,1
+samsung,vivalto3mveml3gsea,SM-G318MZ,5,-24,1
+samsung,cs02,SM-G350,5,-24,1
+samsung,cs023g,SM-G3502,5,-24,1
+samsung,cs02ve3g,SM-G3502C,5,-24,1
+samsung,cs02ve3g,SM-G3502I,5,-24,1
+samsung,cs02ve3g,SM-G3502L,5,-24,1
+samsung,cs02ve3gdtv,SM-G3502T,5,-24,1
+samsung,cs023g,SM-G3502U,5,-24,1
+samsung,cs02cmcc,SM-G3508,5,-24,1
+samsung,cs02ve,SM-G3508I,5,-24,1
+samsung,cs02ve3g,SM-G3508J,5,-24,1
+samsung,cs02ctc,SM-G3509,5,-24,1
+samsung,cs02ve3g,SM-G3509I,5,-24,1
+samsung,higgs2g,SM-G350E,5,-24,1
+samsung,cs02ve3gss,SM-G350L,5,-24,1
+samsung,cs02ve3gss,SM-G350M,5,-24,1
+samsung,cs03lte,SM-G3518,5,-24,1
+samsung,kanas3g,SM-G3556D,5,-24,1
+samsung,kanas3gcmcc,SM-G3558,5,-24,1
+samsung,kanas3gctc,SM-G3559,5,-24,1
+samsung,kanas,SM-G355H,5,-24,1
+samsung,kanas3gnfc,SM-G355HN,5,-24,1
+samsung,kanas,SM-G355HQ,5,-24,1
+samsung,kanas,SM-G355M,5,-24,1
+samsung,heatqlte,SM-G357FZ,5,-24,1
+samsung,heatlte,SM-G357M,5,-24,1
+samsung,victorlte,SM-G3586V,5,-24,1
+samsung,victorlte,SM-G3589W,5,-24,1
+samsung,rossalte,SM-G3606,5,-24,1
+samsung,rossalte,SM-G3608,5,-24,1
+samsung,rossaltectc,SM-G3609,5,-24,1
+samsung,coreprimeltedtv,SM-G360BT,5,-24,1
+samsung,coreprimelte,SM-G360F,5,-24,1
+samsung,coreprimelte,SM-G360FY,5,-24,1
+samsung,rossaltexsa,SM-G360GY,5,-24,1
+samsung,core33g,SM-G360H,5,-24,1
+samsung,core33g,SM-G360HU,5,-24,1
+samsung,coreprimelte,SM-G360M,5,-24,1
+samsung,coreprimeltespr,SM-G360P,5,-24,1
+samsung,coreprimeltelra,SM-G360R6,5,-24,1
+samsung,cprimeltetmo,SM-G360T,5,-24,1
+samsung,cprimeltemtr,SM-G360T1,5,-24,1
+samsung,coreprimeltevzw,SM-G360V,5,-24,1
+samsung,coreprimevelte,SM-G361F,5,-24,1
+samsung,coreprimeve3g,SM-G361H,5,-24,1
+samsung,coreprimeve3g,SM-G361HU,5,-24,1
+samsung,coreprimevelte,SM-G361M,5,-24,1
+samsung,wilcoxds,SM-G3812,5,-24,1
+samsung,wilcoxds,SM-G3812B,5,-24,1
+samsung,wilcoxlte,SM-G3815,5,-24,1
+samsung,wilcox3g,SM-G3818,5,-24,1
+samsung,wilcoxctc,SM-G3819,5,-24,1
+samsung,wilcoxctc,SM-G3819D,5,-24,1
+samsung,afyonlte,SM-G386F,5,-24,1
+samsung,afyonltetmo,SM-G386T,5,-24,1
+samsung,afyonlteMetroPCS,SM-G386T1,5,-24,1
+samsung,afyonltecan,SM-G386W,5,-24,1
+samsung,xcover3lte,SM-G388F,5,-24,1
+samsung,xcover3velte,SM-G389F,5,-24,1
+samsung,xcover4lte,SM-G390F,5,-24,1
+samsung,xcover4ltecan,SM-G390W,5,-24,1
+samsung,xcover4lte,SM-G390Y,5,-24,1
+samsung,xcover4s,SM-G398FN,5,-24,1
+samsung,kleoslte,SM-G5108,5,-24,1
+samsung,kleoslte,SM-G5108Q,5,-24,1
+samsung,fortunalte,SM-G5306W,5,-24,1
+samsung,fortunalte,SM-G5308W,5,-24,1
+samsung,fortunaltezh,SM-G5308W,5,-24,1
+samsung,fortunaltectc,SM-G5309W,5,-24,1
+samsung,fortuna3gdtv,SM-G530BT,5,-24,1
+samsung,fortunalte,SM-G530F,5,-24,1
+samsung,grandprimelte,SM-G530FZ,5,-24,1
+samsung,fortunave3g,SM-G530H,5,-24,1
+samsung,fortuna3g,SM-G530H,5,-24,1
+samsung,fortunalte,SM-G530M,5,-24,1
+samsung,fortunaltezt,SM-G530MU,5,-24,1
+samsung,gprimeltespr,SM-G530P,5,-24,1
+samsung,gprimelteusc,SM-G530R4,5,-24,1
+samsung,gprimelteacg,SM-G530R7,5,-24,1
+samsung,gprimeltetmo,SM-G530T,5,-24,1
+samsung,gprimeltemtr,SM-G530T1,5,-24,1
+samsung,gprimeltecan,SM-G530W,5,-24,1
+samsung,fortunaltezt,SM-G530Y,5,-24,1
+samsung,grandprimeve3gdtv,SM-G531BT,5,-24,1
+samsung,grandprimevelte,SM-G531F,5,-24,1
+samsung,grandprimeve3g,SM-G531H,5,-24,1
+samsung,grandprimevelteltn,SM-G531M,5,-24,1
+samsung,grandprimeveltezt,SM-G531Y,5,-24,1
+samsung,grandpplte,SM-G532F,4,-24,1
+samsung,grandpplte,SM-G532G,4,-24,1
+samsung,grandpplte,SM-G532M,4,-24,3
+samsung,grandppltedtv,SM-G532MT,5,-24,1
+samsung,o5ltechn,SM-G5500,5,-24,1
+samsung,o5prolte,SM-G550FY,5,-24,1
+samsung,o5lte,SM-G550FY,5,-24,1
+samsung,on5ltetmo,SM-G550T,5,-24,1
+samsung,on5ltemtr,SM-G550T1,5,-24,1
+samsung,on5ltetmo,SM-G550T2,5,-24,1
+samsung,on5xlltechn,SM-G5510,5,-24,1
+samsung,on5xfltechn,SM-G5520,5,-24,1
+samsung,on5xfltechn,SM-G5528,5,-24,1
+samsung,on5xltechn,SM-G5700,5,-24,1
+samsung,on5xelte,SM-G570F,5,-24,1
+samsung,on5xelteins,SM-G570F,5,-24,1
+samsung,on5xelte,SM-G570M,5,-24,1
+samsung,on5xelte,SM-G570Y,5,-24,1
+samsung,o7ltechn,SM-G6000,3,-22,3
+samsung,on7elte,SM-G600F,3,-22,1
+samsung,o7lte,SM-G600FY,3,-22,1
+samsung,o7prolte,SM-G600FY,5,-24,1
+samsung,on7nlteskt,SM-G600S,5,-24,1
+samsung,on7xltechn,SM-G6100,5,-24,1
+samsung,on7xelte,SM-G610F,7,2,3
+samsung,on7xeltektt,SM-G610K,5,-24,1
+samsung,on7xeltelgt,SM-G610L,5,-24,1
+samsung,on7xelte,SM-G610M,7,2,1
+samsung,on7xelteskt,SM-G610S,5,-24,1
+samsung,on7xelte,SM-G610Y,7,2,1
+samsung,on7xreflte,SM-G611F,6,-2,3
+samsung,on7xreflteins,SM-G611FF,5,-24,1
+samsung,on7xrefltektt,SM-G611K,6,-2,1
+samsung,on7xrefltelgt,SM-G611L,6,-2,1
+samsung,on7xreflte,SM-G611M,6,-2,1
+samsung,on7xreflte,SM-G611MT,6,-2,1
+samsung,on7xreflteskt,SM-G611S,6,-2,1
+samsung,j7maxlte,SM-G615F,5,-24,1
+samsung,j7maxlte,SM-G615FU,5,-24,1
+samsung,Phoenix,SM-G6200,5,-24,1
+samsung,ms013gss,SM-G710,5,-24,1
+samsung,ms013g,SM-G7102,5,-24,1
+samsung,ms013gdtv,SM-G7102T,5,-24,1
+samsung,ms01lte,SM-G7105,5,-24,1
+samsung,ms01lte,SM-G7105H,5,-24,1
+samsung,ms01lte,SM-G7105L,5,-24,1
+samsung,ms013g,SM-G7106,5,-24,1
+samsung,ms013g,SM-G7108,5,-24,1
+samsung,ms013g,SM-G7109,5,-24,1
+samsung,ms01ltektt,SM-G710K,5,-24,1
+samsung,ms01ltelgt,SM-G710L,5,-24,1
+samsung,ms01lteskt,SM-G710S,5,-24,1
+samsung,xcoverpro,SM-G715FN,5,-24,1
+samsung,xcoverpro,SM-G715U,5,-24,1
+samsung,xcoverpro,SM-G715U1,5,-24,1
+samsung,xcoverpro,SM-G715W,5,-24,1
+samsung,grandmaxltechn,SM-G7200,5,-24,1
+samsung,grandmax3g,SM-G7202,5,-24,1
+samsung,grandmaxltechn,SM-G720AX,5,-24,1
+samsung,grandmaxltekx,SM-G720N0,5,-24,1
+samsung,goldenltevzw,SM-G730V,5,-24,1
+samsung,goldenltebmc,SM-G730W8,5,-24,1
+samsung,vastaltezh,SM-G7508Q,5,-24,1
+samsung,vastalte,SM-G7508Q,5,-24,1
+samsung,mega2lte,SM-G750F,5,-24,1
+samsung,mega23g,SM-G750H,5,-24,1
+samsung,vasta3g,SM-G750H,5,-24,1
+samsung,r5q,SM-G770F,5,-24,1
+samsung,r5q,SM-G770U1,5,-24,1
+samsung,kminilte,SM-G800F,5,-24,1
+samsung,kmini3g,SM-G800H,5,-24,1
+samsung,kmini3g,SM-G800HQ,5,-24,1
+samsung,kminilte,SM-G800M,5,-24,1
+samsung,kminilteusc,SM-G800R4,5,-24,1
+samsung,kminiwifi,SM-G800X,5,-24,1
+samsung,kminilte,SM-G800Y,5,-24,1
+samsung,sltechn,SM-G8508S,17,-33,1
+samsung,slte,SM-G850F,17,-33,3
+samsung,slte,SM-G850FQ,17,-33,1
+samsung,sltektt,SM-G850K,17,-33,1
+samsung,sltelgt,SM-G850L,17,-33,1
+samsung,slte,SM-G850M,17,-33,1
+samsung,slteskt,SM-G850S,17,-33,1
+samsung,sltecan,SM-G850W,17,-33,1
+samsung,slte,SM-G850X,17,-33,1
+samsung,slte,SM-G850Y,17,-33,1
+samsung,kltesprsports,SM-G860P,5,-24,1
+samsung,klteactive,SM-G870F,5,-24,1
+samsung,kactiveltekx,SM-G870F0,5,-24,1
+samsung,kltecanactive,SM-G870W,5,-24,1
+samsung,dreamliteqltechn,SM-G8750,5,-24,1
+samsung,astarqltechn,SM-G8850,3,-24,3
+samsung,astarqltecmcc,SM-G8858,3,-24,1
+samsung,astarqlte,SM-G885F,1,-24,1
+samsung,astarqlteskt,SM-G885S,1,-24,3
+samsung,astarqlte,SM-G885Y,1,-24,1
+samsung,a8sqltechn,SM-G8870,5,-24,1
+samsung,a8sqlte,SM-G887F,5,-24,1
+samsung,a8sqlteks,SM-G887N,5,-24,1
+samsung,haechiy19lteatt,SM-G889A,5,-24,1
+samsung,haechiy19,SM-G889F,5,-24,1
+samsung,haechiy19,SM-G889G,5,-24,1
+samsung,haechiy19,SM-G889YB,5,-24,1
+samsung,cruiserlteatt,SM-G892A,8,-24,3
+samsung,cruiserltesq,SM-G892U,8,-24,1
+samsung,klteduoszn,SM-G9006W,11,-23,1
+samsung,klte,SM-G9008W,12,-24,1
+samsung,klte,SM-G9009W,12,-24,1
+samsung,klte,SM-G900F,12,-24,3
+samsung,klte,SM-G900FD,12,-24,1
+samsung,kgedlte,SM-G900FG,5,-24,1
+samsung,klte,SM-G900FQ,12,-24,1
+samsung,k3g,SM-G900H,11,-23,1
+samsung,klte,SM-G900I,12,-24,1
+samsung,kltektt,SM-G900K,11,-23,1
+samsung,kltelgt,SM-G900L,11,-23,1
+samsung,klte,SM-G900M,12,-24,1
+samsung,klte,SM-G900MD,12,-24,1
+samsung,kltespr,SM-G900P,11,-23,1
+samsung,klteusc,SM-G900R4,11,-23,1
+samsung,kltelra,SM-G900R6,11,-23,1
+samsung,klteacg,SM-G900R7,11,-23,1
+samsung,klteskt,SM-G900S,11,-23,1
+samsung,kltetmo,SM-G900T,11,-23,1
+samsung,klteMetroPCS,SM-G900T1,11,-23,1
+samsung,kltetmo,SM-G900T3,11,-23,1
+samsung,klteMetroPCS,SM-G900T4,11,-23,1
+samsung,kltevzw,SM-G900V,11,-23,1
+samsung,kltecan,SM-G900W8,11,-23,1
+samsung,kwifi,SM-G900X,11,-23,1
+samsung,kccat6,SM-G901F,5,-24,1
+samsung,s5neolte,SM-G903F,5,-24,1
+samsung,s5neolte,SM-G903M,5,-24,1
+samsung,s5neoltecan,SM-G903W,5,-24,1
+samsung,lentisltektt,SM-G906K,11,-23,1
+samsung,lentisltelgt,SM-G906L,11,-23,1
+samsung,lentislteskt,SM-G906S,11,-23,1
+samsung,flteskt,SM-G910S,5,-24,1
+samsung,philippeltechn,SM-G9198,5,-24,1
+samsung,zerofltechn,SM-G9200,8,-24,1
+samsung,zerofltechn,SM-G9208,8,-24,1
+samsung,zerofltectc,SM-G9209,8,-24,1
+samsung,zeroflte,SM-G920F,9,-25,3
+samsung,zeroflte,SM-G920I,7,-24,3
+samsung,zerofltektt,SM-G920K,8,-24,1
+samsung,zerofltelgt,SM-G920L,8,-24,1
+samsung,zerofltespr,SM-G920P,8,-24,1
+samsung,zeroflteusc,SM-G920R4,8,-24,1
+samsung,zerofltelra,SM-G920R6,8,-24,1
+samsung,zeroflteacg,SM-G920R7,8,-24,1
+samsung,zeroflteskt,SM-G920S,8,-24,1
+samsung,zerofltetmo,SM-G920T,8,-24,3
+samsung,zerofltemtr,SM-G920T1,8,-24,1
+samsung,zerofltevzw,SM-G920V,8,-24,1
+samsung,zerofltebmc,SM-G920W8,8,-24,1
+samsung,zeroflte,SM-G920X,8,-24,1
+samsung,zeroltechn,SM-G9250,4,-23,1
+samsung,zerolte,SM-G925F,8,-25,3
+samsung,zerolte,SM-G925I,4,-23,3
+samsung,zeroltektt,SM-G925K,4,-23,1
+samsung,zeroltelgt,SM-G925L,8,-25,1
+samsung,zeroltespr,SM-G925P,4,-23,1
+samsung,zerolteusc,SM-G925R4,4,-23,1
+samsung,zeroltelra,SM-G925R6,4,-23,1
+samsung,zerolteacg,SM-G925R7,4,-23,1
+samsung,zerolteskt,SM-G925S,4,-23,1
+samsung,zeroltetmo,SM-G925T,4,-23,1
+samsung,zeroltevzw,SM-G925V,4,-23,1
+samsung,zeroltebmc,SM-G925W8,4,-23,1
+samsung,zerolte,SM-G925X,6,-24,1
+samsung,zenltechn,SM-G9280,5,-24,1
+samsung,zenlte,SM-G9287,5,-24,1
+samsung,zenlte,SM-G9287C,5,-24,1
+samsung,zenlte,SM-G928C,5,-24,1
+samsung,zenlte,SM-G928F,5,-24,1
+samsung,zenlte,SM-G928G,5,-24,1
+samsung,zenlte,SM-G928I,5,-24,1
+samsung,zenltektt,SM-G928K,5,-24,1
+samsung,zenltelgt,SM-G928L,5,-24,1
+samsung,zenltekx,SM-G928N0,5,-24,1
+samsung,zenltespr,SM-G928P,5,-24,1
+samsung,zenlteusc,SM-G928R4,5,-24,1
+samsung,zenlteskt,SM-G928S,5,-24,1
+samsung,zenltetmo,SM-G928T,5,-24,1
+samsung,zenltevzw,SM-G928V,5,-24,1
+samsung,zenltebmc,SM-G928W8,5,-24,1
+samsung,zenlte,SM-G928X,5,-24,1
+samsung,venenoltechn,SM-G9298,5,-24,1
+samsung,heroqltechn,SM-G9300,10,-33,1
+samsung,heroqltechn,SM-G9308,10,-33,1
+samsung,herolte,SM-G930F,10,-33,1
+samsung,heroltektt,SM-G930K,10,-33,1
+samsung,heroltelgt,SM-G930L,10,-33,1
+samsung,heroqltespr,SM-G930P,7,-32,3
+samsung,heroqlteusc,SM-G930R4,12,-35,3
+samsung,heroqltelra,SM-G930R6,10,-33,1
+samsung,heroqlteacg,SM-G930R7,10,-33,1
+samsung,herolteskt,SM-G930S,10,-33,1
+samsung,heroqltetmo,SM-G930T,10,-33,1
+samsung,heroqltemtr,SM-G930T1,10,-33,1
+samsung,heroqlteue,SM-G930U,10,-33,1
+samsung,heroqltevzw,SM-G930V,9,-32,3
+samsung,heroqltecctvzw,SM-G930VC,10,-33,1
+samsung,heroqltetfnvzw,SM-G930VL,10,-33,1
+samsung,heroltebmc,SM-G930W8,10,-33,1
+samsung,herolte,SM-G930X,10,-33,1
+samsung,hero2qltechn,SM-G9350,8,-31,3
+samsung,hero2lte,SM-G935F,8,-31,1
+samsung,hero2ltektt,SM-G935K,9,-31,1
+samsung,hero2ltelgt,SM-G935L,8,-31,1
+samsung,hero2qltespr,SM-G935P,8,-31,3
+samsung,hero2qlteusc,SM-G935R4,9,-29,3
+samsung,hero2lteskt,SM-G935S,9,-31,1
+samsung,hero2qltetmo,SM-G935T,4,-28,3
+samsung,hero2qlteue,SM-G935U,8,-31,1
+samsung,hero2qltevzw,SM-G935V,14,-34,3
+samsung,hero2qltecctvzw,SM-G935VC,9,-31,1
+samsung,hero2ltebmc,SM-G935W8,9,-31,1
+samsung,hero2lte,SM-G935X,9,-31,1
+samsung,dreamqltechn,SM-G9500,10,-27,1
+samsung,dreamqltecmcc,SM-G9508,10,-27,1
+samsung,dreamlte,SM-G950F,10,-27,1
+samsung,dreamlteks,SM-G950N,11,-27,3
+samsung,dreamqltesq,SM-G950U,10,-27,1
+samsung,dreamqlteue,SM-G950U1,10,-27,3
+samsung,dreamqltecan,SM-G950W,9,-24,3
+samsung,dream2qltechn,SM-G9550,9,-25,1
+samsung,dream2lte,SM-G955F,9,-26,3
+samsung,dream2lteks,SM-G955N,10,-26,3
+samsung,dream2qltesq,SM-G955U,9,-25,1
+samsung,dream2qlteue,SM-G955U1,10,-26,3
+samsung,dream2qltecan,SM-G955W,8,-23,3
+samsung,starqltechn,SM-G9600,4,-22,3
+samsung,starqltecmcc,SM-G9608,7,-25,1
+samsung,starlte,SM-G960F,7,-27,3
+samsung,starlteks,SM-G960N,7,-28,3
+samsung,starqltesq,SM-G960U,7,-25,1
+samsung,starqlteue,SM-G960U1,4,-19,3
+samsung,starqltecs,SM-G960W,7,-25,1
+samsung,star2qltechn,SM-G9650,7,-26,3
+samsung,star2lte,SM-G965F,8,-27,3
+samsung,star2lteks,SM-G965N,9,-25,3
+samsung,star2qltesq,SM-G965U,9,-27,1
+samsung,star2qlteue,SM-G965U1,6,-24,3
+samsung,star2qltecs,SM-G965W,9,-27,1
+samsung,beyond0q,SM-G9700,5,-24,1
+samsung,beyond0q,SM-G9708,5,-24,1
+samsung,beyond0,SM-G970F,5,-24,1
+samsung,beyond0,SM-G970N,5,-24,1
+samsung,beyond0q,SM-G970U,5,-24,1
+samsung,beyond0q,SM-G970U1,5,-24,1
+samsung,beyond0q,SM-G970W,5,-24,1
+samsung,beyond1q,SM-G9730,5,-24,1
+samsung,beyond1q,SM-G9738,5,-24,1
+samsung,beyond1q,SM-G973C,5,-24,1
+samsung,beyond1,SM-G973F,5,-24,1
+samsung,beyond1,SM-G973N,5,-24,1
+samsung,beyond1q,SM-G973U,5,-24,1
+samsung,beyond1q,SM-G973U1,5,-24,1
+samsung,beyond1q,SM-G973W,5,-24,1
+samsung,beyond2q,SM-G9750,1,-26,1
+samsung,beyond2q,SM-G9758,1,-26,1
+samsung,beyond2,SM-G975F,1,-26,3
+samsung,beyond2,SM-G975N,1,-26,1
+samsung,beyond2q,SM-G975U,1,-26,1
+samsung,beyond2q,SM-G975U1,1,-26,1
+samsung,beyond2q,SM-G975W,1,-26,1
+samsung,beyondx,SM-G977B,0,-26,1
+samsung,beyondx,SM-G977N,0,-26,3
+samsung,beyondxq,SM-G977P,-3,-34,3
+samsung,beyondxq,SM-G977T,-3,-34,1
+samsung,beyondxq,SM-G977U,-3,-34,1
+samsung,x1s,SM-G980F,5,-24,1
+samsung,x1q,SM-G9810,5,-24,1
+samsung,x1s,SM-G981B,5,-24,1
+samsung,x1q,SM-G981N,5,-24,1
+samsung,x1q,SM-G981U,5,-24,1
+samsung,x1q,SM-G981U1,5,-24,1
+samsung,x1q,SM-G981V,5,-24,1
+samsung,x1q,SM-G981W,5,-24,1
+samsung,y2s,SM-G985F,5,-24,1
+samsung,y2q,SM-G9860,5,-24,1
+samsung,y2s,SM-G986B,5,-24,1
+samsung,y2q,SM-G986N,5,-24,1
+samsung,y2q,SM-G986U,5,-24,1
+samsung,y2q,SM-G986U1,5,-24,1
+samsung,y2q,SM-G986W,5,-24,1
+samsung,z3q,SM-G9880,5,-24,1
+samsung,z3s,SM-G988B,5,-24,1
+samsung,z3q,SM-G988N,5,-24,1
+samsung,z3q,SM-G988U,5,-24,1
+samsung,z3q,SM-G988U1,5,-24,1
+samsung,z3q,SM-G988W,5,-24,1
+samsung,j1lte,SM-J100F,6,-22,1
+samsung,j1nlte,SM-J100FN,6,-22,1
+samsung,j1lte,SM-J100G,6,-22,1
+samsung,j13g,SM-J100H,6,-22,1
+samsung,j1lte,SM-J100M,6,-22,1
+samsung,j13g,SM-J100ML,6,-22,1
+samsung,j1nlte,SM-J100MU,6,-22,1
+samsung,j1qltevzw,SM-J100VPP,6,-22,3
+samsung,j1nlte,SM-J100Y,6,-22,1
+samsung,j1mini3gdx,SM-J105B,5,-24,1
+samsung,j1mini3g,SM-J105B,5,-24,1
+samsung,j1minilte,SM-J105F,5,-24,1
+samsung,j1mini3g,SM-J105H,5,-24,1
+samsung,j1mini3gxw,SM-J105H,5,-24,1
+samsung,j1minilte,SM-J105M,5,-24,1
+samsung,j1minilte,SM-J105Y,5,-24,1
+samsung,j1minive3g,SM-J106B,5,-24,1
+samsung,j1minive3gxtc,SM-J106B,5,-24,1
+samsung,j1minivelte,SM-J106F,5,-24,1
+samsung,j1minive3g,SM-J106H,5,-24,1
+samsung,j1minivelte,SM-J106M,5,-24,1
+samsung,j1acelte,SM-J110F,5,-24,1
+samsung,j1acelte,SM-J110G,5,-24,1
+samsung,j1pop3g,SM-J110H,5,-24,1
+samsung,j1pop3g,SM-J110L,5,-24,1
+samsung,j1acelteltn,SM-J110M,5,-24,1
+samsung,j1acevelte,SM-J111F,5,-24,1
+samsung,j1acevelte,SM-J111M,5,-24,1
+samsung,j1xlte,SM-J120F,5,-24,1
+samsung,j1xlte,SM-J120FN,6,-22,1
+samsung,j1xlte,SM-J120G,5,-24,1
+samsung,j1x3g,SM-J120H,5,-24,1
+samsung,j1xlte,SM-J120M,6,-22,1
+samsung,j1xqltespr,SM-J120P,6,-22,1
+samsung,j1xltecan,SM-J120W,6,-22,1
+samsung,j1xlte,SM-J120ZN,5,-24,1
+samsung,j2ltedtv,SM-J200BT,5,-24,1
+samsung,j2lte,SM-J200F,5,-24,1
+samsung,j2lte,SM-J200G,5,-24,1
+samsung,j2lte,SM-J200GU,5,-24,1
+samsung,j23g,SM-J200H,5,-24,1
+samsung,j2lte,SM-J200M,5,-24,1
+samsung,j2lte,SM-J200Y,5,-24,1
+samsung,j2xlte,SM-J210F,5,-24,1
+samsung,j2xlteins,SM-J210F,3,-27,1
+samsung,j2y18lte,SM-J250F,3,-27,3
+samsung,j2y18lte,SM-J250G,3,-27,1
+samsung,j2y18lte,SM-J250M,3,-27,1
+samsung,j2y18lte,SM-J250Y,3,-27,1
+samsung,j2coreplteatt,SM-J260A,5,-24,1
+samsung,j2coreplteaio,SM-J260AZ,5,-24,1
+samsung,j2corelte,SM-J260F,7,-27,1
+samsung,j2corey20lte,SM-J260FU,7,-27,1
+samsung,j2corelte,SM-J260G,7,-27,3
+samsung,j2corey20lte,SM-J260GU,7,-27,1
+samsung,j2corelte,SM-J260M,7,-27,1
+samsung,j2corey20lte,SM-J260MU,7,-27,1
+samsung,j2corepltemtr,SM-J260T1,5,-24,1
+samsung,j2corelte,SM-J260Y,7,-27,1
+samsung,j3ltectc,SM-J3109,6,-24,1
+samsung,j3xproltechn,SM-J3110,5,-24,1
+samsung,j3xproltectc,SM-J3119,5,-24,1
+samsung,j3xpro6mltechn,SM-J3119S,5,-24,1
+samsung,j3xlte,SM-J320F,1,-17,1
+samsung,j3xnlte,SM-J320FN,1,-17,1
+samsung,j3xlte,SM-J320G,1,-17,1
+samsung,j3x3g,SM-J320H,6,-24,1
+samsung,j3xlte,SM-J320M,1,-17,1
+samsung,j3ltekx,SM-J320N0,1,-17,1
+samsung,j3ltespr,SM-J320P,6,-24,1
+samsung,j3lteusc,SM-J320R4,1,-17,1
+samsung,j3ltevzw,SM-J320V,1,-17,3
+samsung,j3ltevzw,SM-J320VPP,1,-17,1
+samsung,j3xltebmc,SM-J320W8,1,-17,1
+samsung,j3ltetw,SM-J320Y,1,-17,1
+samsung,j3ltetw,SM-J320YZ,1,-17,1
+samsung,j3ltexsa,SM-J320ZN,1,-17,1
+samsung,j3popltespr,SM-J327P,5,-24,1
+samsung,j3poplteusc,SM-J327R4,6,-24,1
+samsung,j3popltelra,SM-J327R6,6,-24,1
+samsung,j3poplteacg,SM-J327R7,6,-24,1
+samsung,j3popeltetmo,SM-J327T,5,-24,1
+samsung,j3popeltemtr,SM-J327T1,5,-24,1
+samsung,j3popelteue,SM-J327U,6,-24,3
+samsung,j3popltevzw,SM-J327V,5,-24,1
+samsung,j3popltevzw,SM-J327VPP,5,-24,1
+samsung,j3popeltecan,SM-J327W,5,-24,1
+samsung,j3y17qltecmcc,SM-J3300,6,-24,1
+samsung,j3y17qltecmcc,SM-J3308,6,-24,1
+samsung,j3y17lte,SM-J330F,2,-22,1
+samsung,j3y17ltelgt,SM-J330F,3,-24,3
+samsung,j3y17lte,SM-J330FN,2,-22,1
+samsung,j3y17lte,SM-J330G,5,-24,1
+samsung,j3y17ltelgt,SM-J330L,2,-22,3
+samsung,j3y17ltekx,SM-J330N,2,-22,1
+samsung,j3toplteaio,SM-J336AZ,5,-24,1
+samsung,j3toplteatt,SM-J337A,5,-24,1
+samsung,j3toplteaio,SM-J337AZ,5,-24,1
+samsung,j3topeltespr,SM-J337P,5,-24,1
+samsung,j3topelteusc,SM-J337R4,5,-24,1
+samsung,j3topelteacg,SM-J337R7,6,-24,1
+samsung,j3topltetmo,SM-J337T,5,-24,1
+samsung,j3toplteue,SM-J337U,6,-24,1
+samsung,j3topeltevzw,SM-J337V,0,-19,3
+samsung,j3topeltevzw,SM-J337VPP,0,-19,1
+samsung,j3topltecs,SM-J337W,5,-24,1
+samsung,j4lte,SM-J400F,5,-24,1
+samsung,j4lte,SM-J400G,5,-24,1
+samsung,j4lte,SM-J400M,5,-24,1
+samsung,j4corelte,SM-J410F,5,-24,1
+samsung,j4corelte,SM-J410G,5,-24,1
+samsung,j4primelte,SM-J415F,5,-24,1
+samsung,j4primelte,SM-J415FN,5,-24,1
+samsung,j4primelte,SM-J415G,5,-24,1
+samsung,j4primelte,SM-J415GN,5,-24,1
+samsung,j4primeltekx,SM-J415N,5,-24,1
+samsung,j5lte,SM-J5007,3,-18,1
+samsung,j5ltechn,SM-J5008,2,-18,1
+samsung,j5lte,SM-J500F,4,-19,3
+samsung,j5nlte,SM-J500FN,2,-18,1
+samsung,j5lte,SM-J500G,3,-18,1
+samsung,j53g,SM-J500H,-1,-18,3
+samsung,j5lte,SM-J500M,2,-18,3
+samsung,j5ltekx,SM-J500N0,2,-18,1
+samsung,j5ylte,SM-J500Y,2,-18,1
+samsung,j5xltecmcc,SM-J5108,2,-19,1
+samsung,j5xnlte,SM-J510F,2,-19,1
+samsung,j5xnlte,SM-J510FN,1,-18,3
+samsung,j5xnlte,SM-J510FQ,2,-19,1
+samsung,j5xnlte,SM-J510GN,3,-19,3
+samsung,j5x3g,SM-J510H,2,-19,1
+samsung,j5xnltektt,SM-J510K,2,-19,1
+samsung,j5xnltelgt,SM-J510L,2,-19,1
+samsung,j5xnlte,SM-J510MN,3,-20,3
+samsung,j5xnlteskt,SM-J510S,2,-19,1
+samsung,j5xnlte,SM-J510UN,2,-19,1
+samsung,j5y17lte,SM-J530F,2,-18,1
+samsung,j5y17lte,SM-J530FM,2,-18,1
+samsung,j5y17lte,SM-J530G,5,-24,1
+samsung,j5y17lte,SM-J530GM,5,-24,1
+samsung,j5y17ltektt,SM-J530K,2,-18,1
+samsung,j5y17ltelgt,SM-J530L,2,-18,1
+samsung,j5y17lteskt,SM-J530S,2,-18,1
+samsung,j5y17ltedx,SM-J530Y,5,-24,1
+samsung,j5y17ltextc,SM-J530YM,5,-24,1
+samsung,j6lte,SM-J600F,5,-24,1
+samsung,j6lte,SM-J600FN,5,-24,1
+samsung,j6lte,SM-J600G,5,-24,1
+samsung,j6lte,SM-J600GF,5,-24,1
+samsung,j6lte,SM-J600GT,5,-24,1
+samsung,j6ltelgt,SM-J600L,5,-24,1
+samsung,j6ltekx,SM-J600N,5,-24,1
+samsung,j6primelte,SM-J610F,4,-26,3
+samsung,j6primelte,SM-J610FN,4,-26,1
+samsung,j6primelte,SM-J610G,4,-26,1
+samsung,j7ltechn,SM-J7008,5,-24,1
+samsung,j7elte,SM-J700F,5,-24,1
+samsung,j7e3g,SM-J700H,5,-24,1
+samsung,j75ltektt,SM-J700K,5,-24,1
+samsung,j7elte,SM-J700M,5,-24,1
+samsung,j7ltespr,SM-J700P,5,-24,1
+samsung,j7eltetmo,SM-J700T,5,-24,1
+samsung,j7eltemtr,SM-J700T1,5,-24,1
+samsung,j7velte,SM-J701F,5,-24,1
+samsung,j7velte,SM-J701M,5,-24,1
+samsung,j7velte,SM-J701MT,5,-24,1
+samsung,j7xeltecmcc,SM-J7108,5,-24,1
+samsung,j7xltectc,SM-J7109,5,-24,1
+samsung,j7xelte,SM-J710F,5,-24,1
+samsung,j7xlte,SM-J710FN,5,-24,1
+samsung,j7xelte,SM-J710FQ,5,-24,1
+samsung,j7xelte,SM-J710GN,5,-24,1
+samsung,j7xeltektt,SM-J710K,5,-24,1
+samsung,j7xelte,SM-J710MN,5,-24,1
+samsung,j7duolte,SM-J720F,5,-24,1
+samsung,j7duolte,SM-J720M,5,-24,1
+samsung,j7popltespr,SM-J727P,5,-24,1
+samsung,j7poplteusc,SM-J727R4,5,-24,1
+samsung,j7popelteskt,SM-J727S,5,-24,1
+samsung,j7popeltetmo,SM-J727T,5,-24,1
+samsung,j7popeltemtr,SM-J727T1,5,-24,1
+samsung,j7popelteue,SM-J727U,5,-24,1
+samsung,j7popltevzw,SM-J727V,4,-20,3
+samsung,j7popltevzw,SM-J727VPP,4,-20,1
+samsung,j7y17lte,SM-J730F,5,-24,1
+samsung,j7y17lte,SM-J730FM,5,-24,1
+samsung,j7y17lte,SM-J730G,5,-24,1
+samsung,j7y17lte,SM-J730GM,5,-24,1
+samsung,j7y17ltektt,SM-J730K,4,-30,3
+samsung,j7toplteatt,SM-J737A,5,-24,1
+samsung,j7topeltespr,SM-J737P,5,-24,1
+samsung,j7topelteusc,SM-J737R4,5,-24,1
+samsung,j7toplteskt,SM-J737S,5,-24,1
+samsung,j7topltetmo,SM-J737T,5,-24,1
+samsung,j7topltemtr,SM-J737T1,5,-24,1
+samsung,j7toplteue,SM-J737U,5,-24,1
+samsung,j7topeltevzw,SM-J737V,4,-20,1
+samsung,j7topeltevzw,SM-J737VPP,5,-24,1
+samsung,j8y18lte,SM-J810F,5,-29,3
+samsung,j8y18lte,SM-J810G,5,-29,1
+samsung,j8y18lte,SM-J810GF,5,-29,1
+samsung,j8y18lte,SM-J810M,5,-29,1
+samsung,j8y18lte,SM-J810Y,5,-29,1
+samsung,m01q,SM-M015F,5,-24,1
+samsung,m01q,SM-M015G,5,-24,1
+samsung,m10lte,SM-M105F,5,-24,1
+samsung,m10lte,SM-M105G,5,-24,1
+samsung,m10lte,SM-M105M,5,-24,1
+samsung,m10lte,SM-M105Y,5,-24,1
+samsung,m10s,SM-M107F,5,-24,1
+samsung,m11q,SM-M115F,5,-24,1
+samsung,m11q,SM-M115M,5,-24,1
+samsung,m20lte,SM-M205F,3,-22,3
+samsung,m20lte,SM-M205FN,3,-22,1
+samsung,m20lte,SM-M205G,3,-22,1
+samsung,m20lte,SM-M205M,3,-22,1
+samsung,m20,SM-M205N,3,-22,1
+samsung,m21,SM-M215F,5,-24,1
+samsung,m30lte,SM-M305F,5,-24,1
+samsung,m30lte,SM-M305M,5,-24,1
+samsung,m30s,SM-M3070,5,-24,1
+samsung,m30s,SM-M307F,5,-24,1
+samsung,m30s,SM-M307FN,5,-24,1
+samsung,m31,SM-M315F,5,-24,1
+samsung,m40,SM-M405F,5,-24,1
+samsung,hl3g,SM-N750,5,-24,1
+samsung,hl3g,SM-N7500Q,5,-24,1
+samsung,hl3gds,SM-N7502,5,-24,1
+samsung,hllte,SM-N7505,5,-24,1
+samsung,hllte,SM-N7505L,5,-24,1
+samsung,hllte,SM-N7507,5,-24,1
+samsung,frescoltektt,SM-N750K,5,-24,1
+samsung,frescoltelgt,SM-N750L,5,-24,1
+samsung,frescolteskt,SM-N750S,5,-24,1
+samsung,r7,SM-N770F,5,-24,1
+samsung,ha3g,SM-N900,5,-24,1
+samsung,ha3g,SM-N9000Q,5,-24,1
+samsung,hlte,SM-N9002,5,-24,1
+samsung,hlte,SM-N9005,5,-24,1
+samsung,hlte,SM-N9006,5,-24,1
+samsung,hlte,SM-N9007,5,-24,1
+samsung,htdlte,SM-N9007,5,-24,1
+samsung,hlte,SM-N9008,5,-24,1
+samsung,hlte,SM-N9008V,5,-24,1
+samsung,hlte,SM-N9009,5,-24,1
+samsung,hltektt,SM-N900K,5,-24,1
+samsung,hltelgt,SM-N900L,5,-24,1
+samsung,hltespr,SM-N900P,5,-24,1
+samsung,hlteusc,SM-N900R4,5,-24,1
+samsung,hlteskt,SM-N900S,5,-24,1
+samsung,hltetmo,SM-N900T,5,-24,1
+samsung,hlte,SM-N900U,5,-24,1
+samsung,hltevzw,SM-N900V,5,-24,1
+samsung,hltecan,SM-N900W8,5,-24,1
+samsung,trltechnzh,SM-N9100,11,-31,1
+samsung,trltechn,SM-N9100,11,-31,1
+samsung,trltechn,SM-N9106W,11,-31,1
+samsung,trltechn,SM-N9108V,11,-31,1
+samsung,trltechn,SM-N9109W,11,-31,1
+samsung,trelte,SM-N910C,11,-31,3
+samsung,trlte,SM-N910F,11,-31,1
+samsung,trlteatt,SM-N910F,11,-31,1
+samsung,trlte,SM-N910G,11,-31,1
+samsung,tre3g,SM-N910H,11,-31,1
+samsung,treltektt,SM-N910K,11,-31,1
+samsung,treltelgt,SM-N910L,11,-31,1
+samsung,trltespr,SM-N910P,11,-31,1
+samsung,trlteusc,SM-N910R4,11,-31,1
+samsung,trelteskt,SM-N910S,11,-31,1
+samsung,trltetmo,SM-N910T,11,-31,1
+samsung,trltetmo,SM-N910T2,11,-31,1
+samsung,trltetmo,SM-N910T3,11,-31,1
+samsung,trhplte,SM-N910U,11,-31,1
+samsung,trltevzw,SM-N910V,11,-31,1
+samsung,trltecan,SM-N910W8,11,-31,1
+samsung,trlte,SM-N910X,11,-31,1
+samsung,tblte,SM-N9150,7,-24,1
+samsung,tbltechn,SM-N9150,7,-24,1
+samsung,tblte,SM-N915F,7,-24,1
+samsung,tblte,SM-N915FY,7,-24,1
+samsung,tblte,SM-N915G,7,-24,3
+samsung,tbeltektt,SM-N915K,7,-24,1
+samsung,tbeltelgt,SM-N915L,7,-24,1
+samsung,tbltespr,SM-N915P,7,-24,1
+samsung,tblteusc,SM-N915R4,7,-24,1
+samsung,tbelteskt,SM-N915S,7,-24,1
+samsung,tbltetmo,SM-N915T,7,-24,1
+samsung,tbltetmo,SM-N915T3,7,-24,1
+samsung,tbltevzw,SM-N915V,7,-24,1
+samsung,tbltecan,SM-N915W8,7,-24,1
+samsung,tblte,SM-N915X,7,-24,1
+samsung,tre3caltektt,SM-N916K,11,-31,1
+samsung,tre3caltelgt,SM-N916L,5,-24,1
+samsung,tre3calteskt,SM-N916S,5,-24,1
+samsung,nobleltehk,SM-N9200,5,-29,1
+samsung,nobleltechn,SM-N9200,5,-29,1
+samsung,nobleltecmcc,SM-N9208,5,-29,1
+samsung,noblelte,SM-N9208,4,-29,3
+samsung,noblelte,SM-N920C,5,-30,3
+samsung,noblelte,SM-N920F,5,-29,1
+samsung,noblelte,SM-N920G,5,-29,1
+samsung,noblelte,SM-N920I,5,-29,1
+samsung,nobleltektt,SM-N920K,5,-29,1
+samsung,nobleltelgt,SM-N920L,5,-29,1
+samsung,nobleltespr,SM-N920P,5,-29,1
+samsung,noblelteusc,SM-N920R4,5,-29,1
+samsung,nobleltelra,SM-N920R6,5,-29,1
+samsung,noblelteacg,SM-N920R7,5,-29,1
+samsung,noblelteskt,SM-N920S,5,-29,1
+samsung,nobleltetmo,SM-N920T,5,-29,1
+samsung,nobleltevzw,SM-N920V,5,-29,1
+samsung,nobleltebmc,SM-N920W8,5,-29,1
+samsung,noblelte,SM-N920X,5,-29,1
+samsung,graceqltechn,SM-N9300,5,-24,1
+samsung,gracelte,SM-N930F,5,-24,1
+samsung,graceltektt,SM-N930K,5,-24,1
+samsung,graceltelgt,SM-N930L,5,-24,1
+samsung,graceqltespr,SM-N930P,5,-24,1
+samsung,graceqlteusc,SM-N930R4,5,-24,1
+samsung,graceqltelra,SM-N930R6,5,-24,1
+samsung,graceqlteacg,SM-N930R7,5,-24,1
+samsung,gracelteskt,SM-N930S,5,-24,1
+samsung,graceqltetmo,SM-N930T,5,-24,1
+samsung,graceqlteue,SM-N930U,5,-24,1
+samsung,graceqltevzw,SM-N930V,5,-24,1
+samsung,graceqltetfnvzw,SM-N930VL,5,-24,1
+samsung,graceqltebmc,SM-N930W8,5,-24,1
+samsung,gracelte,SM-N930X,5,-24,1
+samsung,gracerlte,SM-N935F,5,-24,1
+samsung,gracerltektt,SM-N935K,5,-24,1
+samsung,gracerltelgt,SM-N935L,5,-24,1
+samsung,gracerlteskt,SM-N935S,5,-24,1
+samsung,greatqltechn,SM-N9500,8,-25,1
+samsung,greatqltecmcc,SM-N9508,8,-25,1
+samsung,greatlte,SM-N950F,8,-24,3
+samsung,greatlteks,SM-N950N,6,-24,3
+samsung,greatqlte,SM-N950U,9,-25,3
+samsung,greatqlteue,SM-N950U1,9,-26,3
+samsung,greatqltecs,SM-N950W,8,-25,1
+samsung,greatlteks,SM-N950XN,6,-24,1
+samsung,crownqltechn,SM-N9600,7,-26,1
+samsung,crownlte,SM-N960F,7,-28,3
+samsung,crownlteks,SM-N960N,9,-27,3
+samsung,crownqltesq,SM-N960U,5,-24,3
+samsung,crownqlteue,SM-N960U1,5,-24,3
+samsung,crownqltecs,SM-N960W,7,-26,1
+samsung,d1q,SM-N9700,5,-24,1
+samsung,d1,SM-N970F,5,-24,1
+samsung,d1q,SM-N970U,5,-24,1
+samsung,d1q,SM-N970U1,5,-24,1
+samsung,d1q,SM-N970W,5,-24,1
+samsung,d1x,SM-N971N,5,-24,1
+samsung,d2q,SM-N9750,5,-24,1
+samsung,d2q,SM-N975C,5,-24,1
+samsung,d2s,SM-N975F,5,-24,1
+samsung,d2q,SM-N975U,5,-24,1
+samsung,d2q,SM-N975U1,5,-24,1
+samsung,d2q,SM-N975W,5,-24,1
+samsung,d2xq,SM-N9760,5,-24,1
+samsung,d2x,SM-N976B,5,-24,1
+samsung,d2x,SM-N976N,5,-24,1
+samsung,d2xq,SM-N976Q,5,-24,1
+samsung,d2xq2,SM-N976U,5,-24,1
+samsung,d2xq,SM-N976V,5,-24,1
+samsung,wisdomwifi,SM-P200,5,-24,1
+samsung,wisdom,SM-P205,5,-24,1
+samsung,gt5note8wifichn,SM-P350,2,-18,1
+samsung,gt5note8wifi,SM-P350,2,-18,1
+samsung,gt5note8lte,SM-P355,2,-18,1
+samsung,gt5note8ltechn,SM-P355C,5,-24,1
+samsung,gt5note8lte,SM-P355M,5,-24,1
+samsung,gt5note8ltechn,SM-P355Y,2,-18,1
+samsung,gt5note10wifichn,SM-P550,5,-24,1
+samsung,gt5note10wifi,SM-P550,5,-24,1
+samsung,gt5note10lte,SM-P555,5,-24,1
+samsung,gt5note10ltechn,SM-P555C,5,-24,1
+samsung,gt5note10ltektt,SM-P555K,5,-24,1
+samsung,gt5note10ltelgt,SM-P555L,5,-24,1
+samsung,gt5note10lte,SM-P555M,5,-24,1
+samsung,gt5note10lteskt,SM-P555S,5,-24,1
+samsung,gt5note10ltehktw,SM-P555Y,5,-24,1
+samsung,gtanotexlwifikx,SM-P580,5,-24,1
+samsung,gtanotexlwifikx,SM-P580X,5,-24,1
+samsung,gtanotexlwifichn,SM-P583,5,-24,1
+samsung,gtanotexllte,SM-P585,5,-24,1
+samsung,gtanotexllte,SM-P585M,5,-24,1
+samsung,gtanotexlltekx,SM-P585N0,5,-24,1
+samsung,gtanotexllte,SM-P585Y,5,-24,1
+samsung,gtanotexllte,SM-P587,5,-24,1
+samsung,gtanotexlltechn,SM-P588C,5,-24,1
+samsung,lt03wifikx,SM-P600,5,-24,1
+samsung,lt03wifi,SM-P600,5,-24,1
+samsung,lt03wifiue,SM-P600,5,-24,1
+samsung,lt033g,SM-P601,5,-24,1
+samsung,lt033g,SM-P602,5,-24,1
+samsung,lt03lte,SM-P605,5,-24,1
+samsung,lt03ltektt,SM-P605K,5,-24,1
+samsung,lt03ltelgt,SM-P605L,5,-24,1
+samsung,lt03lte,SM-P605M,5,-24,1
+samsung,lt03lteskt,SM-P605S,5,-24,1
+samsung,lt03ltevzw,SM-P605V,5,-24,1
+samsung,lt03ltetmo,SM-P607T,5,-24,1
+samsung,gta4xlwifi,SM-P610,5,-24,1
+samsung,gta4xlwifi,SM-P610X,5,-24,1
+samsung,gta4xl,SM-P615,5,-24,1
+samsung,gta4xl,SM-P615C,5,-24,1
+samsung,gta4xl,SM-P615N,5,-24,1
+samsung,gta4xl,SM-P617,5,-24,1
+samsung,v1awifi,SM-P900,5,-24,1
+samsung,v1awifikx,SM-P900,5,-24,1
+samsung,v1a3g,SM-P901,5,-24,1
+samsung,viennalte,SM-P905,5,-24,1
+samsung,viennaltekx,SM-P905F0,5,-24,1
+samsung,viennalte,SM-P905M,5,-24,1
+samsung,viennaltevzw,SM-P905V,5,-24,1
+samsung,a10e,SM-S102DL,5,-24,1
+samsung,a01q,SM-S111DL,5,-24,1
+samsung,j1xqltetfnvzw,SM-S120VL,6,-22,1
+samsung,a20p,SM-S205DL,5,-24,1
+samsung,j2corepltetfntmo,SM-S260DL,5,-24,1
+samsung,j3ltetfnvzw,SM-S320VL,1,-17,1
+samsung,j3popltetfnvzw,SM-S327VL,5,-24,1
+samsung,j3popeltetfntmo,SM-S337TL,5,-24,1
+samsung,j3topltetfntmo,SM-S357BL,3,-21,1
+samsung,j3topeltetfnvzw,SM-S367VL,3,-21,3
+samsung,a50,SM-S506DL,5,-24,1
+samsung,on5ltetfntmo,SM-S550TL,5,-24,1
+samsung,j7popqltetfnvzw,SM-S727VL,4,-18,3
+samsung,j7popeltetfntmo,SM-S737TL,5,-24,1
+samsung,j7topltetfntmo,SM-S757BL,5,-24,1
+samsung,heat3gtfnvzw,SM-S765C,5,-24,1
+samsung,heat3gtfnvzw,SM-S766C,5,-24,1
+samsung,j7topeltetfnvzw,SM-S767VL,5,-24,1
+samsung,j13gtfnvzw,SM-S777C,6,-22,1
+samsung,coreprimeltetfnvzw,SM-S820L,5,-24,1
+samsung,kltetfnvzw,SM-S903VL,11,-23,1
+samsung,zerofltetfnvzw,SM-S906L,8,-24,1
+samsung,zerofltetfnvzw,SM-S907VL,8,-24,1
+samsung,gprimeltetfnvzw,SM-S920L,5,-24,1
+samsung,jfltetfnatt,SM-S975L,5,-24,1
+samsung,e5ltetfnvzw,SM-S978L,5,-24,1
+samsung,goyawifi,SM-T110,5,-24,1
+samsung,goya3g,SM-T111,5,-24,1
+samsung,goya3g,SM-T111M,5,-24,1
+samsung,goyavewifi,SM-T113,5,-24,1
+samsung,goyavewifixtc,SM-T113NU,5,-24,1
+samsung,goyave3g,SM-T116,5,-24,1
+samsung,goyave3gsea,SM-T116BU,5,-24,1
+samsung,goyairis3g,SM-T116IR,5,-24,1
+samsung,goyave3g,SM-T116NQ,5,-24,1
+samsung,goyave3gsea,SM-T116NU,5,-24,1
+samsung,goyave3g5M,SM-T116NY,5,-24,1
+samsung,lt02wifi,SM-T210,5,-24,1
+samsung,lt02kidswifi,SM-T2105,5,-24,1
+samsung,lt02wifilgt,SM-T210L,5,-24,1
+samsung,lt02wifi,SM-T210R,5,-24,1
+samsung,lt02lduwifi,SM-T210X,5,-24,1
+samsung,lt023g,SM-T211,5,-24,1
+samsung,lt023gdtv,SM-T211M,5,-24,1
+samsung,lt023g,SM-T212,5,-24,1
+samsung,lt02lte,SM-T215,5,-24,1
+samsung,lt02ltespr,SM-T217S,5,-24,1
+samsung,lt02ltetmo,SM-T217T,5,-24,1
+samsung,degaswifi,SM-T230,5,-24,1
+samsung,degaswifidtv,SM-T230NT,5,-24,1
+samsung,degaswifiue,SM-T230NU,5,-24,1
+samsung,degaswifiopenbnn,SM-T230NU,5,-24,1
+samsung,degas2wifi,SM-T230NW,5,-24,1
+samsung,degas2wifibmwchn,SM-T230NW,5,-24,1
+samsung,degaswifibmwzc,SM-T230NY,5,-24,1
+samsung,degaswifi,SM-T230NY,5,-24,1
+samsung,degasy18wifi,SM-T230NZ,5,-24,1
+samsung,degasy18wifichn,SM-T230NZ,5,-24,1
+samsung,degaswifi,SM-T230X,5,-24,1
+samsung,degas3g,SM-T231,5,-24,1
+samsung,degas3g,SM-T232,5,-24,1
+samsung,degaslte,SM-T235,5,-24,1
+samsung,degaslte,SM-T235Y,5,-24,1
+samsung,degasltespr,SM-T237P,5,-24,1
+samsung,degasltevzw,SM-T237V,5,-24,1
+samsung,degasvelte,SM-T239,5,-24,1
+samsung,degasvelte,SM-T2397,5,-24,1
+samsung,degasveltechn,SM-T239C,5,-24,1
+samsung,degasvelte,SM-T239M,5,-24,1
+samsung,q7,SM-T2519,5,-24,1
+samsung,q7lteskt,SM-T255S,5,-24,1
+samsung,gtexswifi,SM-T280,5,-24,1
+samsung,gtexslte,SM-T285,5,-24,1
+samsung,gtexslte,SM-T285M,5,-24,1
+samsung,gtexslteswa,SM-T285YD,5,-24,1
+samsung,gtexslte,SM-T287,5,-24,1
+samsung,gtowifi,SM-T290,5,-24,1
+samsung,gto,SM-T295,5,-24,1
+samsung,gto,SM-T295C,5,-24,1
+samsung,gto,SM-T295N,5,-24,1
+samsung,gto,SM-T297,5,-24,1
+samsung,gta4s,SM-T307U,5,-24,1
+samsung,lt01wifikx,SM-T310,5,-24,1
+samsung,lt01wifi,SM-T310,5,-24,1
+samsung,lt01wifi,SM-T310X,5,-24,1
+samsung,lt013g,SM-T311,5,-24,1
+samsung,lt013g,SM-T312,5,-24,1
+samsung,lt01lte,SM-T315,5,-24,1
+samsung,lt01lte,SM-T315T,5,-24,1
+samsung,mondrianwifi,SM-T320,5,-24,1
+samsung,mondrianwifikx,SM-T320,5,-24,1
+samsung,mondrianwifiue,SM-T320,5,-24,1
+samsung,mondrianwifiue,SM-T320NU,5,-24,1
+samsung,mondrianwifi,SM-T320X,5,-24,1
+samsung,mondrianlte,SM-T325,5,-24,1
+samsung,milletwifikx,SM-T330,5,-24,1
+samsung,milletwifi,SM-T330,5,-24,1
+samsung,milletwifiue,SM-T330NU,5,-24,1
+samsung,milletwifi,SM-T330X,5,-24,1
+samsung,millet3g,SM-T331,5,-24,1
+samsung,milletlte,SM-T335,5,-24,1
+samsung,milletltektt,SM-T335K,5,-24,1
+samsung,milletltelgt,SM-T335L,5,-24,1
+samsung,milletltetmo,SM-T337T,5,-24,1
+samsung,milletltevzw,SM-T337V,5,-24,1
+samsung,gt58wifichn,SM-T350,2,-18,1
+samsung,gt58wifi,SM-T350,2,-18,3
+samsung,gt58wifi,SM-T350X,2,-18,1
+samsung,gt58wifichn,SM-T350X,2,-18,1
+samsung,gt58lte,SM-T355,2,-18,1
+samsung,gt58ltechn,SM-T355C,5,-24,1
+samsung,gt58lte,SM-T355Y,2,-18,1
+samsung,gt58ltetmo,SM-T357T,2,-18,1
+samsung,gt58ltebmc,SM-T357W,5,-24,1
+samsung,rubenswifi,SM-T360,5,-24,1
+samsung,rubenswifichn,SM-T360,5,-24,1
+samsung,rubenslte,SM-T365,5,-24,1
+samsung,rubensltekx,SM-T365F0,5,-24,1
+samsung,rubenslte,SM-T365M,5,-24,1
+samsung,rubenslte,SM-T365Y,5,-24,1
+samsung,gtesltelgt,SM-T375L,5,-24,1
+samsung,gteslteskt,SM-T375S,5,-24,1
+samsung,gtesltetw,SM-T3777,5,-24,1
+samsung,gtesqltespr,SM-T377P,5,-24,1
+samsung,gtesqlteusc,SM-T377R4,5,-24,1
+samsung,gtesltetmo,SM-T377T,5,-24,1
+samsung,gtesltevzw,SM-T377V,5,-24,1
+samsung,gtesltebmc,SM-T377W,5,-24,1
+samsung,gtesltektt,SM-T378K,5,-24,1
+samsung,gtesltelgt,SM-T378L,5,-24,1
+samsung,gteslteskt,SM-T378S,5,-24,1
+samsung,gtesveltevzw,SM-T378V,1,-20,3
+samsung,gta2swifi,SM-T380,4,-19,3
+samsung,gta2swifichn,SM-T380C,4,-20,3
+samsung,gta2slte,SM-T385,3,-19,1
+samsung,gta2sltechn,SM-T385C,4,-20,3
+samsung,gta2sltektt,SM-T385K,3,-18,3
+samsung,gta2sltelgt,SM-T385L,2,-19,3
+samsung,gta2slte,SM-T385M,3,-19,1
+samsung,gta2slteskt,SM-T385S,3,-19,1
+samsung,gtaslitelteatt,SM-T387AA,5,-24,1
+samsung,gtasliteltespr,SM-T387P,5,-24,1
+samsung,gtaslitelteusc,SM-T387R4,5,-24,1
+samsung,gtasliteltetmo,SM-T387T,5,-24,1
+samsung,gtasliteltevzw,SM-T387V,2,-18,1
+samsung,gtasliteltevzw,SM-T387VK,5,-24,1
+samsung,gtasliteltecs,SM-T387W,2,-18,1
+samsung,gtactive2wifi,SM-T390,-11,-23,3
+samsung,gtactive2lte,SM-T395,-8,-26,3
+samsung,gtactive2ltechn,SM-T395C,-9,-24,1
+samsung,gtactive2ltekx,SM-T395N,-9,-24,1
+samsung,gtactive2lteue,SM-T397U,-9,-24,1
+samsung,gta3xlwifi,SM-T510,5,-24,1
+samsung,gta3xl,SM-T515,5,-24,1
+samsung,gta3xl,SM-T515N,5,-24,1
+samsung,gta3xl,SM-T517,5,-24,1
+samsung,gta3xl,SM-T517P,5,-24,1
+samsung,picassowifi,SM-T520,5,-24,1
+samsung,picassowificc,SM-T520CC,5,-24,1
+samsung,picassolte,SM-T525,5,-24,1
+samsung,matissewifikx,SM-T530,5,-24,1
+samsung,matissewifi,SM-T530,5,-24,1
+samsung,matissewifigoogle,SM-T530NN,5,-24,1
+samsung,matissewifiue,SM-T530NU,5,-24,1
+samsung,matissewifiopenbnn,SM-T530NU,5,-24,1
+samsung,matissewifi,SM-T530X,5,-24,1
+samsung,matisse3g,SM-T531,5,-24,1
+samsung,matissevewifi,SM-T533,5,-24,1
+samsung,matisselte,SM-T535,5,-24,1
+samsung,matisse10wifikx,SM-T536,5,-24,1
+samsung,matisselteusc,SM-T537R4,5,-24,1
+samsung,matisseltevzw,SM-T537V,5,-24,1
+samsung,gtactivexlwifi,SM-T540,5,-24,1
+samsung,gtactivexl,SM-T545,5,-24,1
+samsung,gtactivexl,SM-T547,5,-24,1
+samsung,gtactivexl,SM-T547U,5,-24,1
+samsung,gt510wifichn,SM-T550,5,-24,1
+samsung,gt510wifi,SM-T550,5,-24,1
+samsung,gt510wifi,SM-T550X,5,-24,1
+samsung,gt510wifichn,SM-T550X,5,-24,1
+samsung,gt510lte,SM-T555,5,-24,1
+samsung,gt510ltechn,SM-T555C,5,-24,1
+samsung,gtelwifichn,SM-T560,5,-24,1
+samsung,gtelwifi,SM-T560,5,-24,1
+samsung,gtelwifiue,SM-T560NU,5,-24,1
+samsung,gtel3g,SM-T561,5,-24,1
+samsung,gtel3g,SM-T561M,5,-24,1
+samsung,gtel3g,SM-T561Y,5,-24,1
+samsung,gtel3g,SM-T562,5,-24,1
+samsung,gtelltevzw,SM-T567V,5,-24,1
+samsung,gtaxlwifichn,SM-T580,-12,-22,1
+samsung,gtaxlwifi,SM-T580,-12,-22,3
+samsung,gtaxlwifi,SM-T580X,-12,-22,1
+samsung,gtaxlwifichn,SM-T580X,5,-24,1
+samsung,gtaxladwifikx,SM-T583,5,-24,1
+samsung,gtaxllte,SM-T585,-12,-22,1
+samsung,gtaxlltechn,SM-T585C,-12,-22,1
+samsung,gtaxllte,SM-T585M,5,-24,1
+samsung,gtaxlltekx,SM-T585N0,-12,-22,1
+samsung,gtaxllte,SM-T587,5,-24,1
+samsung,gtaxlqltespr,SM-T587P,5,-24,1
+samsung,gta2xlwifichn,SM-T590,5,-24,1
+samsung,gta2xlwifi,SM-T590,5,-24,1
+samsung,gta2xllte,SM-T595,5,-24,1
+samsung,gta2xlltechn,SM-T595C,5,-24,1
+samsung,gta2xlltekx,SM-T595N,5,-24,1
+samsung,gta2xllte,SM-T597,5,-24,1
+samsung,gta2xlltespr,SM-T597P,5,-24,1
+samsung,gta2xlltevzw,SM-T597V,5,-24,1
+samsung,gta2xlltecs,SM-T597W,5,-24,1
+samsung,gvwifijpn,SM-T670,5,-24,1
+samsung,gvwifiue,SM-T670,5,-24,1
+samsung,gvltexsp,SM-T677,5,-24,1
+samsung,gvlte,SM-T677,5,-24,1
+samsung,gvltektt,SM-T677NK,5,-24,1
+samsung,gvltelgt,SM-T677NL,5,-24,1
+samsung,gvltevzw,SM-T677V,5,-24,1
+samsung,klimtwifi,SM-T700,5,-24,1
+samsung,klimtwifikx,SM-T700,5,-24,1
+samsung,klimtlte,SM-T705,5,-24,1
+samsung,klimtlte,SM-T705C,5,-24,1
+samsung,klimtlte,SM-T705M,5,-24,1
+samsung,klimtltecan,SM-T705W,5,-24,1
+samsung,klimtlte,SM-T705Y,5,-24,1
+samsung,klimtltevzw,SM-T707V,5,-24,1
+samsung,gts28wifi,SM-T710,5,-24,1
+samsung,gts28wifichn,SM-T710,5,-24,1
+samsung,gts28wifi,SM-T710X,5,-24,1
+samsung,gts28vewifi,SM-T713,5,-24,1
+samsung,gts28vewifichn,SM-T713,5,-24,1
+samsung,gts28lte,SM-T715,5,-24,1
+samsung,gts28ltechn,SM-T715C,5,-24,1
+samsung,gts28ltekx,SM-T715N0,5,-24,1
+samsung,gts28lte,SM-T715Y,5,-24,1
+samsung,gts28velte,SM-T719,5,-24,1
+samsung,gts28veltechn,SM-T719C,5,-24,1
+samsung,gts28velte,SM-T719Y,5,-24,1
+samsung,gts4lvwifichn,SM-T720,5,-24,1
+samsung,gts4lvwifi,SM-T720,5,-24,1
+samsung,gts4lv,SM-T725,5,-24,1
+samsung,gts4lv,SM-T725C,5,-24,1
+samsung,gts4lv,SM-T725N,5,-24,1
+samsung,gts4lv,SM-T727,5,-24,1
+samsung,gts4lv,SM-T727A,5,-24,1
+samsung,gts4lv,SM-T727R4,5,-24,1
+samsung,gts4lv,SM-T727U,5,-24,1
+samsung,gts4lv,SM-T727V,5,-24,1
+samsung,chagallwifikx,SM-T800,5,-24,1
+samsung,chagallwifi,SM-T800,5,-24,1
+samsung,chagallwifi,SM-T800X,5,-24,1
+samsung,chagalllte,SM-T805,5,-24,1
+samsung,chagalllte,SM-T805C,5,-24,1
+samsung,chagallhltektt,SM-T805K,5,-24,1
+samsung,chagallhltelgt,SM-T805L,5,-24,1
+samsung,chagalllte,SM-T805M,5,-24,1
+samsung,chagallhlteskt,SM-T805S,5,-24,1
+samsung,chagallltecan,SM-T805W,5,-24,1
+samsung,chagalllte,SM-T805Y,5,-24,1
+samsung,chagalllte,SM-T807,5,-24,1
+samsung,chagallltespr,SM-T807P,5,-24,1
+samsung,chagalllteusc,SM-T807R4,5,-24,1
+samsung,chagallltetmo,SM-T807T,5,-24,1
+samsung,chagallltevzw,SM-T807V,5,-24,1
+samsung,gts210wifi,SM-T810,5,-24,1
+samsung,gts210wifi,SM-T810X,5,-24,1
+samsung,gts210vewifichn,SM-T813,5,-24,1
+samsung,gts210vewifi,SM-T813,5,-24,1
+samsung,gts210lte,SM-T815,5,-24,1
+samsung,gts210lte,SM-T815C,5,-24,1
+samsung,gts210ltekx,SM-T815N0,5,-24,1
+samsung,gts210lte,SM-T815Y,5,-24,1
+samsung,gts210lte,SM-T817,5,-24,1
+samsung,gts210ltespr,SM-T817P,5,-24,1
+samsung,gts210lteusc,SM-T817R4,5,-24,1
+samsung,gts210ltetmo,SM-T817T,5,-24,1
+samsung,gts210ltevzw,SM-T817V,5,-24,1
+samsung,gts210ltecan,SM-T817W,5,-24,1
+samsung,gts210velte,SM-T818,5,-24,1
+samsung,gts210veltetmo,SM-T818T,5,-24,1
+samsung,gts210veltevzw,SM-T818V,5,-24,1
+samsung,gts210veltecan,SM-T818W,5,-24,1
+samsung,gts210velte,SM-T819,5,-24,1
+samsung,gts210veltechn,SM-T819C,5,-24,1
+samsung,gts210velte,SM-T819Y,5,-24,1
+samsung,gts3lwifichn,SM-T820,-5,-22,1
+samsung,gts3lwifi,SM-T820,-10,-23,3
+samsung,gts3lwifi,SM-T820X,-10,-23,1
+samsung,gts3llte,SM-T825,5,-24,1
+samsung,gts3lltechn,SM-T825C,5,-24,1
+samsung,gts3llte,SM-T825C,-5,-22,1
+samsung,gts3lltekx,SM-T825N0,-5,-22,1
+samsung,gts3llte,SM-T825X,-5,-22,1
+samsung,gts3llte,SM-T825Y,5,-24,1
+samsung,gts3llte,SM-T827,-5,-22,1
+samsung,gts3llteusc,SM-T827R4,-5,-22,1
+samsung,gts3lltevzw,SM-T827V,0,-22,3
+samsung,gts4lwifi,SM-T830,1,-20,1
+samsung,gts4lwifichn,SM-T830,1,-20,1
+samsung,gts4llte,SM-T835,1,-20,1
+samsung,gts4lltechn,SM-T835C,1,-20,1
+samsung,gts4lltekx,SM-T835N,1,-20,1
+samsung,gts4llte,SM-T837,1,-20,1
+samsung,gts4llteatt,SM-T837A,1,-20,1
+samsung,gts4lltespr,SM-T837P,1,-20,1
+samsung,gts4llteusc,SM-T837R4,1,-20,1
+samsung,gts4lltetmo,SM-T837T,1,-20,1
+samsung,gts4lltevzw,SM-T837V,1,-20,3
+samsung,gts6lwifi,SM-T860,5,-24,1
+samsung,gts6l,SM-T865,5,-24,1
+samsung,gts6x,SM-T866N,5,-24,1
+samsung,gts6l,SM-T867,5,-24,1
+samsung,gts6l,SM-T867R4,5,-24,1
+samsung,gts6l,SM-T867U,5,-24,1
+samsung,gts6l,SM-T867V,5,-24,1
+samsung,v2wifi,SM-T900,5,-24,1
+samsung,v2wifi,SM-T900X,5,-24,1
+samsung,v2lte,SM-T905,5,-24,1
+samsung,gview2lteatt,SM-T927A,5,-24,1
+samsung,montblanc3gctc,SM-W2014,5,-24,1
+samsung,pateklte,SM-W2015,5,-24,1
+samsung,royceltectc,SM-W2016,5,-24,1
+samsung,veyronltectc,SM-W2017,5,-24,1
+samsung,kellyltechn,SM-W2018,5,-24,1
+samsung,kellyltechn,SM-W2018X,5,-24,1
+samsung,zodiac,SM-W2020,5,-24,1
+samsung,ik1,SMT-E5015,5,-24,1
+samsung,SMT-i9100,SMT-i9100,5,-24,1
+samsung,SPH-D600,SPH-D600,5,-24,1
+samsung,SPH-D700,SPH-D700,5,-24,1
+samsung,SPH-D710,SPH-D710,5,-24,1
+samsung,SPH-D710BST,SPH-D710BST,5,-24,1
+samsung,SPH-D710VMUB,SPH-D710VMUB,5,-24,1
+samsung,goghspr,SPH-L300,5,-24,1
+samsung,goghvmu,SPH-L300,5,-24,1
+samsung,stunnerltespr,SPH-L500,5,-24,1
+samsung,serranoltespr,SPH-L520,5,-24,1
+samsung,meliusltespr,SPH-L600,5,-24,1
+samsung,d2spr,SPH-L710,5,-24,1
+samsung,d2vmu,SPH-L710,5,-24,1
+samsung,d2lterefreshspr,SPH-L710T,5,-24,1
+samsung,jfltespr,SPH-L720,5,-24,1
+samsung,jflterefreshspr,SPH-L720T,5,-24,1
+samsung,t0ltespr,SPH-L900,5,-24,1
+samsung,SPH-M580,SPH-M580,5,-24,1
+samsung,SPH-M580BST,SPH-M580BST,5,-24,1
+samsung,SPH-M820,SPH-M820-BST,5,-24,1
+samsung,prevail2spr,SPH-M830,5,-24,1
+samsung,raybst,SPH-M840,5,-24,1
+samsung,SPH-M900,SPH-M900,5,-24,1
+samsung,SPH-M910,SPH-M910,5,-24,1
+samsung,SPH-M920,SPH-M920,5,-24,1
+samsung,SPH-M930,SPH-M930,5,-24,1
+samsung,SPH-M930BST,SPH-M930BST,5,-24,1
+samsung,iconvmu,SPH-M950,5,-24,1
+samsung,SPH-P100,SPH-P100,5,-24,1
+samsung,espresso10spr,SPH-P500,5,-24,1
+samsung,p4noteltespr,SPH-P600,5,-24,1
+samsung,celes_cheets,Samsung Chromebook 3,5,-24,1
+samsung,kevin_cheets,Samsung Chromebook Plus,5,-24,1
+samsung,nautilus_cheets,Samsung Chromebook Plus (V2),5,-24,1
+samsung,caroline_cheets,Samsung Chromebook Pro,5,-24,1
+samsung,YP-G1,YP-G1,5,-24,1
+samsung,YP-G50,YP-G50,5,-24,1
+samsung,YP-G70,YP-G70,5,-24,1
+samsung,YP-GB1,YP-GB1,5,-24,1
+samsung,YP-GB70,YP-GB70,5,-24,1
+samsung,YP-GB70D,YP-GB70D,5,-24,1
+samsung,gokey,YP-GH1,5,-24,1
+samsung,YP-GI1,YP-GI1,5,-24,1
+samsung,hendrix,YP-GI2,5,-24,1
+samsung,harrisonkrlgt,YP-GP1,5,-24,1
+samsung,harrisonkrktt,YP-GP1,5,-24,1
+samsung,harrison,YP-GP1,5,-24,1
+samsung,YP-GS1,YP-GS1,5,-24,1
+samsung,archer,archer,5,-24,1
+samsung,caroline_cheets,caroline,5,-24,1
+samsung,gprimelteacg,gprimelteacg,5,-24,1
+samsung,kevin_cheets,kevin,5,-24,1
+samsung,nautilus_cheets,nautilus,5,-24,1
+samsung,fiber-athena,samsung-printer-tablet,5,-24,1
+sharp,taurus_2tcxxaf,2T-C12AF,5,-25,1
+sharp,taurus_2tcxxap,2T-C12AP,5,-25,1
+sharp,taurus_2tcfxxap,2T-C16AP,5,-25,1
+sharp,SG304SH,304SH,5,-25,1
+sharp,SG305SH,305SH,5,-25,1
+sharp,SG306SH,306SH,5,-25,1
+sharp,SG401SH,401SH,5,-25,1
+sharp,SG402SH,402SH,5,-25,1
+sharp,SG403SH,403SH,5,-25,1
+sharp,SG404SH,404SH,5,-25,1
+sharp,SG502SH,502SH,5,-25,1
+sharp,SG503SH,503SH,5,-25,1
+sharp,SG506SH,506SH,5,-25,1
+sharp,eve_sprout,507SH,5,-25,1
+sharp,SG509SH,509SH,5,-25,1
+sharp,SG603SH,603SH,5,-25,1
+sharp,SG605SH,605SH,5,-25,1
+sharp,SG606SH,606SH,5,-25,1
+sharp,SG701SH,701SH,5,-25,1
+sharp,SG702SH,702SH,5,-25,1
+sharp,SG704SH,704SH,5,-25,1
+sharp,SG706SH,706SH,5,-25,1
+sharp,SG801SH,801SH,5,-25,1
+sharp,SG803SH,803SH,5,-25,1
+sharp,SG808SH,808SH,5,-25,1
+sharp,SG901SH,901SH,5,-25,1
+sharp,SG906SH,906SH,5,-25,1
+sharp,SG907SH,907SH,5,-25,1
+sharp,SG908SH,908SH,5,-25,1
+sharp,A01SH,A01SH,5,-25,1
+sharp,an_np40,AN-NP40,5,-25,1
+sharp,lc_sunuj,AQUOS-4KTVJ17,5,-25,1
+sharp,lc_theut,AQUOS-4KTVT17,5,-25,1
+sharp,lc_theux,AQUOS-4KTVX17,5,-25,1
+sharp,tcme8sj,AQUOS-8KTVJ19,5,-25,1
+sharp,tcme8tsj,AQUOS-8KTVJ20,5,-25,1
+sharp,tcsu2uj,AQUOS-TVJ18,5,-25,1
+sharp,tcmeruj,AQUOS-TVJ19,5,-25,1
+sharp,tcmeruj,AQUOS-TVJ19B,5,-25,1
+sharp,tcmeruj,AQUOS-TVJ20B,5,-25,1
+sharp,tcth2ut,AQUOS-TVT18,5,-25,1
+sharp,guro,AQUOS-TVU19A,5,-25,1
+sharp,tcth2ux,AQUOS-TVX18,5,-25,1
+sharp,ebisu,AQUOS-TVX19A,5,-25,1
+sharp,gangnam,AQUOS-TVX19B,5,-25,1
+sharp,meguro,AQUOS-TVX19C,5,-25,1
+sharp,jamsil,AQUOS-TVX19D,5,-25,1
+sharp,sindang,AQUOS_TVE19A,5,-25,1
+sharp,DM-01H,DM-01H,5,-25,1
+sharp,DM-01J,DM-01J,5,-25,1
+sharp,DM009SH,DM009SH,5,-25,1
+sharp,DM010SH,DM010SH,5,-25,1
+sharp,DM011SH,DM011SH,5,-25,1
+sharp,DM012SH,DM012SH,5,-25,1
+sharp,DM013SH,DM013SH,5,-25,1
+sharp,DM014SH,DM014SH,5,-25,1
+sharp,DM016SH,DM016SH,5,-25,1
+sharp,EB-A71GJ,EB-A71GJ,5,-25,1
+sharp,EB-L76G-B,EB-L76G-B,5,-25,1
+sharp,Galapagos,EB-W51GJ,5,-25,1
+sharp,Galapagos,EB-WX1GJ,5,-25,1
+sharp,MS1,FS8001,5,-25,1
+sharp,TSP,FS8002,5,-25,1
+sharp,TSL,FS8002,5,-25,1
+sharp,SAT,FS8008,5,-25,1
+sharp,VN3N,FS8009,5,-25,1
+sharp,SS2,FS8010,5,-25,1
+sharp,SE3,FS8014,5,-25,1
+sharp,SE3_VN,FS8014,5,-25,1
+sharp,SE3_TH,FS8014,5,-25,1
+sharp,SD1,FS8015,5,-25,1
+sharp,SAT,FS8016,5,-25,1
+sharp,SG1,FS8018,5,-25,1
+sharp,SI3,FS8025,5,-25,1
+sharp,SJ3,FS8026,5,-25,1
+sharp,SK3,FS8028,5,-25,1
+sharp,HH6_sprout,FS8032,5,-25,1
+sharp,HH1,FS8032,5,-25,1
+sharp,HCTT1,HCTT1,5,-25,1
+sharp,AH3,IF9003,5,-25,1
+sharp,AG3,IF9007,5,-25,1
+sharp,HQ3,IF9009,5,-25,1
+sharp,SHX11,INFOBAR A01,5,-25,1
+sharp,SHX12,INFOBAR C01,5,-25,1
+sharp,SHI01,IS01,5,-25,1
+sharp,SHI03,IS03,5,-25,1
+sharp,SHI05,IS05,5,-25,1
+sharp,SHI11,IS11SH,5,-25,1
+sharp,SHI12,IS12SH,5,-25,1
+sharp,SHI13,IS13SH,5,-25,1
+sharp,SHI14,IS14SH,5,-25,1
+sharp,SHI15,IS15SH,5,-25,1
+sharp,SHI17,IS17SH,5,-25,1
+sharp,SHI16,ISW16SH,5,-25,1
+sharp,LC-42LE860H,LC-42LE860H,5,-25,1
+sharp,LC-42LE860M,LC-42LE860M,5,-25,1
+sharp,LC-50LE860H,LC-50LE860H,5,-25,1
+sharp,LC-50LE860M,LC-50LE860M,5,-25,1
+sharp,LC-50UE1H,LC-50UE1H,5,-25,1
+sharp,LC-50UE1M,LC-50UE1M,5,-25,1
+sharp,LC-55LE860H,LC-55LE860H,5,-25,1
+sharp,LC-55LE860M,LC-55LE860M,5,-25,1
+sharp,LC-58UE1H,LC-58UE1H,5,-25,1
+sharp,LC-58UE1M,LC-58UE1M,5,-25,1
+sharp,a11a,LC-A11A,5,-25,1
+sharp,a1h,LC-A1H,5,-25,1
+sharp,lc_le580t,LC-LE580T,5,-25,1
+sharp,lc_le580x,LC-LE580X,5,-25,1
+sharp,lx565h,LC-LX565H,5,-25,1
+sharp,lc_s3h01,LC-S3H-01,5,-25,1
+sharp,lc_u35t,LC-U35T,5,-25,1
+sharp,lc_ue630x,LC-UE630X,5,-25,1
+sharp,sharp_2k15_us_android,LC-Ux30US,5,-25,1
+sharp,lc_xu35t,LC-XU35T,5,-25,1
+sharp,lc_xu930x_830x,LC-XU930X_830X,5,-25,1
+sharp,lc_xxbel6t,LC-xxBEL6T,5,-25,1
+sharp,lc_xxbel8h_b,LC-xxBEL8H-B,5,-25,1
+sharp,lc_xxbel8h_c,LC-xxBEL8H-C,5,-25,1
+sharp,lc_xxbel9h,LC-xxBEL9H,5,-25,1
+sharp,lc_xxcae5h,LC-xxCAE5H,5,-25,1
+sharp,lc_xxdem6h,LC-xxDEM6H,5,-25,1
+sharp,lc_xxeos5h,LC-xxEOS5H,5,-25,1
+sharp,LC-xxLE570X,LC-xxLE570X,5,-25,1
+sharp,cv6a648_base,LCD-45FOC518H1A,5,-25,1
+sharp,cv6a648_4K_base,LCD-60FOC518H1A,5,-25,1
+sharp,lx460a,LCD-LX460A,5,-25,1
+sharp,lx560a,LCD-LX560A,5,-25,1
+sharp,msd818sharp,LCD-LX565A,5,-25,1
+sharp,lx565ab,LCD-LX565A-B,5,-25,1
+sharp,lcd_s3a01,LCD-S3A-01,5,-25,1
+sharp,lcd_uf30a,LCD-UF30A,5,-25,1
+sharp,v3a,LCD-V3A,5,-25,1
+sharp,lcd_xxbel6a,LCD-xxBEL6A,5,-25,1
+sharp,lcd_xxbel7a_c,LCD-xxBEL7A-C,5,-25,1
+sharp,lcd_xxbel7a_d,LCD-xxBEL7A-D,5,-25,1
+sharp,lcd_xxbel8a,LCD-xxBEL8A,5,-25,1
+sharp,lcd_xxbel8a_b,LCD-xxBEL8A-B,5,-25,1
+sharp,lcd_xxcae5a,LCD-xxCAE5A,5,-25,1
+sharp,lcd_xxcae5a_c,LCD-xxCAE5A-C,5,-25,1
+sharp,lcd_xxcae5a_d,LCD-xxCAE5A-D,5,-25,1
+sharp,lcd_xxcae5a_e,LCD-xxCAE5A-E,5,-25,1
+sharp,lcd_xxdem6a,LCD-xxDEM6A,5,-25,1
+sharp,lcd_xxdem6a_b,LCD-xxDEM6A-B,5,-25,1
+sharp,lcd_xxdem7a,LCD-xxDEM7A,5,-25,1
+sharp,lcd_xxdem8a,LCD-xxDEM8A,5,-25,1
+sharp,lcd_xxdem9a,LCD-xxDEM9A,5,-25,1
+sharp,lcd_xxdemxa,LCD-xxDEMXA,5,-25,1
+sharp,lcd_xxeos5a,LCD-xxEOS5A,5,-25,1
+sharp,lcd_xxgae7a,LCD-xxGAE7A,5,-25,1
+sharp,lcd_xxgae9a,LCD-xxGAE9A,5,-25,1
+sharp,Lcd_32sfinf380a,LCD_32SFINF380A,5,-25,1
+sharp,Lcd_40foc465a,LCD_40FOC465A,5,-25,1
+sharp,Lcd_40foc466a,LCD_40FOC466A,5,-25,1
+sharp,Lcd_40foc468a,LCD_40FOC468A,5,-25,1
+sharp,LCD_40X418FOCH1A,LCD_40X418FOCH1A,5,-25,1
+sharp,Lcd_45foc3000a,LCD_45FOC3000A,5,-25,1
+sharp,Lcd_45foc46a,LCD_45FOC46A,5,-25,1
+sharp,LCD_45X418FOCH1A,LCD_45X418FOCH1A,5,-25,1
+sharp,Lcd_50foc4000a,LCD_50FOC4000A,5,-25,1
+sharp,LCD_50FOCAG1T,LCD_50FOCAG1T,5,-25,1
+sharp,Lcd_50sufoc480a,LCD_50SUFOC480A,5,-25,1
+sharp,Lcd_50sumtcca_xa,LCD_50SUMTCCA_XA,5,-25,1
+sharp,Lcd_50ufoczq48a,LCD_50UFOCZQ48A,5,-25,1
+sharp,Lcd_60sufoc485a,LCD_60SUFOC485A,5,-25,1
+sharp,Lcd_foc36a,LCD_FOC36A,5,-25,1
+sharp,Lcd_xxffoczq48a,LCD_xxFFOCZQ48A,5,-25,1
+sharp,Lcd_xxfoc580a1,LCD_xxFOC580A1,5,-25,1
+sharp,Lcd_xxfoc580a2,LCD_xxFOC580A2,5,-25,1
+sharp,cv6a648_base,LCD_xxSFFOC470A,5,-25,1
+sharp,Lcd_xxsffoc475a,LCD_xxSFFOC475A,5,-25,1
+sharp,Lcd_xxsffoc480a,LCD_xxSFFOC480A,5,-25,1
+sharp,Lcd_xxsffocbc_h,LCD_xxSFFOCBC_H,5,-25,1
+sharp,Lcd_xxsffocca_c,LCD_xxSFFOCCA_C,5,-25,1
+sharp,cv6a648_4K_base,LCD_xxSUFOC470A,5,-25,1
+sharp,Lcd_xxsufoc471a,LCD_xxSUFOC471A,5,-25,1
+sharp,Lcd_xxsufoc475a,LCD_xxSUFOC475A,5,-25,1
+sharp,Lcd_xxsufoc480a,LCD_xxSUFOC480A,5,-25,1
+sharp,Lcd_xxsufoc5a,LCD_xxSUFOC5A,5,-25,1
+sharp,Lcd_xxsufoc6a,LCD_xxSUFOC6A,5,-25,1
+sharp,Lcd_xxufoczq48a,LCD_xxUFOCZQ48A,5,-25,1
+sharp,Lc_40foc466t,LC_40FOC466T,5,-25,1
+sharp,Lc_45foc460t,LC_45FOC460T,5,-25,1
+sharp,Lc_50foc45h,LC_50FOC45H,5,-25,1
+sharp,P1X,P1X,5,-25,1
+sharp,PN_ZC02,PN-ZC02,5,-25,1
+sharp,PN_B_series,PN_B_series,5,-25,1
+sharp,PN_B_series_w,PN_B_series,5,-25,1
+sharp,PN_M_series,PN_M_series,5,-25,1
+sharp,PN_M_series_w,PN_M_series,5,-25,1
+sharp,RW107,RW107,5,-25,1
+sharp,rk3188_10P_A,RZ-E302,5,-25,1
+sharp,kaleido_sprout,S1,5,-25,1
+sharp,rome_sprout,S3-SH,5,-25,1
+sharp,zeon_sprout,S5-SH,5,-25,1
+sharp,vespa_sprout,S7-SH,5,-25,1
+sharp,SBM003SH,SBM003SH,5,-25,1
+sharp,SBM005SH,SBM005SH,5,-25,1
+sharp,SBM006SH,SBM006SH,5,-25,1
+sharp,SBM007SH,SBM007SH,5,-25,1
+sharp,SBM007SHJ,SBM007SHJ,5,-25,1
+sharp,SBM007SHK,SBM007SHK,5,-25,1
+sharp,SBM009SH,SBM009SH,5,-25,1
+sharp,SBM009SHY,SBM009SHY,5,-25,1
+sharp,SBM101SH,SBM101SH,5,-25,1
+sharp,SBM102SH,SBM102SH,5,-25,1
+sharp,SBM102SH2,SBM102SH2,5,-25,1
+sharp,SBM103SH,SBM103SH,5,-25,1
+sharp,SBM104SH,SBM104SH,5,-25,1
+sharp,SBM106SH,SBM106SH,5,-25,1
+sharp,SBM107SH,SBM107SH,5,-25,1
+sharp,SBM107SHB,SBM107SHB,5,-25,1
+sharp,SBM200SH,SBM200SH,5,-25,1
+sharp,SBM203SH,SBM203SH,5,-25,1
+sharp,SBM204SH,SBM204SH,5,-25,1
+sharp,SBM205SH,SBM205SH,5,-25,1
+sharp,SBM206SH,SBM206SH,5,-25,1
+sharp,SBM302SH,SBM302SH,5,-25,1
+sharp,SBM303SH,SBM303SH,5,-25,1
+sharp,scallop,SC-S01,5,-25,1
+sharp,SH01D,SH-01D,5,-25,1
+sharp,SH01E,SH-01E,5,-25,1
+sharp,SH01EVW,SH-01EVW,5,-25,1
+sharp,SH-01F,SH-01F,5,-25,1
+sharp,SH-01FDQ,SH-01FDQ,5,-25,1
+sharp,SH-01G,SH-01G,5,-25,1
+sharp,SH-01H,SH-01H,5,-25,1
+sharp,SH-01K,SH-01K,5,-25,1
+sharp,SH-01L,SH-01L,5,-25,1
+sharp,SH-01M,SH-01M,5,-25,1
+sharp,SH02D,SH-02D,5,-25,1
+sharp,SH02E,SH-02E,5,-25,1
+sharp,SH-02F,SH-02F,5,-25,1
+sharp,SH-02G,SH-02G,5,-25,1
+sharp,SH-02H,SH-02H,5,-25,1
+sharp,SH-02J,SH-02J,5,-25,1
+sharp,SH-02L,SH-02L,5,-25,1
+sharp,SH-02M,SH-02M,5,-25,1
+sharp,SH03C,SH-03C,5,-25,1
+sharp,SH03F,SH-03F,5,-25,1
+sharp,SH-03G,SH-03G,5,-25,1
+sharp,SH-03H,SH-03H,5,-25,1
+sharp,SH-03J,SH-03J,5,-25,1
+sharp,SH-03K,SH-03K,4,-28,3
+sharp,SH04D,SH-04D,5,-25,1
+sharp,SH04E,SH-04E,5,-25,1
+sharp,SH-04F,SH-04F,5,-25,1
+sharp,SH-04G,SH-04G,5,-25,1
+sharp,SH-04H,SH-04H,5,-25,1
+sharp,SH-04L,SH-04L,5,-25,1
+sharp,SH05E,SH-05E,5,-25,1
+sharp,SH-05F,SH-05F,5,-25,1
+sharp,SH-05G,SH-05G,5,-25,1
+sharp,SH06D,SH-06D,5,-25,1
+sharp,SH06DNERV,SH-06DNERV,5,-25,1
+sharp,SH-06E,SH-06E,5,-25,1
+sharp,SH-06F,SH-06F,5,-25,1
+sharp,SH-06G,SH-06G,5,-25,1
+sharp,SH07D,SH-07D,5,-25,1
+sharp,SH-07E,SH-07E,5,-25,1
+sharp,SH-08E,SH-08E,5,-25,1
+sharp,SH09D,SH-09D,5,-25,1
+sharp,SH10B,SH-10B,5,-25,1
+sharp,SH10D,SH-10D,5,-25,1
+sharp,SH12C,SH-12C,5,-25,1
+sharp,SH13C,SH-13C,5,-25,1
+sharp,SH-51A,SH-51A,5,-25,1
+sharp,SH-A01,SH-A01,5,-25,1
+sharp,VGO,SH-C02,5,-25,1
+sharp,SH-D01,SH-D01,5,-25,1
+sharp,VZJ,SH-H01,5,-25,1
+sharp,SH-L02,SH-L02,5,-25,1
+sharp,SH-M01,SH-M01,5,-25,1
+sharp,SH-M02,SH-M02,5,-25,1
+sharp,SH-M02-EVA20,SH-M02-EVA20,5,-25,1
+sharp,SH-M03,SH-M03,5,-25,1
+sharp,SH-M04,SH-M04,5,-25,1
+sharp,SH-M05,SH-M05,5,-25,1
+sharp,SH-M06,SH-M06,5,-25,1
+sharp,SH-M07,SH-M07,5,-25,1
+sharp,SH-M08,SH-M08,5,-25,1
+sharp,SH-M09,SH-M09,5,-25,1
+sharp,SH-M10,SH-M10,5,-25,1
+sharp,SH-M11,SH-M11,5,-25,1
+sharp,SH-M12,SH-M12,5,-25,1
+sharp,SH-M13,SH-M13,5,-25,1
+sharp,SH-R10,SH-R10A,5,-25,1
+sharp,SH-RM02,SH-RM02,5,-25,1
+sharp,SH-RM11,SH-RM11,5,-25,1
+sharp,SH-RM12,SH-RM12,5,-25,1
+sharp,SH-Z01,SH-Z01,5,-25,1
+sharp,SH-Z10,SH-Z10,5,-25,1
+sharp,SH-Z10A,SH-Z10A,5,-25,1
+sharp,SH-Z20,SH-Z20,5,-25,1
+sharp,SH7218T,SH7218T,5,-25,1
+sharp,SH80F,SH80F,5,-25,1
+sharp,msm7627_surf,SH8118U,5,-25,1
+sharp,msm7627,SH8118U,5,-25,1
+sharp,msm7627,SH8128U,5,-25,1
+sharp,SH8188U,SH8188U,5,-25,1
+sharp,SH825Wi,SH825Wi,5,-25,1
+sharp,SH8268U,SH8268U,5,-25,1
+sharp,SH8288U,SH8288U,5,-25,1
+sharp,SH8298U,SH8298U,5,-25,1
+sharp,SH90B,SH90B,5,-25,1
+sharp,ADS1,SHARP-ADS1,5,-25,1
+sharp,SHF31,SHF31,5,-25,1
+sharp,SHF32,SHF32,5,-25,1
+sharp,SHF33,SHF33,5,-25,1
+sharp,TGD,SHG01,5,-25,1
+sharp,SHL21,SHL21,5,-25,1
+sharp,SHL22,SHL22,5,-25,1
+sharp,SHL23,SHL23,5,-25,1
+sharp,SHL24,SHL24,5,-25,1
+sharp,SHL25,SHL25,5,-25,1
+sharp,SHT21,SHT21,5,-25,1
+sharp,SHT22,SHT22,5,-25,1
+sharp,SHV31,SHV31,5,-25,1
+sharp,SHV32,SHV32,5,-25,1
+sharp,SHV33,SHV33,5,-25,1
+sharp,SHV34,SHV34,5,-25,1
+sharp,SHV35,SHV35,5,-25,1
+sharp,SHV36,SHV36,5,-25,1
+sharp,FSP,SHV37,5,-25,1
+sharp,FSP_u,SHV37_u,5,-25,1
+sharp,GTQ,SHV38,5,-25,1
+sharp,HUR,SHV39,5,-22,3
+sharp,KXU,SHV40,5,-25,1
+sharp,KXU_u,SHV40_u,5,-25,1
+sharp,JWT,SHV41,5,-25,1
+sharp,LYV,SHV42,5,-25,1
+sharp,MZW,SHV43,5,-25,1
+sharp,MZW-u,SHV43-u,5,-25,1
+sharp,NAX,SHV44,5,-25,1
+sharp,PCZ,SHV45,5,-25,1
+sharp,PCZ-u,SHV45-u,5,-25,1
+sharp,OBY,SHV46,5,-25,1
+sharp,QDA,SHV47,5,-25,1
+sharp,SR01MW,SR01MW,5,-25,1
+sharp,SR02MW,SR02MW,5,-25,1
+sharp,SRX002,SRX002,5,-25,1
+sharp,SW001SH,SW001SH,5,-25,1
+sharp,gangnam,TVX19B,5,-25,1
+sharp,WX04SH,WX04SH,5,-25,1
+sharp,WX05SH,WX05SH,5,-25,1
+sharp,nasa_sprout,X1,5,-25,1
+sharp,vespa_sprout,X4-SH,5,-25,1
+sony,401SO,401SO,5,-30,1
+sony,402SO,402SO,5,-30,1
+sony,501SO,501SO,10,-26,1
+sony,502SO,502SO,-1,-32,1
+sony,601SO,601SO,-1,-31,1
+sony,602SO,602SO,-3,-30,3
+sony,701SO,701SO,6,-26,3
+sony,702SO,702SO,6,-31,1
+sony,801SO,801SO,6,-30,1
+sony,802SO,802SO,5,-30,1
+sony,901SO,901SO,5,-30,1
+sony,902SO,902SO,5,-30,1
+sony,SVP-DTV15,BRAVIA 2015,5,-30,1
+sony,BRAVIA_ATV3_2K,BRAVIA 2K GB ATV3,5,-30,1
+sony,SVP-DTV15,BRAVIA 4K 2015,5,-30,1
+sony,BRAVIA_ATV2,BRAVIA 4K GB,5,-30,1
+sony,BRAVIA_ATV3_4K,BRAVIA 4K GB ATV3,5,-30,1
+sony,BRAVIA_UR1_4K,BRAVIA 4K UR1,5,-30,1
+sony,BRAVIA_UR2_4K,BRAVIA 4K UR2,5,-30,1
+sony,BRAVIA_UR3,BRAVIA 4K UR3,5,-30,1
+sony,BRAVIA_VH1,BRAVIA VH1,5,-30,1
+sony,BRAVIA_VU1,BRAVIA VU1,5,-30,1
+sony,C1504,C1504,5,-30,1
+sony,C1505,C1505,5,-30,1
+sony,C1604,C1604,5,-30,1
+sony,C1605,C1605,5,-30,1
+sony,C1904,C1904,5,-30,1
+sony,C1905,C1905,5,-30,1
+sony,C2004,C2004,5,-30,1
+sony,C2005,C2005,5,-30,1
+sony,C2104,C2104,5,-30,1
+sony,C2105,C2105,5,-30,1
+sony,C2304,C2304,5,-30,1
+sony,C2305,C2305,5,-30,1
+sony,C5302,C5302,5,-30,1
+sony,C5303,C5303,5,-30,1
+sony,C5306,C5306,5,-30,1
+sony,C5502,C5502,5,-30,1
+sony,C5503,C5503,5,-30,1
+sony,C6502,C6502,5,-30,1
+sony,C6503,C6503,5,-30,1
+sony,C6506,C6506,5,-30,1
+sony,C6602,C6602,5,-30,1
+sony,C6603,C6603,5,-30,1
+sony,C6606,C6606,5,-30,1
+sony,C6616,C6616,5,-30,1
+sony,C6802,C6802,5,-30,1
+sony,C6806,C6806,5,-30,1
+sony,C6806,C6806_GPe,5,-30,1
+sony,C6833,C6833,5,-30,1
+sony,C6843,C6843,5,-30,1
+sony,C6902,C6902,5,-30,1
+sony,C6903,C6903,5,-30,1
+sony,C6906,C6906,5,-30,1
+sony,C6916,C6916,5,-30,1
+sony,C6943,C6943,5,-30,1
+sony,D2004,D2004,5,-30,1
+sony,D2005,D2005,5,-30,1
+sony,D2104,D2104,5,-30,1
+sony,D2105,D2105,5,-30,1
+sony,D2114,D2114,5,-30,1
+sony,D2202,D2202,5,-30,1
+sony,D2203,D2203,5,-30,1
+sony,D2206,D2206,5,-30,1
+sony,D2212,D2212,5,-30,1
+sony,D2243,D2243,5,-30,1
+sony,D2302,D2302,5,-30,1
+sony,D2303,D2303,5,-30,1
+sony,D2305,D2305,5,-30,1
+sony,D2306,D2306,5,-30,1
+sony,D2403,D2403,5,-30,1
+sony,D2406,D2406,5,-30,1
+sony,D2502,D2502,5,-30,1
+sony,D2533,D2533,5,-30,1
+sony,D5102,D5102,5,-30,1
+sony,D5103,D5103,5,-30,1
+sony,D5106,D5106,5,-30,1
+sony,D5303,D5303,5,-30,1
+sony,D5306,D5306,5,-30,1
+sony,D5316,D5316,5,-30,1
+sony,D5316N,D5316N,5,-30,1
+sony,D5322,D5322,5,-30,1
+sony,D5503,D5503,5,-30,1
+sony,D5788,D5788,5,-30,1
+sony,aries,D5803,5,-30,1
+sony,D5803,D5803,5,-30,1
+sony,D5833,D5833,5,-30,1
+sony,D6502,D6502,5,-30,1
+sony,D6503,D6503,5,-30,1
+sony,D6543,D6543,5,-30,1
+sony,D6563,D6563,5,-30,1
+sony,D6603,D6603,5,-30,1
+sony,leo,D6603,5,-30,1
+sony,D6616,D6616,5,-30,1
+sony,D6633,D6633,5,-30,1
+sony,D6643,D6643,5,-30,1
+sony,D6646,D6646,5,-30,1
+sony,D6653,D6653,5,-30,1
+sony,D6683,D6683,5,-30,1
+sony,D6708,D6708,5,-30,1
+sony,E2003,E2003,5,-30,1
+sony,E2006,E2006,5,-30,1
+sony,E2033,E2033,5,-30,1
+sony,E2043,E2043,5,-30,1
+sony,E2053,E2053,5,-30,1
+sony,E2104,E2104,5,-30,1
+sony,E2105,E2105,5,-30,1
+sony,E2115,E2115,5,-30,1
+sony,E2124,E2124,5,-30,1
+sony,E2303,E2303,5,-30,1
+sony,E2306,E2306,5,-30,1
+sony,E2312,E2312,5,-30,1
+sony,E2333,E2333,5,-30,1
+sony,E2353,E2353,5,-30,1
+sony,E2363,E2363,5,-30,1
+sony,E5303,E5303,5,-30,1
+sony,E5306,E5306,5,-30,1
+sony,E5333,E5333,5,-30,1
+sony,E5343,E5343,5,-30,1
+sony,E5353,E5353,5,-30,1
+sony,E5363,E5363,5,-30,1
+sony,E5506,E5506,5,-30,1
+sony,E5533,E5533,5,-30,1
+sony,E5553,E5553,5,-30,1
+sony,E5563,E5563,5,-30,1
+sony,E5603,E5603,5,-30,1
+sony,E5606,E5606,5,-30,1
+sony,E5633,E5633,5,-30,1
+sony,E5643,E5643,5,-30,1
+sony,E5653,E5653,5,-30,1
+sony,E5663,E5663,5,-30,1
+sony,E5803,E5803,5,-30,1
+sony,E5823,E5823,5,-30,1
+sony,E6508,E6508,5,-30,1
+sony,E6533,E6533,5,-30,1
+sony,E6553,E6553,5,-30,1
+sony,E6603,E6603,10,-26,3
+sony,E6633,E6633,13,-26,3
+sony,E6653,E6653,10,-26,1
+sony,E6683,E6683,13,-26,1
+sony,E6833,E6833,5,-30,1
+sony,E6853,E6853,5,-30,1
+sony,E6883,E6883,5,-30,1
+sony,F3111,F3111,5,-30,1
+sony,F3112,F3112,5,-30,1
+sony,F3113,F3113,5,-30,1
+sony,F3115,F3115,5,-30,1
+sony,F3116,F3116,5,-30,1
+sony,F3211,F3211,5,-30,1
+sony,F3212,F3212,5,-30,1
+sony,F3213,F3213,5,-30,1
+sony,F3215,F3215,5,-30,1
+sony,F3216,F3216,5,-30,1
+sony,F3311,F3311,5,-30,1
+sony,F3313,F3313,5,-30,1
+sony,F5121,F5121,8,-34,3
+sony,suzu,F5121,8,-34,1
+sony,F5122,F5122,8,-34,1
+sony,F5321,F5321,5,-30,1
+sony,F8131,F8131,1,-32,3
+sony,F8132,F8132,-1,-32,1
+sony,F8331,F8331,-2,-29,3
+sony,F8332,F8332,-2,-31,3
+sony,G1109,G1109,5,-30,1
+sony,G1209,G1209,5,-30,1
+sony,G2199,G2199,5,-30,1
+sony,G2299,G2299,5,-30,1
+sony,G3112,G3112,4,-24,1
+sony,G3116,G3116,4,-24,1
+sony,G3121,G3121,4,-24,1
+sony,G3123,G3123,4,-24,3
+sony,G3125,G3125,4,-24,1
+sony,G3212,G3212,8,-27,1
+sony,G3221,G3221,8,-27,1
+sony,G3223,G3223,8,-27,3
+sony,G3226,G3226,8,-27,1
+sony,G3311,G3311,5,-30,1
+sony,G3312,G3312,5,-30,1
+sony,G3313,G3313,5,-30,1
+sony,G3412,G3412,5,-30,1
+sony,G3416,G3416,5,-30,1
+sony,G3421,G3421,5,-30,1
+sony,G3423,G3423,5,-30,1
+sony,G3426,G3426,5,-30,1
+sony,G8141,G8141,10,-28,1
+sony,G8142,G8142,10,-27,3
+sony,G8188,G8188,10,-28,1
+sony,G8231,G8231,-1,-32,1
+sony,G8232,G8232,0,-34,3
+sony,G8341,G8341,14,-34,3
+sony,G8342,G8342,9,-28,3
+sony,G8343,G8343,9,-29,1
+sony,G8441,G8441,5,-24,3
+sony,H3113,H3113,5,-30,1
+sony,H3123,H3123,5,-30,1
+sony,H3133,H3133,5,-30,1
+sony,H3213,H3213,5,-30,1
+sony,H3223,H3223,5,-30,1
+sony,H3311,H3311,5,-30,1
+sony,H3321,H3321,5,-30,1
+sony,H3413,H3413,5,-30,1
+sony,H4113,H4113,5,-30,1
+sony,H4133,H4133,5,-30,1
+sony,H4213,H4213,5,-30,1
+sony,H4233,H4233,5,-30,1
+sony,H4311,H4311,5,-30,1
+sony,H4331,H4331,5,-30,1
+sony,H4413,H4413,5,-30,1
+sony,H4493,H4493,5,-30,1
+sony,H8116,H8116,5,-30,1
+sony,H8166,H8166,5,-30,1
+sony,H8216,H8216,5,-31,3
+sony,H8266,H8266,6,-30,3
+sony,H8276,H8276,6,-31,1
+sony,H8296,H8296,8,-32,3
+sony,H8314,H8314,9,-33,3
+sony,H8324,H8324,9,-33,3
+sony,H8416,H8416,6,-30,3
+sony,H9436,H9436,6,-30,1
+sony,H9493,H9493,6,-30,1
+sony,I3113,I3113,5,-30,1
+sony,I3123,I3123,5,-30,1
+sony,I3213,I3213,8,-27,1
+sony,I3223,I3223,8,-27,1
+sony,I3312,I3312,5,-30,1
+sony,I4113,I4113,5,-30,1
+sony,I4193,I4193,5,-30,1
+sony,I4213,I4213,8,-27,3
+sony,I4293,I4293,8,-27,1
+sony,I4312,I4312,5,-30,1
+sony,I4332,I4332,5,-30,1
+sony,asura,Internet TV,5,-30,1
+sony,eagle,Internet TV Box,5,-30,1
+sony,J3173,J3173,5,-30,1
+sony,J8110,J8110,5,-30,1
+sony,J8170,J8170,5,-30,1
+sony,J8210,J8210,5,-30,1
+sony,J8270,J8270,5,-30,1
+sony,J9110,J9110,5,-30,1
+sony,J9150,J9150,5,-30,1
+sony,J9180,J9180,5,-30,1
+sony,J9210,J9210,5,-30,1
+sony,L35h,L35h,5,-30,1
+sony,L36h,L36h,5,-30,1
+sony,L39h,L39h,5,-30,1
+sony,L39t,L39t,5,-30,1
+sony,L39u,L39u,5,-30,1
+sony,LT18i,LT18i,5,-30,1
+sony,LT22i,LT22i,5,-30,1
+sony,LT25i,LT25i,5,-30,1
+sony,LT26i,LT26i,5,-30,1
+sony,LT26ii,LT26ii,5,-30,1
+sony,LT26w,LT26w,5,-30,1
+sony,LT28h,LT28h,5,-30,1
+sony,LT28i,LT28i,5,-30,1
+sony,LT29i,LT29i,5,-30,1
+sony,LT30a,LT30a,5,-30,1
+sony,LT30p,LT30p,5,-30,1
+sony,M35h,M35h,5,-30,1
+sony,M35t,M35t,5,-30,1
+sony,M51w,M51w,5,-30,1
+sony,MK16i,MK16i,5,-30,1
+sony,MT25i,MT25i,5,-30,1
+sony,MT27i,MT27i,5,-30,1
+sony,NSZGS7,NSZ-GS7/GX70,5,-30,1
+sony,NSZGU1,NSZ-GU1,5,-30,1
+sony,icx1216,NW-Z1000Series,5,-30,1
+sony,icx1216,NWZ-Z1000Series,5,-30,1
+sony,R800a,R800a,5,-30,1
+sony,R800i,R800i,5,-30,1
+sony,SGP311,SGP311,5,-30,1
+sony,SGP312,SGP312,5,-30,1
+sony,SGP321,SGP321,5,-30,1
+sony,SGP351,SGP351,5,-30,1
+sony,SGP412,SGP412,5,-30,1
+sony,SGP511,SGP511,5,-30,1
+sony,SGP512,SGP512,5,-30,1
+sony,SGP521,SGP521,5,-30,1
+sony,SGP551,SGP551,5,-30,1
+sony,SGP561,SGP561,5,-30,1
+sony,SGP611,SGP611,5,-30,1
+sony,SGP612,SGP612,5,-30,1
+sony,SGP621,SGP621,5,-30,1
+sony,SGP641,SGP641,5,-30,1
+sony,SGP712,SGP712,5,-30,1
+sony,SGP771,SGP771,5,-30,1
+sony,txs03,SGPT12,5,-30,1
+sony,txs03,SGPT13,5,-30,1
+sony,SK17a,SK17a,5,-30,1
+sony,SO-01F,SO-01F,5,-30,1
+sony,SO-01G,SO-01G,5,-30,1
+sony,SO-01H,SO-01H,10,-26,1
+sony,SO-01J,SO-01J,0,-32,3
+sony,SO-01K,SO-01K,9,-29,1
+sony,SO-01L,SO-01L,6,-30,1
+sony,SO-01M,SO-01M,5,-30,1
+sony,SO-02E,SO-02E,5,-30,1
+sony,SO-02F,SO-02F,5,-30,1
+sony,SO-02G,SO-02G,5,-30,1
+sony,SO-02H,SO-02H,5,-30,1
+sony,SO-02J,SO-02J,5,-30,1
+sony,SO-02K,SO-02K,5,-24,1
+sony,SO-02L,SO-02L,5,-30,1
+sony,SO-03D,SO-03D,5,-30,1
+sony,SO-03F,SO-03F,5,-30,1
+sony,SO-03G,SO-03G,5,-30,1
+sony,SO-03H,SO-03H,5,-30,1
+sony,SO-03J,SO-03J,-1,-33,3
+sony,SO-03K,SO-03K,6,-31,1
+sony,SO-03L,SO-03L,5,-30,1
+sony,SO-04E,SO-04E,5,-30,1
+sony,SO-04F,SO-04F,5,-30,1
+sony,SO-04G,SO-04G,5,-30,1
+sony,SO-04H,SO-04H,-1,-32,1
+sony,SO-04J,SO-04J,10,-30,3
+sony,SO-04K,SO-04K,5,-30,1
+sony,SO-05F,SO-05F,5,-30,1
+sony,SO-05G,SO-05G,5,-30,1
+sony,SO-05K,SO-05K,9,-33,1
+sony,SO-51A,SO-51A,5,-30,1
+sony,SOG01,SOG01,5,-30,1
+sony,SOL23,SOL23,5,-30,1
+sony,SOL24,SOL24,5,-30,1
+sony,SOL25,SOL25,5,-30,1
+sony,SOL26,SOL26,5,-30,1
+sony,SOT21,SOT21,5,-30,1
+sony,SOT31,SOT31,5,-30,1
+sony,SOV31,SOV31,5,-30,1
+sony,SOV32,SOV32,10,-26,1
+sony,SOV33,SOV33,-3,-33,3
+sony,SOV34,SOV34,-2,-32,3
+sony,SOV35,SOV35,-1,-32,1
+sony,SOV36,SOV36,8,-27,3
+sony,SOV37,SOV37,6,-31,1
+sony,SOV38,SOV38,5,-30,1
+sony,SOV39,SOV39,6,-30,1
+sony,SOV40,SOV40,5,-30,1
+sony,SOV41,SOV41,5,-30,1
+sony,SOV42,SOV42,5,-30,1
+sony,SOV42-u,SOV42-u,5,-30,1
+sony,ST17i,ST17i,5,-30,1
+sony,ST18i,ST18i,5,-30,1
+sony,ST21a,ST21a,5,-30,1
+sony,ST21a2,ST21a2,5,-30,1
+sony,ST21i,ST21i,5,-30,1
+sony,ST21i2,ST21i2,5,-30,1
+sony,ST23a,ST23a,5,-30,1
+sony,ST23i,ST23i,5,-30,1
+sony,ST25a,ST25a,5,-30,1
+sony,ST25i,ST25i,5,-30,1
+sony,ST26a,ST26a,5,-30,1
+sony,ST26i,ST26i,5,-30,1
+sony,ST27a,ST27a,5,-30,1
+sony,ST27i,ST27i,5,-30,1
+sony,tetra,SmartWatch 3,5,-30,1
+sony,nbx02,Sony Tablet P,5,-30,1
+sony,nbx03,Sony Tablet S,5,-30,1
+sony,icx1237,WALKMAN,5,-30,1
+sony,icx1227,WALKMAN,5,-30,1
+sony,icx1265,WALKMAN,5,-30,1
+sony,icx1240,WALKMAN,5,-30,1
+sony,WT19a,WT19a,5,-30,1
+sony,WT19i,WT19i,5,-30,1
+sony,XL39h,XL39h,5,-30,1
+sony,XQ-AD51,XQ-AD51,5,-30,1
+sony,XQ-AD52,XQ-AD52,5,-30,1
+sony,XQ-AU52,XQ-AU52,5,-30,1
+sprint,htc_acawhl,2PYB2,10,-27,3
+sprint,NKJ_AQT100,AQT100,10,-27,1
+sprint,NKS_AQT80,AQT80,10,-27,1
+sprint,NKSA_AQT82,AQT82,10,-27,1
+tct (alcatel),Pixi3-4,4003A,3,-24,1
+tct (alcatel),Pixi3-4,4003J,3,-24,1
+tct (alcatel),PIXI3_35,4009A,3,-24,1
+tct (alcatel),PIXI3_35,4009D,3,-24,1
+tct (alcatel),PIXI3_35,4009E,3,-24,1
+tct (alcatel),PIXI3_35,4009F,3,-24,1
+tct (alcatel),PIXI3_35,4009K,3,-24,1
+tct (alcatel),PIXI3_35,4009M,3,-24,1
+tct (alcatel),PIXI3_35,4009S,3,-24,1
+tct (alcatel),PIXI3_35,4009X,3,-24,1
+tct (alcatel),Pixi3-4,4013D,3,-24,1
+tct (alcatel),Pixi3-4,4013E,3,-24,1
+tct (alcatel),Pixi3-4,4013J,3,-24,1
+tct (alcatel),Pixi3-4,4013K,3,-24,1
+tct (alcatel),Pixi3-4,4013M,3,-24,1
+tct (alcatel),Pixi3-4,4013X,3,-24,1
+tct (alcatel),Pixi3-4,4014A,3,-24,1
+tct (alcatel),Pixi3-4,4014E,3,-24,1
+tct (alcatel),Pixi3-4,4014M,3,-24,1
+tct (alcatel),Yaris35_GSM,4016D,3,-24,1
+tct (alcatel),PIXI4-35,4017A,3,-24,1
+tct (alcatel),PIXI4-35,4017D,3,-24,1
+tct (alcatel),PIXI4-35,4017F,3,-24,1
+tct (alcatel),PIXI4-35,4017S,3,-24,1
+tct (alcatel),PIXI4-35,4017X,3,-24,1
+tct (alcatel),SOUL35,4018A,3,-24,1
+tct (alcatel),SOUL35,4018D,3,-24,1
+tct (alcatel),SOUL35,4018E,3,-24,1
+tct (alcatel),SOUL35,4018F,3,-24,1
+tct (alcatel),SOUL35,4018M,3,-24,1
+tct (alcatel),SOUL35,4018X,3,-24,1
+tct (alcatel),PLAY_P1,4024D,3,-24,1
+tct (alcatel),PLAY_P1,4024E,3,-24,1
+tct (alcatel),PLAY_P1,4024X,3,-24,1
+tct (alcatel),Pixi3-45,4027A,3,-24,1
+tct (alcatel),Pixi3-45,4027D,3,-24,1
+tct (alcatel),Pixi3-45,4027N,3,-24,1
+tct (alcatel),Pixi3-45,4027X,3,-24,1
+tct (alcatel),Pixi3-45,4028A,3,-24,1
+tct (alcatel),Pixi3-45,4028E,3,-24,1
+tct (alcatel),Pixi3-45,4028J,3,-24,1
+tct (alcatel),Pixi3-45,4028S,3,-24,1
+tct (alcatel),Yaris_M_GSM,4032A,3,-24,1
+tct (alcatel),Yaris_M_GSM,4032D,3,-24,1
+tct (alcatel),Yaris_M_GSM,4032E,3,-24,1
+tct (alcatel),Yaris_M_GSM,4032X,3,-24,1
+tct (alcatel),Yaris_M_GSM,4033L,3,-24,1
+tct (alcatel),Pixi4-4,4034A,3,-24,1
+tct (alcatel),Pixi4-4,4034D,3,-24,1
+tct (alcatel),Pixi4-4,4034E,3,-24,1
+tct (alcatel),Pixi4-4,4034F,3,-24,1
+tct (alcatel),Pixi4-4,4034G,3,-24,1
+tct (alcatel),PIXI4-4C_GO,4034L,3,-24,1
+tct (alcatel),PIXI4-4C_GO,4034L_EEA,3,-24,1
+tct (alcatel),PIXI4-4C_GO,4034T,3,-24,1
+tct (alcatel),Pixi4-4,4034X,3,-24,1
+tct (alcatel),SOUL4,4035A,3,-24,1
+tct (alcatel),SOUL4,4035D,3,-24,1
+tct (alcatel),SOUL4,4035X,3,-24,1
+tct (alcatel),SOUL4,4035X_Orange,3,-24,1
+tct (alcatel),SOUL4,4035Y,3,-24,1
+tct (alcatel),SOUL4,4036E,3,-24,1
+tct (alcatel),alto4_8g,4045A,3,-24,1
+tct (alcatel),alto4,4045A,3,-24,1
+tct (alcatel),alto4_8g,4045D,3,-24,1
+tct (alcatel),alto4_8g,4045L,3,-24,1
+tct (alcatel),alto4_8g,4045O,3,-24,1
+tct (alcatel),alto4_8g,4045X,3,-24,1
+tct (alcatel),U5_3G,4047A,3,-24,1
+tct (alcatel),U5_3G,4047D,3,-24,1
+tct (alcatel),U5_3G,4047F,3,-24,1
+tct (alcatel),U5_3G,4047G,3,-24,1
+tct (alcatel),U5_3G,4047N,3,-24,1
+tct (alcatel),U5_3G,4047X,3,-24,1
+tct (alcatel),U3_3G,4049D,3,-24,1
+tct (alcatel),U3_3G,4049E,3,-24,1
+tct (alcatel),U3_3G,4049G,3,-24,1
+tct (alcatel),U3_3G,4049M,3,-24,1
+tct (alcatel),U3_3G,4049X,3,-24,1
+tct (alcatel),U3,4055A,3,-24,1
+tct (alcatel),U3,4055I,3,-24,1
+tct (alcatel),U3,4055J,3,-24,1
+tct (alcatel),U3,4055Q,3,-24,1
+tct (alcatel),U3,4055T,3,-24,1
+tct (alcatel),U3,4055U,3,-24,1
+tct (alcatel),Pixi445CAN,4060S,3,-24,1
+tct (alcatel),Pixi445,4060W,3,-24,1
+tct (alcatel),Pixi3-4,4114E,3,-24,1
+tct (alcatel),Wright,5001A,3,-24,1
+tct (alcatel),Wright,5001D_EEA,3,-24,1
+tct (alcatel),Wright,5001D_RU,3,-24,1
+tct (alcatel),Wright,5001J,3,-24,1
+tct (alcatel),Wright,5001T,3,-24,1
+tct (alcatel),Wright,5001U,3,-24,1
+tct (alcatel),Seoul,5002A,3,-24,1
+tct (alcatel),Seoul,5002D,3,-24,1
+tct (alcatel),Seoul,5002D_EEA,3,-24,1
+tct (alcatel),Seoul,5002D_RU,3,-24,1
+tct (alcatel),Seoul,5002D_TR,3,-24,1
+tct (alcatel),Seoul,5002F,3,-24,1
+tct (alcatel),Seoul,5002F_RU,3,-24,1
+tct (alcatel),Seoul,5002I,3,-24,1
+tct (alcatel),Seoul,5002J,3,-24,1
+tct (alcatel),Seoul,5002L,3,-24,1
+tct (alcatel),Seoul,5002M,3,-24,1
+tct (alcatel),Seoul,5002S,3,-24,1
+tct (alcatel),Seoul,5002U,3,-24,1
+tct (alcatel),Seoul,5002X,3,-24,1
+tct (alcatel),Seoul,5002X_EEA,3,-24,1
+tct (alcatel),Curie,5003D,3,-24,1
+tct (alcatel),Curie,5003D_EEA,3,-24,1
+tct (alcatel),5006,5006A,3,-24,1
+tct (alcatel),5006,5006G,3,-24,1
+tct (alcatel),Tokyo_Lite,5007A,3,-24,1
+tct (alcatel),Tokyo_Lite,5007G,3,-24,1
+tct (alcatel),Tokyo_CAN,5007O,3,-24,1
+tct (alcatel),Tokyo_Lite,5007U,3,-24,1
+tct (alcatel),Tokyo_Lite,5007U_EEA,3,-24,1
+tct (alcatel),Tokyo_Lite,5007U_RU,3,-24,1
+tct (alcatel),Tokyo_Lite,5007U_TR,3,-24,1
+tct (alcatel),Edison,5008A,3,-24,1
+tct (alcatel),Edison,5008D,3,-24,1
+tct (alcatel),Edison,5008D_EEA,3,-24,1
+tct (alcatel),Edison_CKT,5008R,3,-24,1
+tct (alcatel),Edison,5008T,3,-24,1
+tct (alcatel),Edison,5008U,3,-24,1
+tct (alcatel),Edison,5008Y,3,-24,1
+tct (alcatel),Edison,5008Y_EEA,3,-24,1
+tct (alcatel),Edison,5008Y_RU,3,-24,1
+tct (alcatel),U5A_PLUS_3G,5009A,3,-24,1
+tct (alcatel),U5A_PLUS_3G,5009D,3,-24,1
+tct (alcatel),U5A_PLUS_3G,5009D_RU,3,-24,1
+tct (alcatel),U5A_PLUS_3G,5009U,3,-24,1
+tct (alcatel),Pixi4-5,5010D,3,-24,1
+tct (alcatel),Pixi4-5,5010E,3,-24,1
+tct (alcatel),Pixi4-5,5010G,3,-24,1
+tct (alcatel),Pixi4-5,5010S,3,-24,1
+tct (alcatel),Pixi4-5,5010U,3,-24,1
+tct (alcatel),Pixi4-5,5010X,3,-24,1
+tct (alcatel),BUZZ6_55,5011A,3,-24,1
+tct (alcatel),PIXI4_55_3G,5012D,3,-24,1
+tct (alcatel),PIXI4_55_3G,5012F,3,-24,1
+tct (alcatel),PIXI4_55_3G,5012G,3,-24,1
+tct (alcatel),PIXI3-5,5015A,3,-24,1
+tct (alcatel),PIXI3-5,5015D,3,-24,1
+tct (alcatel),PIXI3-5,5015E,3,-24,1
+tct (alcatel),PIXI3-5,5015X,3,-24,1
+tct (alcatel),PIXI3-5,5016A,3,-24,1
+tct (alcatel),PIXI3-5,5016J,3,-24,1
+tct (alcatel),PIXI3_45_4G,5017A,5,-29,1
+tct (alcatel),Pixi3454GSPR,5017B,3,-24,1
+tct (alcatel),PIXI3_45_4G,5017D,5,-29,1
+tct (alcatel),PIXI3_45_4G,5017E,5,-29,1
+tct (alcatel),PIXI3_45_4G,5017O,5,-29,3
+tct (alcatel),PIXI3_45_4G,5017X,5,-29,1
+tct (alcatel),PIXI3_45_4G,5019D,5,-29,1
+tct (alcatel),Pixi4PlusPower,5023E,3,-24,1
+tct (alcatel),Pixi4PlusPower,5023F,3,-24,1
+tct (alcatel),Faraday,5024A,3,-24,1
+tct (alcatel),Faraday,5024D,3,-24,1
+tct (alcatel),Faraday,5024D_EEA,3,-24,1
+tct (alcatel),Faraday,5024D_RU,3,-24,1
+tct (alcatel),Faraday,5024F,3,-24,1
+tct (alcatel),Faraday,5024F_EEA,3,-24,1
+tct (alcatel),Faraday,5024I,3,-24,1
+tct (alcatel),Faraday,5024J,3,-24,1
+tct (alcatel),PIXI3-55,5025D,3,-24,1
+tct (alcatel),PIXI3-55,5025E,3,-24,1
+tct (alcatel),PIXI3-55,5025G,3,-24,1
+tct (alcatel),PIXI3-55,5025X,3,-24,1
+tct (alcatel),A3A_XL_3G,5026A,3,-24,1
+tct (alcatel),A3A_XL_3G,5026D,3,-24,1
+tct (alcatel),A3A_XL_3G,5026J,3,-24,1
+tct (alcatel),Pixi445SPR,5027B,3,-24,1
+tct (alcatel),Tokyo,5028A,3,-24,1
+tct (alcatel),Tokyo,5028D,3,-24,1
+tct (alcatel),Tokyo,5028D_EEA,3,-24,1
+tct (alcatel),Tokyo,5028D_RU,3,-24,1
+tct (alcatel),Tokyo,5028D_TR,3,-24,1
+tct (alcatel),Tokyo,5028Y,3,-24,1
+tct (alcatel),Tokyo,5028Y_EEA,3,-24,1
+tct (alcatel),Tokyo,5028Y_RU,3,-24,1
+tct (alcatel),TokyoPro,5029A,3,-24,1
+tct (alcatel),TokyoPro,5029D,3,-24,1
+tct (alcatel),TokyoPro,5029D_EEA,3,-24,1
+tct (alcatel),TokyoPro,5029D_RU,3,-24,1
+tct (alcatel),TokyoPro,5029D_TR,3,-24,1
+tct (alcatel),TokyoPro,5029E,3,-24,1
+tct (alcatel),TokyoPro,5029Y,3,-24,1
+tct (alcatel),TokyoPro,5029Y_EEA,3,-24,1
+tct (alcatel),TokyoPro,5029Y_RU,3,-24,1
+tct (alcatel),Jakarta,5030D,3,-24,1
+tct (alcatel),Jakarta,5030D_EEA,3,-24,1
+tct (alcatel),Jakarta,5030D_RU,3,-24,1
+tct (alcatel),Jakarta,5030F,3,-24,1
+tct (alcatel),Jakarta,5030F_EEA,3,-24,1
+tct (alcatel),Jakarta,5030F_TR,3,-24,1
+tct (alcatel),Jakarta,5030I,3,-24,1
+tct (alcatel),Jakarta,5030J,3,-24,1
+tct (alcatel),Jakarta,5030U,3,-24,1
+tct (alcatel),Morgan_4G,5032W,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033A,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033D,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033D_EEA,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033D_RU,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033F,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033F_EEA,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033G,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033G_EEA,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033J,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033M,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033O,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033S,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033T,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033X,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033X_EEA,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033Y,3,-24,1
+tct (alcatel),U3A_PLUS_4G,5033Y_EEA,3,-24,1
+tct (alcatel),A3A_LITE,5034D,3,-24,1
+tct (alcatel),A3A_LITE,5034D_EEA,3,-24,1
+tct (alcatel),A3A_LITE,5034D_RU,3,-24,1
+tct (alcatel),SOUL45_GSM,5038A,3,-24,1
+tct (alcatel),SOUL45_GSM,5038D,3,-24,1
+tct (alcatel),SOUL45_GSM,5038E,3,-24,1
+tct (alcatel),SOUL45_GSM,5038X,3,-24,1
+tct (alcatel),Benz,5039D,3,-24,1
+tct (alcatel),Benz,5039D_EEA,3,-24,1
+tct (alcatel),Benz,5039D_RU,3,-24,1
+tct (alcatel),Benz,5039U,3,-24,1
+tct (alcatel),Benz,5039Y_RU,3,-24,1
+tct (alcatel),U50A_ATT,5041C,3,-24,1
+tct (alcatel),PIXI4_5_4G,5041D,3,-24,1
+tct (alcatel),Alto45,5042A,3,-24,1
+tct (alcatel),Alto45,5042D,3,-24,1
+tct (alcatel),alto45_latam_b28,5042G,3,-24,1
+tct (alcatel),ALTO45TMO,5042T,3,-24,1
+tct (alcatel),alto45_latam_b28,5042W,3,-24,1
+tct (alcatel),Alto45,5042X,3,-24,1
+tct (alcatel),BUZZ6T4G,5044A,3,-24,1
+tct (alcatel),BUZZ6T4G,5044D,3,-24,1
+tct (alcatel),BUZZ6T4GTELUS,5044G,3,-24,1
+tct (alcatel),BUZZ6T4G,5044I,3,-24,1
+tct (alcatel),BUZZ6T4G,5044K,3,-24,1
+tct (alcatel),BUZZ6T4G,5044O,3,-24,1
+tct (alcatel),BUZZ6T4G,5044P,3,-24,1
+tct (alcatel),BUZZ6T4GTELUS,5044S,3,-24,1
+tct (alcatel),BUZZ6T4G,5044T,3,-24,1
+tct (alcatel),BUZZ6T4G,5044Y,3,-24,1
+tct (alcatel),PIXI4_5_4G,5045A,3,-24,1
+tct (alcatel),PIXI4_5_4G,5045D,3,-24,1
+tct (alcatel),PIXI4_5_4G,5045F,3,-24,1
+tct (alcatel),PIXI4_5_4G,5045G,3,-24,1
+tct (alcatel),PIXI4_5_4G,5045I,3,-24,1
+tct (alcatel),PIXI4_5_4G,5045J,3,-24,1
+tct (alcatel),PIXI4_5_4G,5045T,3,-24,1
+tct (alcatel),PIXI4_5_4G,5045X,3,-24,1
+tct (alcatel),PIXI4_5_4G,5045Y,3,-24,1
+tct (alcatel),mickey6,5046A,3,-24,1
+tct (alcatel),mickey6,5046D,3,-24,1
+tct (alcatel),MICKEY6US,5046G,3,-24,1
+tct (alcatel),mickey6,5046I,3,-24,1
+tct (alcatel),mickey6,5046J,3,-24,1
+tct (alcatel),Mickey6VZW,5046S,3,-24,1
+tct (alcatel),mickey6,5046T,3,-24,1
+tct (alcatel),mickey6,5046U,3,-24,1
+tct (alcatel),mickey6,5046Y,3,-24,1
+tct (alcatel),BUZZ6E,5047D,3,-24,1
+tct (alcatel),BUZZ6E,5047I,3,-24,1
+tct (alcatel),BUZZ6E,5047U,3,-24,1
+tct (alcatel),BUZZ6E,5047Y,3,-24,1
+tct (alcatel),Venice,5048A,3,-24,1
+tct (alcatel),Venice,5048I,3,-24,1
+tct (alcatel),Venice,5048U,3,-24,1
+tct (alcatel),Venice,5048U_EEA,3,-24,1
+tct (alcatel),Venice,5048Y,3,-24,1
+tct (alcatel),Venice,5048Y_EEA,3,-24,1
+tct (alcatel),Venice,5048Y_RU,3,-24,1
+tct (alcatel),Venice,5048Y_TR,3,-24,1
+tct (alcatel),mickey6t,5049E,3,-24,1
+tct (alcatel),mickey6t,5049G,3,-24,1
+tct (alcatel),Mickey6TVZW,5049S,3,-24,1
+tct (alcatel),Mickey6TTMO,5049W,3,-24,1
+tct (alcatel),Mickey6TTMO,5049Z,3,-24,1
+tct (alcatel),RIO_4G,5050A,3,-24,1
+tct (alcatel),RIO_4G,5050S,3,-24,1
+tct (alcatel),RIO_4G,5050X,3,-24,1
+tct (alcatel),RIO_4G,5050Y,3,-24,1
+tct (alcatel),POP45,5051,3,-24,1
+tct (alcatel),POP45,5051A,3,-24,1
+tct (alcatel),POP45,5051D,3,-24,1
+tct (alcatel),POP45,5051J,3,-24,1
+tct (alcatel),POP45,5051M,3,-24,1
+tct (alcatel),POP45,5051T,3,-24,1
+tct (alcatel),POP45,5051X,3,-24,1
+tct (alcatel),A3A,5052A,3,-24,1
+tct (alcatel),A3A,5052D,3,-24,1
+tct (alcatel),A3A,5052D_EEA,3,-24,1
+tct (alcatel),A3A,5052D_RU,3,-24,1
+tct (alcatel),A3A,5052Y,3,-24,1
+tct (alcatel),A3A,5052Y_EEA,3,-24,1
+tct (alcatel),Gauss,5053A,3,-24,1
+tct (alcatel),Gauss,5053D,3,-24,1
+tct (alcatel),Gauss,5053D_EEA,3,-24,1
+tct (alcatel),Gauss,5053K,3,-24,1
+tct (alcatel),Gauss,5053K_EEA,3,-24,1
+tct (alcatel),Gauss,5053K_RU,3,-24,1
+tct (alcatel),Gauss,5053Y,3,-24,1
+tct (alcatel),Gauss,5053Y_EEA,3,-24,1
+tct (alcatel),Gauss,5053Y_RU,3,-24,1
+tct (alcatel),Pop355,5054A,3,-24,1
+tct (alcatel),Pop355,5054D,3,-24,1
+tct (alcatel),Pop355,5054S,3,-24,1
+tct (alcatel),Pop355,5054T,3,-24,1
+tct (alcatel),Pop355,5054W,3,-24,1
+tct (alcatel),Pop355,5054X,3,-24,1
+tct (alcatel),POP455C,5056,3,-24,1
+tct (alcatel),POP455C,5056A,3,-24,1
+tct (alcatel),POP455C,5056D,3,-24,1
+tct (alcatel),POP455C,5056E,3,-24,1
+tct (alcatel),POP455C,5056G,3,-24,1
+tct (alcatel),POP455C,5056I,3,-24,1
+tct (alcatel),POP455C,5056M,3,-24,1
+tct (alcatel),POP455C,5056N,3,-24,1
+tct (alcatel),POP455C,5056T,3,-24,1
+tct (alcatel),POP455C,5056U,3,-24,1
+tct (alcatel),POP455C,5056W,3,-24,1
+tct (alcatel),POP455C,5056X,3,-24,1
+tct (alcatel),feijao,5057M,3,-24,1
+tct (alcatel),A3A_PLUS,5058A,3,-24,1
+tct (alcatel),A3A_PLUS,5058I,3,-24,1
+tct (alcatel),A3A_PLUS,5058I_RU,3,-24,1
+tct (alcatel),A3A_PLUS,5058J,3,-24,1
+tct (alcatel),A3A_PLUS,5058T,3,-24,1
+tct (alcatel),A3A_PLUS,5058Y,3,-24,1
+tct (alcatel),U5A_PLUS_4G,5059A,1,-20,3
+tct (alcatel),U5A_PLUS_4G,5059D,1,-20,1
+tct (alcatel),U5A_PLUS_4G,5059D_RU,1,-20,1
+tct (alcatel),U5A_PLUS_4G,5059I,1,-20,1
+tct (alcatel),U5A_PLUS_4G,5059J,1,-20,1
+tct (alcatel),U5A_PLUS_4G,5059T,1,-20,1
+tct (alcatel),U5A_PLUS_4G,5059X,1,-20,1
+tct (alcatel),U5A_PLUS_4G,5059Y,1,-20,1
+tct (alcatel),U50APLUSTMO,5059Z,3,-24,1
+tct (alcatel),A5X,5060A,3,-24,1
+tct (alcatel),A5X,5060D,3,-24,1
+tct (alcatel),A5X,5060D_EEA,3,-24,1
+tct (alcatel),A5X,5060D_RU,3,-24,1
+tct (alcatel),A5X,5060J,3,-24,1
+tct (alcatel),Milan,5061A,3,-24,1
+tct (alcatel),Milan,5061K,3,-24,1
+tct (alcatel),Milan,5061K_EEA,3,-24,1
+tct (alcatel),Milan,5061K_RU,3,-24,1
+tct (alcatel),Milan,5061K_TR,3,-24,1
+tct (alcatel),Milan,5061U,3,-24,1
+tct (alcatel),Milan,5061U_EEA,3,-24,1
+tct (alcatel),Milan,5061U_TR,3,-24,1
+tct (alcatel),Pop35,5065A,3,-24,1
+tct (alcatel),Pop35,5065D,3,-24,1
+tct (alcatel),Pop35,5065N,3,-24,1
+tct (alcatel),Pop35,5065W,3,-24,1
+tct (alcatel),Pop35,5065X,3,-24,1
+tct (alcatel),P3-5_4G,5070D,3,-24,1
+tct (alcatel),shine_lite,5080A,3,-24,1
+tct (alcatel),shine_lite,5080D,3,-24,1
+tct (alcatel),shine_lite,5080F,3,-24,1
+tct (alcatel),shine_lite,5080Q,3,-24,1
+tct (alcatel),shine_lite,5080U,3,-24,1
+tct (alcatel),shine_lite,5080X,3,-24,1
+tct (alcatel),ELSA6,5085A,3,-24,1
+tct (alcatel),ELSA6,5085B,3,-24,1
+tct (alcatel),ELSA6,5085D,3,-24,1
+tct (alcatel),elsa6_amz,5085G,3,-24,1
+tct (alcatel),ELSA6,5085H,3,-24,1
+tct (alcatel),ELSA6,5085I,3,-24,1
+tct (alcatel),ELSA6,5085J,3,-24,1
+tct (alcatel),ELSA6,5085N,3,-24,1
+tct (alcatel),elsa6_amz,5085O,3,-24,1
+tct (alcatel),ELSA6,5085Q,3,-24,1
+tct (alcatel),ELSA6,5085Y,3,-24,1
+tct (alcatel),A5A_INFINI,5086A,3,-24,1
+tct (alcatel),A5A_INFINI,5086Y,3,-24,1
+tct (alcatel),ELSA6P,5090A,3,-24,1
+tct (alcatel),ELSA6P,5090I,3,-24,1
+tct (alcatel),ELSA6P,5090Y,3,-24,1
+tct (alcatel),shine_plus,5095I,3,-24,1
+tct (alcatel),shine_plus,5095K,3,-24,1
+tct (alcatel),shine_plus,5095Y,3,-24,1
+tct (alcatel),Pixi4-64GMEX,5098O,3,-24,1
+tct (alcatel),Pixi4-6_4G,5098S,3,-24,1
+tct (alcatel),A3A_XL_4G,5099A,3,-24,1
+tct (alcatel),A3A_XL_4G,5099D,3,-24,1
+tct (alcatel),A3A_XL_4G,5099D_RU,3,-24,1
+tct (alcatel),A3A_XL_4G,5099I,3,-24,1
+tct (alcatel),A3A_XL_4G,5099U,3,-24,1
+tct (alcatel),A3A_XL_4G,5099Y,3,-24,1
+tct (alcatel),PIXI3-5,5116J,3,-24,1
+tct (alcatel),PIXI4_5_4G,5145A,3,-24,1
+tct (alcatel),Pop355,5154A,3,-24,1
+tct (alcatel),shine_plus,562,3,-24,1
+tct (alcatel),Miata_3G,6014X,3,-24,1
+tct (alcatel),Miata_3G,6016A,3,-24,1
+tct (alcatel),Miata_3G,6016D,3,-24,1
+tct (alcatel),Miata_3G,6016E,3,-24,1
+tct (alcatel),Miata_3G,6016X,3,-24,1
+tct (alcatel),MIATA_lte,6036A,3,-24,1
+tct (alcatel),MIATA_lte,6036X,3,-24,1
+tct (alcatel),MIATA_lte,6036Y,3,-24,1
+tct (alcatel),Eclipse,6037B,3,-24,1
+tct (alcatel),Eclipse,6037K,3,-24,1
+tct (alcatel),Eclipse,6037Y,3,-24,1
+tct (alcatel),idol347,6039A,3,-24,1
+tct (alcatel),idol347,6039H,3,-24,1
+tct (alcatel),idol347,6039J,3,-24,1
+tct (alcatel),idol347,6039K,3,-24,1
+tct (alcatel),idol347,6039S,3,-24,1
+tct (alcatel),idol347,6039Y,3,-24,1
+tct (alcatel),CROSSAPAC,6042D,3,-24,1
+tct (alcatel),DIABLOXPLUS,6043A,3,-24,1
+tct (alcatel),DIABLOXPLUS,6043D,3,-24,1
+tct (alcatel),I1-5_4G,6044D,3,-24,1
+tct (alcatel),idol3,6045B,3,-24,1
+tct (alcatel),idol3,6045F,3,-24,1
+tct (alcatel),idol3,6045I,3,-24,1
+tct (alcatel),idol3,6045K,3,-24,1
+tct (alcatel),idol3,6045O,3,-24,1
+tct (alcatel),idol3,6045Y,3,-24,1
+tct (alcatel),EOS_lte,6050A,3,-24,1
+tct (alcatel),EOS_lte,6050F,3,-24,1
+tct (alcatel),EOS_lte,6050W,3,-24,1
+tct (alcatel),EOS4G,6050Y,3,-24,1
+tct (alcatel),EOS_lte,6050Y,3,-24,1
+tct (alcatel),idol4,6055A,3,-24,1
+tct (alcatel),idol4,6055B,3,-24,1
+tct (alcatel),idol4,6055D,3,-24,1
+tct (alcatel),idol4,6055K,3,-24,1
+tct (alcatel),idol4,6055P,3,-24,1
+tct (alcatel),SIMBA6L,6058A,3,-24,1
+tct (alcatel),SIMBA6L,6058D,3,-24,1
+tct (alcatel),SIMBA6L,6058X,3,-24,1
+tct (alcatel),IDOL5S,6060S,3,-24,1
+tct (alcatel),simba6_global,6060X,3,-24,1
+tct (alcatel),A70AXLTMO,6062W,3,-24,1
+tct (alcatel),idol4s,6070K,3,-24,1
+tct (alcatel),idol4s,6070O,3,-24,1
+tct (alcatel),Yaris5TMO,7040N,3,-24,1
+tct (alcatel),Yaris5TMO,7040R,3,-24,1
+tct (alcatel),Yaris5TMO,7040T,3,-24,1
+tct (alcatel),alto5,7043A,3,-24,1
+tct (alcatel),alto5,7043K,3,-24,1
+tct (alcatel),alto5,7043Y,3,-24,1
+tct (alcatel),alto5_premium,7044A,3,-24,1
+tct (alcatel),alto5_premium,7044X,3,-24,1
+tct (alcatel),RIO5,7045Y,3,-24,1
+tct (alcatel),alto5_sporty,7048A,3,-24,1
+tct (alcatel),alto5_sporty,7048S,3,-24,1
+tct (alcatel),alto5_sporty,7048W,3,-24,1
+tct (alcatel),alto5_sporty,7048X,3,-24,1
+tct (alcatel),RIO6_lte,7050Y,3,-24,1
+tct (alcatel),X1,7053D,3,-24,1
+tct (alcatel),Hero2C,7055A,3,-24,1
+tct (alcatel),POP4-6_4G,7070I,3,-24,1
+tct (alcatel),POP4-6_4G,7070Q,3,-24,1
+tct (alcatel),POP4-6_4G,7070X,3,-24,1
+tct (alcatel),POP5-6_4G,7071A,3,-24,1
+tct (alcatel),POP5-6_4G,7071D,3,-24,1
+tct (alcatel),HERO2PLUS,8030B,3,-24,1
+tct (alcatel),HERO2,8030B,3,-24,1
+tct (alcatel),HERO2,8030Y,3,-24,1
+tct (alcatel),Pixi4-6_3G,8050D,3,-24,1
+tct (alcatel),Pixi4-6_3G,8050E,3,-24,1
+tct (alcatel),Pixi4-6_3G,8050G,3,-24,1
+tct (alcatel),Pixi4-6_3G,8050X,3,-24,1
+tct (alcatel),Hulk_7_GL_WIFI,8051,3,-24,1
+tct (alcatel),Hulk_7_GL_WIFI,8051_EEA,3,-24,1
+tct (alcatel),Hulk_7_GL_WIFI,8051_RU,3,-24,1
+tct (alcatel),Hulk_7_KIDS_WIFI,8052,3,-24,1
+tct (alcatel),Hulk_7_KIDS_WIFI,8052_EEA,3,-24,1
+tct (alcatel),Hulk_7_KIDS_WIFI,8052_RU,3,-24,1
+tct (alcatel),Pixi3-7,8053,3,-24,1
+tct (alcatel),Pixi3-7,8054,3,-24,1
+tct (alcatel),Pixi3-7,8055,3,-24,1
+tct (alcatel),Pixi3-7,8056,3,-24,1
+tct (alcatel),Pixi3-7,8057,3,-24,1
+tct (alcatel),Pixi4-7_WIFI,8062,3,-24,1
+tct (alcatel),Pixi4-7_WIFI,8063,3,-24,1
+tct (alcatel),U3A_7_WIFI,8068,3,-24,1
+tct (alcatel),Pixi3-8_WIFI,8070,3,-24,1
+tct (alcatel),Pixi3-10_WiFi,8079,3,-24,1
+tct (alcatel),Pixi3-10_WiFi,8080,3,-24,1
+tct (alcatel),U3A_10_WIFI,8082,3,-24,1
+tct (alcatel),U3A_10_WIFI_P,8084,3,-24,1
+tct (alcatel),U3A_10_WIFI_P,8084_EEA,3,-24,1
+tct (alcatel),A3A_10_4G,8088G,3,-24,1
+tct (alcatel),A3A_10_4G,8088M,3,-24,1
+tct (alcatel),A3A_10_4G,8088X,3,-24,1
+tct (alcatel),Pixi4-7_WIFI,8262,3,-24,1
+tct (alcatel),Pixi4-6_4G,9001D,3,-24,1
+tct (alcatel),Pixi4-6_4G,9001I,3,-24,1
+tct (alcatel),Pixi4-6_4G,9001X,3,-24,1
+tct (alcatel),Pixi3-7_3G,9002A,3,-24,1
+tct (alcatel),Pixi3-7_3G,9002W,3,-24,1
+tct (alcatel),Pixi3-7_3G,9002X,3,-24,1
+tct (alcatel),Pixi4-7_3G,9003A,3,-24,1
+tct (alcatel),Pixi4-7_3G,9003X,3,-24,1
+tct (alcatel),PIXO8_3G,9005X,3,-24,1
+tct (alcatel),Pixi2-7_4G_TMO,9006W,3,-24,1
+tct (alcatel),pixi37,9007A,3,-24,1
+tct (alcatel),Pixi3-7_4G_EE,9007X,3,-24,1
+tct (alcatel),pixi37,9007X,3,-24,1
+tct (alcatel),PIXI5-6_4G,9008A,3,-24,1
+tct (alcatel),PIXI5-6_4G,9008D,3,-24,1
+tct (alcatel),PIXI5-6_4G,9008I,3,-24,1
+tct (alcatel),PIXI5-6_4G,9008J,3,-24,1
+tct (alcatel),PIXI5-6_4G,9008N,3,-24,1
+tct (alcatel),PIXI5-6_4G,9008T,3,-24,1
+tct (alcatel),PIXI5-6_4G,9008U,3,-24,1
+tct (alcatel),PIXI5-6_4G,9008X,3,-24,1
+tct (alcatel),U3A_7_3G,9009A,3,-24,1
+tct (alcatel),U3A_7_3G,9009G,3,-24,1
+tct (alcatel),Pixi3-10_3G,9010X,3,-24,1
+tct (alcatel),King_Kong_7_4G,9013A,3,-24,1
+tct (alcatel),King_Kong_7_4G,9013T,3,-24,1
+tct (alcatel),King_Kong_7_4G,9013X,3,-24,1
+tct (alcatel),King_Kong_7_4G,9013X_EEA,3,-24,1
+tct (alcatel),Pixi4-7_4G_NA,9015B,3,-24,1
+tct (alcatel),Pixi4-7_4G_Telus,9015B,3,-24,1
+tct (alcatel),Pixi4-7_4G_Rogers,9015B,3,-24,1
+tct (alcatel),Pixi4-7_4G_Bell,9015B,3,-24,1
+tct (alcatel),PIXI4-7_4G,9015J,3,-24,1
+tct (alcatel),PIXI4-7_4G,9015Q,3,-24,1
+tct (alcatel),PIXI4-7_4G,9015U,3,-24,1
+tct (alcatel),Pixi4-7_4G_TMO,9015W,3,-24,1
+tct (alcatel),Pop2-8_4G_Telus,9021A,3,-24,1
+tct (alcatel),pixi384g,9022S,3,-24,1
+tct (alcatel),pixi384g,9022X,3,-24,1
+tct (alcatel),PIXI5-8_4G_Telus,9024O,3,-24,1
+tct (alcatel),PIXI5-8_4G_TMO,9024W,3,-24,1
+tct (alcatel),POP4-7_4G,9025Q,3,-24,1
+tct (alcatel),Pixi5-10_4G,9026T,3,-24,1
+tct (alcatel),Pixi5-10_4G,9026X,3,-24,1
+tct (alcatel),A3A_8_4G,9027F,3,-24,1
+tct (alcatel),A3A_8_4G,9027G,3,-24,1
+tct (alcatel),A3A_8_4G,9027Q,3,-24,1
+tct (alcatel),A3A_8_4G,9027T,3,-24,1
+tct (alcatel),A3A_8_4G_TMO,9027W,3,-24,1
+tct (alcatel),A3A_8_4G,9027X,3,-24,1
+tct (alcatel),EasyTAB8TMO,9029G,3,-24,1
+tct (alcatel),EasyTAB8TMO,9029W,3,-24,1
+tct (alcatel),EasyTAB8MPCS,9029Z,3,-24,1
+tct (alcatel),POP4-10_4G,9030G,3,-24,1
+tct (alcatel),POP4-10_4G,9030Q,3,-24,1
+tct (alcatel),Apollo_8_4G,9032X_EEA,3,-24,1
+tct (alcatel),PIXI5-6_4G,9108A,3,-24,1
+tct (alcatel),Pixi5-7_3G,9203A,3,-24,1
+tct (alcatel),ALTO45_TF,A450TL,3,-24,1
+tct (alcatel),PIXI3_4TF,A460G,3,-24,1
+tct (alcatel),PIXI3_4TF,A460T,3,-24,1
+tct (alcatel),Pixi3-35TF,A463BG,3,-24,1
+tct (alcatel),Pixi3-35TF,A464BG,3,-24,1
+tct (alcatel),PIXI4_4TF,A466BG,3,-24,1
+tct (alcatel),PIXI4_4TF,A466T,3,-24,1
+tct (alcatel),FERMI_TF,A501DL,3,-24,1
+tct (alcatel),U50A_PLUS_TF,A502DL,3,-24,1
+tct (alcatel),EDISON_TF,A503DL,3,-24,1
+tct (alcatel),Seoul_TF,A507DL,3,-24,1
+tct (alcatel),Tokyo_TF,A508DL,3,-24,1
+tct (alcatel),Alto4EVDO,A520L,3,-24,1
+tct (alcatel),Alto4NA,A521L,3,-24,1
+tct (alcatel),A554C,A554C,3,-24,1
+tct (alcatel),A556C,A556C,3,-24,1
+tct (alcatel),Pop445,A570BL,3,-24,1
+tct (alcatel),Pixi445TFVZW,A571VL,3,-24,1
+tct (alcatel),Pop445,A572BG,3,-24,1
+tct (alcatel),Pixi445EVDO,A573VC,3,-24,1
+tct (alcatel),BUZZ6T4GTFUMTS,A574BL,3,-24,1
+tct (alcatel),Mickey6TFUMTS,A576BL,3,-24,1
+tct (alcatel),Mickey6CC,A576CC,3,-24,1
+tct (alcatel),Mickey6RW,A576RW,3,-24,1
+tct (alcatel),Mickey6TFEVDO,A577VL,3,-24,1
+tct (alcatel),Pop355,A621BL,3,-24,1
+tct (alcatel),Pop355,A621R,3,-24,1
+tct (alcatel),Pixi3554GEVDO,A622GL,3,-24,1
+tct (alcatel),Pixi3554GEVDO,A622VL,3,-24,1
+tct (alcatel),Alto5TF,A846L,3,-24,1
+tct (alcatel),RadioShack,ADR3010,3,-24,1
+tct (alcatel),ONE_TOUCH_960C,ADR3010,3,-24,1
+tct (alcatel),Yaris35_GSM,ALCATEL 4015T,3,-24,1
+tct (alcatel),Yaris5NA,ALCATEL A564C,3,-24,1
+tct (alcatel),Yaris5NA,ALCATEL A564R,3,-24,1
+tct (alcatel),RIO4G_TF,ALCATEL A845L,3,-24,1
+tct (alcatel),RIO6_lte,ALCATEL A995L,3,-24,1
+tct (alcatel),Beetle_Lite_Edge_GSM,ALCATEL ONE TOUCH 4005D,3,-24,1
+tct (alcatel),Beetle_Lite_GSM,ALCATEL ONE TOUCH 4010A,3,-24,1
+tct (alcatel),Beetle_Lite_GSM,ALCATEL ONE TOUCH 4010D,3,-24,1
+tct (alcatel),Beetle_Lite_GSM,ALCATEL ONE TOUCH 4010E,3,-24,1
+tct (alcatel),Beetle_Lite_GSM,ALCATEL ONE TOUCH 4010X,3,-24,1
+tct (alcatel),Pixi3-45,ALCATEL ONE TOUCH 4027A,3,-24,1
+tct (alcatel),Beetle_GSM,ALCATEL ONE TOUCH 4029A,3,-24,1
+tct (alcatel),Beetle_GSM,ALCATEL ONE TOUCH 4030D,3,-24,1
+tct (alcatel),Beetle_GSM,ALCATEL ONE TOUCH 4030E,3,-24,1
+tct (alcatel),Beetle_GSM,ALCATEL ONE TOUCH 4030X,3,-24,1
+tct (alcatel),Beetle_GSM,ALCATEL ONE TOUCH 4030Y,3,-24,1
+tct (alcatel),Beetle_GSM,ALCATEL ONE TOUCH 4030Y_orange,3,-24,1
+tct (alcatel),SOUL4NA,ALCATEL ONE TOUCH 4037N,3,-24,1
+tct (alcatel),SOUL4NA,ALCATEL ONE TOUCH 4037R,3,-24,1
+tct (alcatel),SOUL4NA,ALCATEL ONE TOUCH 4037T,3,-24,1
+tct (alcatel),Megane_GSM,ALCATEL ONE TOUCH 5020A,3,-24,1
+tct (alcatel),Megane_GSM,ALCATEL ONE TOUCH 5020D,3,-24,1
+tct (alcatel),Megane_GSM,ALCATEL ONE TOUCH 5020E,3,-24,1
+tct (alcatel),Megane,ALCATEL ONE TOUCH 5020N,3,-24,1
+tct (alcatel),Megane_GSM,ALCATEL ONE TOUCH 5020T,3,-24,1
+tct (alcatel),Megane,ALCATEL ONE TOUCH 5020T,3,-24,1
+tct (alcatel),Megane_GSM,ALCATEL ONE TOUCH 5020W,3,-24,1
+tct (alcatel),Megane_GSM,ALCATEL ONE TOUCH 5020X,3,-24,1
+tct (alcatel),Megane_GSM,ALCATEL ONE TOUCH 5021E,3,-24,1
+tct (alcatel),Camry_GSM,ALCATEL ONE TOUCH 5035A,3,-24,1
+tct (alcatel),Camry_GSM,ALCATEL ONE TOUCH 5035D,3,-24,1
+tct (alcatel),Camry_GSM,ALCATEL ONE TOUCH 5035E,3,-24,1
+tct (alcatel),Camry_GSM,ALCATEL ONE TOUCH 5035X,3,-24,1
+tct (alcatel),YarisL_GSM,ALCATEL ONE TOUCH 5036A,3,-24,1
+tct (alcatel),YarisL_GSM,ALCATEL ONE TOUCH 5036D,3,-24,1
+tct (alcatel),YarisL_GSM,ALCATEL ONE TOUCH 5036F,3,-24,1
+tct (alcatel),YarisL_GSM,ALCATEL ONE TOUCH 5036X,3,-24,1
+tct (alcatel),YarisL_GSM,ALCATEL ONE TOUCH 5037A,3,-24,1
+tct (alcatel),YarisL_GSM,ALCATEL ONE TOUCH 5037E,3,-24,1
+tct (alcatel),YarisL_GSM,ALCATEL ONE TOUCH 5037X,3,-24,1
+tct (alcatel),Telsa,ALCATEL ONE TOUCH 6010,3,-24,1
+tct (alcatel),Telsa,ALCATEL ONE TOUCH 6010A,3,-24,1
+tct (alcatel),Telsa,ALCATEL ONE TOUCH 6010D,3,-24,1
+tct (alcatel),Telsa,ALCATEL ONE TOUCH 6010X,3,-24,1
+tct (alcatel),Telsa,ALCATEL ONE TOUCH 6010X-orange,3,-24,1
+tct (alcatel),California,ALCATEL ONE TOUCH 6012D,3,-24,1
+tct (alcatel),California,ALCATEL ONE TOUCH 6012X,3,-24,1
+tct (alcatel),Diablo,ALCATEL ONE TOUCH 6030A,3,-24,1
+tct (alcatel),Diablo,ALCATEL ONE TOUCH 6030D,3,-24,1
+tct (alcatel),Diablo,ALCATEL ONE TOUCH 6030N,3,-24,1
+tct (alcatel),Diablo,ALCATEL ONE TOUCH 6030X,3,-24,1
+tct (alcatel),Diablo,ALCATEL ONE TOUCH 6030X-orange,3,-24,1
+tct (alcatel),Alpha,ALCATEL ONE TOUCH 6032,3,-24,1
+tct (alcatel),Alpha,ALCATEL ONE TOUCH 6032A,3,-24,1
+tct (alcatel),Alpha,ALCATEL ONE TOUCH 6032X,3,-24,1
+tct (alcatel),DiabloHD,ALCATEL ONE TOUCH 6033A,3,-24,1
+tct (alcatel),DiabloHD,ALCATEL ONE TOUCH 6033M,3,-24,1
+tct (alcatel),DiabloHD,ALCATEL ONE TOUCH 6033X,3,-24,1
+tct (alcatel),Diablo_LTE,ALCATEL ONE TOUCH 6034L,3,-24,1
+tct (alcatel),Diablo_LTE,ALCATEL ONE TOUCH 6034M,3,-24,1
+tct (alcatel),Diablo_LTE,ALCATEL ONE TOUCH 6034R,3,-24,1
+tct (alcatel),Diablo_LTE,ALCATEL ONE TOUCH 6034Y,3,-24,1
+tct (alcatel),DiabloHD_LTE,ALCATEL ONE TOUCH 6035L,3,-24,1
+tct (alcatel),DiabloHD_LTE,ALCATEL ONE TOUCH 6035R,3,-24,1
+tct (alcatel),Eclipse,ALCATEL ONE TOUCH 6037B,3,-24,1
+tct (alcatel),DIABLOX,ALCATEL ONE TOUCH 6040A,3,-24,1
+tct (alcatel),DIABLOX,ALCATEL ONE TOUCH 6040D,3,-24,1
+tct (alcatel),DIABLOX,ALCATEL ONE TOUCH 6040E,3,-24,1
+tct (alcatel),DIABLOX,ALCATEL ONE TOUCH 6040X,3,-24,1
+tct (alcatel),EOS4G,ALCATEL ONE TOUCH 6050Y,3,-24,1
+tct (alcatel),EOS_lte,ALCATEL ONE TOUCH 6050Y,3,-24,1
+tct (alcatel),Rav4,ALCATEL ONE TOUCH 7024N,3,-24,1
+tct (alcatel),Rav4,ALCATEL ONE TOUCH 7024R,3,-24,1
+tct (alcatel),Rav4,ALCATEL ONE TOUCH 7024W,3,-24,1
+tct (alcatel),Rav4,ALCATEL ONE TOUCH 7025D,3,-24,1
+tct (alcatel),YARISXL,ALCATEL ONE TOUCH 7040A,3,-24,1
+tct (alcatel),YARISXL,ALCATEL ONE TOUCH 7040D,3,-24,1
+tct (alcatel),YARISXL,ALCATEL ONE TOUCH 7040E,3,-24,1
+tct (alcatel),YARISXL,ALCATEL ONE TOUCH 7040K,3,-24,1
+tct (alcatel),YARISXL,ALCATEL ONE TOUCH 7040X,3,-24,1
+tct (alcatel),YARISXL,ALCATEL ONE TOUCH 7041D,3,-24,1
+tct (alcatel),YARISXL,ALCATEL ONE TOUCH 7041X,3,-24,1
+tct (alcatel),YARISXL,ALCATEL ONE TOUCH 7042A,3,-24,1
+tct (alcatel),YARISXL,ALCATEL ONE TOUCH 7042D,3,-24,1
+tct (alcatel),YARISXL,ALCATEL ONE TOUCH 7042E,3,-24,1
+tct (alcatel),YARIS_55,ALCATEL ONE TOUCH 7047A,3,-24,1
+tct (alcatel),YARIS_55,ALCATEL ONE TOUCH 7047D,3,-24,1
+tct (alcatel),YARIS_55,ALCATEL ONE TOUCH 7047E,3,-24,1
+tct (alcatel),YARIS_55,ALCATEL ONE TOUCH 7047X,3,-24,1
+tct (alcatel),Scribe5_gsm,ALCATEL ONE TOUCH 8000A,3,-24,1
+tct (alcatel),Scribe5_gsm,ALCATEL ONE TOUCH 8000D,3,-24,1
+tct (alcatel),Scribe5HD,ALCATEL ONE TOUCH 8008D,3,-24,1
+tct (alcatel),Scribe5HD,ALCATEL ONE TOUCH 8008X,3,-24,1
+tct (alcatel),SCRIBEPRO,ALCATEL ONE TOUCH 8020A,3,-24,1
+tct (alcatel),SCRIBEPRO,ALCATEL ONE TOUCH 8020D,3,-24,1
+tct (alcatel),SCRIBEPRO,ALCATEL ONE TOUCH 8020E,3,-24,1
+tct (alcatel),SCRIBEPRO,ALCATEL ONE TOUCH 8020X,3,-24,1
+tct (alcatel),Pixi3-7_3G,ALCATEL ONE TOUCH 9002A,3,-24,1
+tct (alcatel),one_touch_903_gsm,ALCATEL ONE TOUCH 903,3,-24,1
+tct (alcatel),one_touch_903A_gsm,ALCATEL ONE TOUCH 903A,3,-24,1
+tct (alcatel),one_touch_903D_gsm,ALCATEL ONE TOUCH 903D,3,-24,1
+tct (alcatel),one_touch_908_gsm,ALCATEL ONE TOUCH 908,3,-24,1
+tct (alcatel),one_touch_916_gsm,ALCATEL ONE TOUCH 916,3,-24,1
+tct (alcatel),one_touch_916A_gsm,ALCATEL ONE TOUCH 916A,3,-24,1
+tct (alcatel),one_touch_916D_gsm,ALCATEL ONE TOUCH 916D,3,-24,1
+tct (alcatel),one_touch_918_gsm,ALCATEL ONE TOUCH 918,3,-24,1
+tct (alcatel),one_touch_918A_gsm,ALCATEL ONE TOUCH 918A,3,-24,1
+tct (alcatel),one_touch_918D_gsm,ALCATEL ONE TOUCH 918D,3,-24,1
+tct (alcatel),ONE_TOUCH_918D_umts,ALCATEL ONE TOUCH 918D,3,-24,1
+tct (alcatel),one_touch_918N_gsm,ALCATEL ONE TOUCH 918N,3,-24,1
+tct (alcatel),one_touch_918_gsm,ALCATEL ONE TOUCH 918N,3,-24,1
+tct (alcatel),ONE_TOUCH_918N_umts,ALCATEL ONE TOUCH 918N,3,-24,1
+tct (alcatel),one_touch_918S_gsm,ALCATEL ONE TOUCH 918S,3,-24,1
+tct (alcatel),one_touch_922_gsm,ALCATEL ONE TOUCH 922,3,-24,1
+tct (alcatel),ONE_TOUCH_928D_gsm,ALCATEL ONE TOUCH 928D,3,-24,1
+tct (alcatel),OT-930,ALCATEL ONE TOUCH 930D,3,-24,1
+tct (alcatel),OT-930,ALCATEL ONE TOUCH 930N,3,-24,1
+tct (alcatel),one_touch_985_gsm,ALCATEL ONE TOUCH 985,3,-24,1
+tct (alcatel),one_touch_985D_gsm,ALCATEL ONE TOUCH 985D,3,-24,1
+tct (alcatel),one_touch_985N_gsm,ALCATEL ONE TOUCH 985N,3,-24,1
+tct (alcatel),one_touch_990_gsm,ALCATEL ONE TOUCH 990,3,-24,1
+tct (alcatel),one_touch_990A_gsm,ALCATEL ONE TOUCH 990A,3,-24,1
+tct (alcatel),one_touch_991_gsm,ALCATEL ONE TOUCH 991,3,-24,1
+tct (alcatel),ONE_TOUCH_991_gsm,ALCATEL ONE TOUCH 991,3,-24,1
+tct (alcatel),ONE_TOUCH_991A_gsm,ALCATEL ONE TOUCH 991A,3,-24,1
+tct (alcatel),one_touch_991D_gsm,ALCATEL ONE TOUCH 991D,3,-24,1
+tct (alcatel),ONE_TOUCH_991D_gsm,ALCATEL ONE TOUCH 991D,3,-24,1
+tct (alcatel),one_touch_991S_gsm,ALCATEL ONE TOUCH 991S,3,-24,1
+tct (alcatel),one_touch_991T_gsm,ALCATEL ONE TOUCH 991T,3,-24,1
+tct (alcatel),Martell_lite_GSM,ALCATEL ONE TOUCH 992,3,-24,1
+tct (alcatel),Martell_lite_GSM,ALCATEL ONE TOUCH 992D,3,-24,1
+tct (alcatel),one_touch_993_gsm,ALCATEL ONE TOUCH 993,3,-24,1
+tct (alcatel),one_touch_993D_gsm,ALCATEL ONE TOUCH 993D,3,-24,1
+tct (alcatel),Martell_GSM,ALCATEL ONE TOUCH 997,3,-24,1
+tct (alcatel),Martell_GSM,ALCATEL ONE TOUCH 997D,3,-24,1
+tct (alcatel),DANIEL,ALCATEL ONE TOUCH D668,3,-24,1
+tct (alcatel),Rav4,ALCATEL ONE TOUCH FIERCE,3,-24,1
+tct (alcatel),Rav4,ALCATEL ONE TOUCH Fierce,3,-24,1
+tct (alcatel),POP7,ALCATEL ONE TOUCH P310A,3,-24,1
+tct (alcatel),POP7,ALCATEL ONE TOUCH P310X,3,-24,1
+tct (alcatel),POP8,ALCATEL ONE TOUCH P320A,3,-24,1
+tct (alcatel),POP8,ALCATEL ONE TOUCH P320X,3,-24,1
+tct (alcatel),POP8,ALCATEL ONE TOUCH P321,3,-24,1
+tct (alcatel),SOUL4NA,ALCATEL ONETOUCH 4037R,3,-24,1
+tct (alcatel),RIO_4G,ALCATEL ONETOUCH 5050X,3,-24,1
+tct (alcatel),Alpha,ALCATEL ONETOUCH 6032,3,-24,1
+tct (alcatel),Alpha,ALCATEL ONETOUCH 6032A,3,-24,1
+tct (alcatel),Alpha,ALCATEL ONETOUCH 6032X,3,-24,1
+tct (alcatel),DIABLOXPLUS,ALCATEL ONETOUCH 6043D,3,-24,1
+tct (alcatel),EOS_lte,ALCATEL ONETOUCH 6050A,3,-24,1
+tct (alcatel),CROSS2,ALCATEL ONETOUCH Flash Plus,3,-24,1
+tct (alcatel),POP7,ALCATEL ONETOUCH P310A,3,-24,1
+tct (alcatel),Pixi4-7_4G_TMO,ALCATEL ONETOUCH POP 7 LTE,3,-24,1
+tct (alcatel),Pixi4-7_4G_Bell,ALCATEL ONETOUCH POP 7 LTE,3,-24,1
+tct (alcatel),SOUL4NA,ALCATEL ONETOUCH POP D3,3,-24,1
+tct (alcatel),OT_918_gsm,ALCATEL OT 918,3,-24,1
+tct (alcatel),OT_919_gsm,ALCATEL OT 919,3,-24,1
+tct (alcatel),OT_919_HelloKitty_gsm,ALCATEL OT 919 HelloKitty,3,-24,1
+tct (alcatel),one_touch_890D_gsm,ALCATEL one touch 890D,3,-24,1
+tct (alcatel),one_touch_918_gsm,ALCATEL one touch 918,3,-24,1
+tct (alcatel),OT986,ALCATEL one touch 986+,3,-24,1
+tct (alcatel),one_touch_990_gsm,ALCATEL one touch 990,3,-24,1
+tct (alcatel),one_touch_990C_cdma,ALCATEL one touch 990C,3,-24,1
+tct (alcatel),one_touch_990C_Plus_cdma,ALCATEL one touch 990C+,3,-24,1
+tct (alcatel),one_touch_D920,ALCATEL one touch D920,3,-24,1
+tct (alcatel),Iris,ALCATEL one touch J320,3,-24,1
+tct (alcatel),Pixi4-4,ALCATEL_4034A,3,-24,1
+tct (alcatel),shine_lite,ALCATEL_5080U,3,-24,1
+tct (alcatel),idol4,ALCATEL_6055K,3,-24,1
+tct (alcatel),PLAY-5,ALCATEL_ONETOUCH_5022D,3,-24,1
+tct (alcatel),X1,ALCATEL_ONETOUCH_7053D,3,-24,1
+tct (alcatel),Beetle_Lite_Edge_GSM,ALCATEL_ONE_TOUCH_4005D,3,-24,1
+tct (alcatel),Megane_GSM,ALCATEL_ONE_TOUCH_5020D_Orange,3,-24,1
+tct (alcatel),Megane_GSM,ALCATEL_ONE_TOUCH_5020X_Orange,3,-24,1
+tct (alcatel),ONE_TOUCH_6010X_gsm,ALCATEL_ONE_TOUCH_6010X_Orange,3,-24,1
+tct (alcatel),Diablo,ALCATEL_ONE_TOUCH_6030X_Orange,3,-24,1
+tct (alcatel),ONE_TOUCH_6030X_gsm,ALCATEL_ONE_TOUCH_6030X_Orange,3,-24,1
+tct (alcatel),one_touch_903_gsm,ALCATEL_ONE_TOUCH_903,3,-24,1
+tct (alcatel),one_touch_903A_gsm,ALCATEL_ONE_TOUCH_903,3,-24,1
+tct (alcatel),one_touch_918M_gsm,ALCATEL_ONE_TOUCH_918M,3,-24,1
+tct (alcatel),one_touch_985_gsm,ALCATEL_ONE_TOUCH_985,3,-24,1
+tct (alcatel),one_touch_991_gsm,ALCATEL_ONE_TOUCH_991_Orange,3,-24,1
+tct (alcatel),OT_990M_gsm,ALCATEL_OT_990M,3,-24,1
+tct (alcatel),Beetle_GSM,ALCATEL_one_touch_4030A,3,-24,1
+tct (alcatel),one_touch_890_gsm,ALCATEL_one_touch_890,3,-24,1
+tct (alcatel),one_touch_891_gsm,ALCATEL_one_touch_891,3,-24,1
+tct (alcatel),one_touch_903A_gsm,ALCATEL_one_touch_903,3,-24,1
+tct (alcatel),OT-906,ALCATEL_one_touch_906,3,-24,1
+tct (alcatel),OT-906,ALCATEL_one_touch_906Y,3,-24,1
+tct (alcatel),one_touch_906_gsm,ALCATEL_one_touch_906Y,3,-24,1
+tct (alcatel),one_touch_908_gsm,ALCATEL_one_touch_908,3,-24,1
+tct (alcatel),one_touch_908A_gsm,ALCATEL_one_touch_908A,3,-24,1
+tct (alcatel),one_touch_908F_gsm,ALCATEL_one_touch_908F,3,-24,1
+tct (alcatel),one_touch_908F_gsm,ALCATEL_one_touch_908F_Orange,3,-24,1
+tct (alcatel),one_touch_908M_gsm,ALCATEL_one_touch_908M,3,-24,1
+tct (alcatel),one_touch_908S_gsm,ALCATEL_one_touch_908S,3,-24,1
+tct (alcatel),one_touch_909A_gsm,ALCATEL_one_touch_909A,3,-24,1
+tct (alcatel),one_touch_909B_cdma,ALCATEL_one_touch_909B,3,-24,1
+tct (alcatel),one_touch_909S_gsm,ALCATEL_one_touch_909S,3,-24,1
+tct (alcatel),one_touch_910_gsm,ALCATEL_one_touch_910,3,-24,1
+tct (alcatel),one_touch_910A_gsm,ALCATEL_one_touch_910A,3,-24,1
+tct (alcatel),OT-913D,ALCATEL_one_touch_913D,3,-24,1
+tct (alcatel),one_touch_918_gsm,ALCATEL_one_touch_918,3,-24,1
+tct (alcatel),one_touch_918A_gsm,ALCATEL_one_touch_918A,3,-24,1
+tct (alcatel),one_touch_918D_umts,ALCATEL_one_touch_918D,3,-24,1
+tct (alcatel),one_touch_918M_umts,ALCATEL_one_touch_918M,3,-24,1
+tct (alcatel),one_touch_918N_umts,ALCATEL_one_touch_918N,3,-24,1
+tct (alcatel),OT-976,ALCATEL_one_touch_976,3,-24,1
+tct (alcatel),OT-978,ALCATEL_one_touch_978,3,-24,1
+tct (alcatel),OT-979,ALCATEL_one_touch_979,3,-24,1
+tct (alcatel),OT-979,ALCATEL_one_touch_979_HelloKitty,3,-24,1
+tct (alcatel),one_touch_983_gsm,ALCATEL_one_touch_983,3,-24,1
+tct (alcatel),ONE_TOUCH_983_gsm,ALCATEL_one_touch_983,3,-24,1
+tct (alcatel),ONE_TOUCH_983A_gsm,ALCATEL_one_touch_983A,3,-24,1
+tct (alcatel),one_touch_985A_gsm,ALCATEL_one_touch_985,3,-24,1
+tct (alcatel),one_touch_985_gsm,ALCATEL_one_touch_985,3,-24,1
+tct (alcatel),one_touch_988_cdma,ALCATEL_one_touch_988,3,-24,1
+tct (alcatel),one_touch_990_gsm,ALCATEL_one_touch_990,3,-24,1
+tct (alcatel),one_touch_990A_gsm,ALCATEL_one_touch_990A,3,-24,1
+tct (alcatel),one_touch_990S_gsm,ALCATEL_one_touch_990S,3,-24,1
+tct (alcatel),one_touch_991_gsm,ALCATEL_one_touch_991,3,-24,1
+tct (alcatel),ONE_TOUCH_991_gsm,ALCATEL_one_touch_991,3,-24,1
+tct (alcatel),ONE_TOUCH_991A_gsm,ALCATEL_one_touch_991,3,-24,1
+tct (alcatel),one_touch_995_gsm,ALCATEL_one_touch_995,3,-24,1
+tct (alcatel),one_touch_995A_gsm,ALCATEL_one_touch_995A,3,-24,1
+tct (alcatel),one_touch_995_gsm,ALCATEL_one_touch_995A,3,-24,1
+tct (alcatel),one_touch_995_gsm,ALCATEL_one_touch_995S,3,-24,1
+tct (alcatel),Alpha,ALOO 6032,3,-24,1
+tct (alcatel),EOS_lte,AM-H100,3,-24,1
+tct (alcatel),idol3,AM-H200,3,-24,1
+tct (alcatel),ASB-D_T918,ASB-D T918,3,-24,1
+tct (alcatel),B-GriffinPlus_TD,ASB-D T918,3,-24,1
+tct (alcatel),Megane_GSM,AURUS III,3,-24,1
+tct (alcatel),elsa6_na,Alcatel 5085C,3,-24,1
+tct (alcatel),idol4,Alcatel 6055U,3,-24,1
+tct (alcatel),Viper_gsm,Alcatel 7030L,3,-24,1
+tct (alcatel),7046T,Alcatel 7046T,3,-24,1
+tct (alcatel),Pixi5-10_4G,Alcatel 9026S,3,-24,1
+tct (alcatel),Viper_gsm,Alcatel A851L,3,-24,1
+tct (alcatel),OT-980_gsm,Alcatel OT-980,3,-24,1
+tct (alcatel),msm7627_ffa,Alcatel OT-980,3,-24,1
+tct (alcatel),OT-980A_gsm,Alcatel OT-980A,3,-24,1
+tct (alcatel),msm7627_ffa,Alcatel OT-980A,3,-24,1
+tct (alcatel),OT-980_gsm,Alcatel OT-980A,3,-24,1
+tct (alcatel),OT-981_gsm,Alcatel OT-981A,3,-24,1
+tct (alcatel),OT-981A_gsm,Alcatel OT-981A,3,-24,1
+tct (alcatel),OT-980_gsm,Alcatel OT-981A,3,-24,1
+tct (alcatel),U3A_PLUS_4G,Alcatel T 5033T,3,-24,1
+tct (alcatel),one_touch_990_gsm,Alcatel one touch 908F Orange,3,-24,1
+tct (alcatel),one_touch_990_gsm,Alcatel one touch 990 Orange,3,-24,1
+tct (alcatel),one_touch_990S_gsm,Alcatel one touch 990S,3,-24,1
+tct (alcatel),Pixi3_7_4G,Alcatel9007T,3,-24,1
+tct (alcatel),pixi384g,Alcatel9022S,3,-24,1
+tct (alcatel),Pixi4-4,Alcatel_4034F,3,-24,1
+tct (alcatel),Pop445,Alcatel_4060A,3,-24,1
+tct (alcatel),Pixi445Cricket,Alcatel_4060O,3,-24,1
+tct (alcatel),FERMI_ATT,Alcatel_5005R,3,-24,1
+tct (alcatel),Edison_CKT,Alcatel_5008R,3,-24,1
+tct (alcatel),BUZZ6T4GCRICKET,Alcatel_5044C,3,-24,1
+tct (alcatel),BUZZ6T4GGOPHONE,Alcatel_5044R,3,-24,1
+tct (alcatel),PIXI4_5_4G,Alcatel_5045A,3,-24,1
+tct (alcatel),Pop355,Alcatel_5054O,3,-24,1
+tct (alcatel),Pop355,Alcatel_5056O,3,-24,1
+tct (alcatel),U50A_PLUS_ATT,Alcatel_5059R,3,-24,1
+tct (alcatel),Pixi4-64GMEX,Alcatel_5098O,3,-24,1
+tct (alcatel),Pixi4-6_4G_CKT,Alcatel_5098O,3,-24,1
+tct (alcatel),idol4,Alcatel_6055U,3,-24,1
+tct (alcatel),simba6_cricket,Alcatel_6060C,3,-24,1
+tct (alcatel),Lion-5,Alcatel_7049D,3,-24,1
+tct (alcatel),Pixi4-6_4G,Alcatel_9001X,3,-24,1
+tct (alcatel),pixi384g,Alcatel_9022S,3,-24,1
+tct (alcatel),one_touch_908F_gsm,Alcatel_one_touch_908F,3,-24,1
+tct (alcatel),one_touch_908_gsm,Alcatel_one_touch_908F_Orange,3,-24,1
+tct (alcatel),one_touch_908F_gsm,Alcatel_one_touch_908F_Orange,3,-24,1
+tct (alcatel),one_touch_918_gsm,Alcatel_one_touch_918_Orange,3,-24,1
+tct (alcatel),TokyoPro,Alpha 20,3,-24,1
+tct (alcatel),Martell_GSM,BASE_Lutea_3,3,-24,1
+tct (alcatel),BASE_Varia_gsm,BASE_Varia,3,-24,1
+tct (alcatel),DiabloHD_LTE,BS472,3,-24,1
+tct (alcatel),YARISXL,Boost View 5.0,3,-24,1
+tct (alcatel),SOUL45_GSM,D45,3,-24,1
+tct (alcatel),HERO8,D819,3,-24,1
+tct (alcatel),HERO8,D820,3,-24,1
+tct (alcatel),HERO8,D820X,3,-24,1
+tct (alcatel),Pixi4-4,DIGICEL DL 1 lite,3,-24,1
+tct (alcatel),PIXI3-55,DIGICEL DL1000,3,-24,1
+tct (alcatel),PIXI3_45_4G,DIGICEL DL810,5,-29,1
+tct (alcatel),PIXI4_5_4G,DIGICELDL1,3,-24,1
+tct (alcatel),POP455C,DIGICELDL1plus,3,-24,1
+tct (alcatel),SOUL4,DL750,3,-24,1
+tct (alcatel),YARISXL,DL900,3,-24,1
+tct (alcatel),X50D,E500,3,-24,1
+tct (alcatel),shine_plus,FL02,3,-24,1
+tct (alcatel),FLASH3,FL03,3,-24,1
+tct (alcatel),Lion-5,Flash2_7049D,3,-24,1
+tct (alcatel),GR-TB7,GR-TB7,3,-24,1
+tct (alcatel),U3A_PLUS_4G,HEYOU10,3,-24,1
+tct (alcatel),U5A_PLUS_4G,HEYOU3,1,-20,1
+tct (alcatel),A3A_LITE,HEYOU5,3,-24,1
+tct (alcatel),Benz,HEYOU50,3,-24,1
+tct (alcatel),TokyoPro,HEYOU60,3,-24,1
+tct (alcatel),mercury,I-L1,3,-24,1
+tct (alcatel),PIXO7,I211,3,-24,1
+tct (alcatel),PIXO7,I212,3,-24,1
+tct (alcatel),PIXO7,I213,3,-24,1
+tct (alcatel),PIXI7,I216A,3,-24,1
+tct (alcatel),PIXI7,I216X,3,-24,1
+tct (alcatel),PIXI8,I220,3,-24,1
+tct (alcatel),PIXI8,I221,3,-24,1
+tct (alcatel),EOS4G,Idol2S_Orange,3,-24,1
+tct (alcatel),Beetle_GSM,Infinity POP,3,-24,1
+tct (alcatel),Iris2PlusUMTS,J630,3,-24,1
+tct (alcatel),Rio5C,J730U,3,-24,1
+tct (alcatel),Pixi3-7,KR076,3,-24,1
+tct (alcatel),Curie,Listo SP50,3,-24,1
+tct (alcatel),one_touch_990_gsm,Los Angeles,3,-24,1
+tct (alcatel),M812,M812C,3,-24,1
+tct (alcatel),MOVE_gsm,MOVE,3,-24,1
+tct (alcatel),Yaris_M_GSM,MS3B,3,-24,1
+tct (alcatel),EVO7,MTC 1065,3,-24,1
+tct (alcatel),E710,MTC 1078,3,-24,1
+tct (alcatel),MTC_960_gsm,MTC 960,3,-24,1
+tct (alcatel),Beetle_GSM,MTC 970,3,-24,1
+tct (alcatel),Megane_GSM,MTC 972,3,-24,1
+tct (alcatel),DiabloHD_LTE,MTC 978,3,-24,1
+tct (alcatel),Vodafone_785,MTC 982,3,-24,1
+tct (alcatel),MTC-962_gsm,MTC-962,3,-24,1
+tct (alcatel),Camry_GSM,MTC975,3,-24,1
+tct (alcatel),one_touch_993_gsm,MTC_968,3,-24,1
+tct (alcatel),VFD700,Maxis VFD 700,3,-24,1
+tct (alcatel),one_touch_995_gsm,MegaFon_SP-A10,3,-24,1
+tct (alcatel),MegaFon_SP-A10,MegaFon_SP-A10,3,-24,1
+tct (alcatel),OT-930,MegaFon_SP-AI,3,-24,1
+tct (alcatel),California,Mobile Sosh,3,-24,1
+tct (alcatel),Pixo_GSM,ONE TOUCH 4007A,3,-24,1
+tct (alcatel),Pixo_GSM,ONE TOUCH 4007D,3,-24,1
+tct (alcatel),Pixo_GSM,ONE TOUCH 4007E,3,-24,1
+tct (alcatel),Pixo_GSM,ONE TOUCH 4007X,3,-24,1
+tct (alcatel),BeetleliteJB,ONE TOUCH 4011X,3,-24,1
+tct (alcatel),Yaris35_GSM,ONE TOUCH 4015A,3,-24,1
+tct (alcatel),Yaris35_GSM,ONE TOUCH 4015D,3,-24,1
+tct (alcatel),Yaris35_GSM,ONE TOUCH 4015N,3,-24,1
+tct (alcatel),Yaris35_GSM,ONE TOUCH 4015X,3,-24,1
+tct (alcatel),Yaris35_GSM,ONE TOUCH 4015X-orange,3,-24,1
+tct (alcatel),Yaris35_GSM,ONE TOUCH 4016A,3,-24,1
+tct (alcatel),Yaris_M_GSM,ONE TOUCH 4032A,3,-24,1
+tct (alcatel),Yaris_M_GSM,ONE TOUCH 4033A,3,-24,1
+tct (alcatel),Yaris_M_GSM,ONE TOUCH 4033D,3,-24,1
+tct (alcatel),Yaris_M_GSM,ONE TOUCH 4033E,3,-24,1
+tct (alcatel),Yaris_M_GSM,ONE TOUCH 4033X,3,-24,1
+tct (alcatel),YarisL_GSM,ONE TOUCH 5036X,3,-24,1
+tct (alcatel),California,ONE TOUCH 6012A,3,-24,1
+tct (alcatel),California_GSM,ONE TOUCH 6012A,3,-24,1
+tct (alcatel),California,ONE TOUCH 6012D,3,-24,1
+tct (alcatel),California,ONE TOUCH 6012E,3,-24,1
+tct (alcatel),California,ONE TOUCH 6012X,3,-24,1
+tct (alcatel),SCRIBEPRO,ONE TOUCH 8020D,3,-24,1
+tct (alcatel),ONE_TOUCH_960C,ONE TOUCH 960C,3,-24,1
+tct (alcatel),ONE_TOUCH_983_gsm,ONE TOUCH 983,3,-24,1
+tct (alcatel),ONE_TOUCH_983M_gsm,ONE TOUCH 983M,3,-24,1
+tct (alcatel),ONE_TOUCH_C505C_cdma,ONE TOUCH C505C,3,-24,1
+tct (alcatel),E710,ONE TOUCH E710,3,-24,1
+tct (alcatel),E710,ONE TOUCH EVO7HD,3,-24,1
+tct (alcatel),E720,ONE TOUCH EVO7HD,3,-24,1
+tct (alcatel),E720,ONE TOUCH EVO8HD,3,-24,1
+tct (alcatel),California,ONE TOUCH IDOL MINI,3,-24,1
+tct (alcatel),POP7,ONE TOUCH P310A,3,-24,1
+tct (alcatel),T011,ONE TOUCH TAB 7,3,-24,1
+tct (alcatel),T016,ONE TOUCH TAB 7HD,3,-24,1
+tct (alcatel),T021,ONE TOUCH TAB 8HD,3,-24,1
+tct (alcatel),Alltel,ONE_TOUCH_960C,3,-24,1
+tct (alcatel),vulcan,ONE_TOUCH_960C,3,-24,1
+tct (alcatel),nTelos,ONE_TOUCH_960C,3,-24,1
+tct (alcatel),Pixi3-4,ONE_TOUCH_PIXI3,3,-24,1
+tct (alcatel),Pixi3-4,ONE_TOUCH_PIXI3D,3,-24,1
+tct (alcatel),OP070,OP070,3,-24,1
+tct (alcatel),OT-990C_cdma,OT-990C,3,-24,1
+tct (alcatel),Yaris_M_GSM,OWN S3010,3,-24,1
+tct (alcatel),Yaris_M_GSM,OWN S3010D,3,-24,1
+tct (alcatel),Telsa,OWN S4010,3,-24,1
+tct (alcatel),DiabloHD,OWN S5010,3,-24,1
+tct (alcatel),EOS_lte,OWN S5030,3,-24,1
+tct (alcatel),YARIS_55,OWN_S4025,3,-24,1
+tct (alcatel),one_touch_995_gsm,Optimus_Madrid,3,-24,1
+tct (alcatel),Diablo,Optimus_San_Remo,3,-24,1
+tct (alcatel),U3A_PLUS_4G,Optus X Start,3,-24,1
+tct (alcatel),California,Orange Covo,3,-24,1
+tct (alcatel),Dive_73,Orange Dive 73,3,-24,1
+tct (alcatel),California,Orange Hiro,3,-24,1
+tct (alcatel),Scribe5HD,Orange Infinity 8008X,3,-24,1
+tct (alcatel),Megane_GSM,Orange Kivo,3,-24,1
+tct (alcatel),Pixi4-4,Orange Rise 34,3,-24,1
+tct (alcatel),U3A_PLUS_4G,Orange Rise 54_Alcatel_5033D,3,-24,1
+tct (alcatel),Beetle_GSM,Orange Runo,3,-24,1
+tct (alcatel),Yaris35_GSM,Orange Yomi,3,-24,1
+tct (alcatel),one_touch_996_gsm,Orange_infinity_996,3,-24,1
+tct (alcatel),Pop7_LTE,P330X,3,-24,1
+tct (alcatel),Pop7_LTE,P330X_orange,3,-24,1
+tct (alcatel),POP8_LTE,P350X,3,-24,1
+tct (alcatel),POP10,P360X,3,-24,1
+tct (alcatel),YARIS_55,PandA_m14,3,-24,1
+tct (alcatel),POP455C,Pop4,3,-24,1
+tct (alcatel),RASPG3201_umts,RASPG3201,3,-24,1
+tct (alcatel),one_touch_995_gsm,RPSPE4301,3,-24,1
+tct (alcatel),RPSPG3201_umts,RPSPG3201,3,-24,1
+tct (alcatel),PIXI3-55,S4035 3G,3,-24,1
+tct (alcatel),Pop355,S4035_4G,3,-24,1
+tct (alcatel),M812,SMART 4G 5.5 Enterprise,3,-24,1
+tct (alcatel),PIXI4_55_3G,SMART_PLUS,3,-24,1
+tct (alcatel),PIXI3-5,SOLO Aspire M,3,-24,1
+tct (alcatel),RIO6_lte,STARXTREM II,3,-24,1
+tct (alcatel),Diablo_LTE,San Remo 4G,3,-24,1
+tct (alcatel),RIO_4G,Siru,3,-24,1
+tct (alcatel),one_touch_996_gsm,Smartphone Android by SFR STARADDICT II,3,-24,1
+tct (alcatel),RIO6_lte,Smartphone Android by SFR STARXTREM II,3,-24,1
+tct (alcatel),one_touch_996_gsm,Smartphone_Android_by_SFR_STARADDICT_II,3,-24,1
+tct (alcatel),PIXI3_35,SoshPhone_mini,3,-24,1
+tct (alcatel),idol4s,T-1000,3,-24,1
+tct (alcatel),idol4s_skt,T-1000,3,-24,1
+tct (alcatel),SOUL35,T4018,3,-24,1
+tct (alcatel),Pixi4-6_3G,T600M,3,-24,1
+tct (alcatel),PIXO7,T70,3,-24,1
+tct (alcatel),HANDYT2,T700A,3,-24,1
+tct (alcatel),HANDYT2,T700X,3,-24,1
+tct (alcatel),T015,TAB 7 DUAL CORE,3,-24,1
+tct (alcatel),T017,TAB 7 DUAL CORE,3,-24,1
+tct (alcatel),Festa5_CU,TCL 302U,3,-24,1
+tct (alcatel),shine_lite,TCL 520,3,-24,1
+tct (alcatel),idol4_mini,TCL 580,3,-24,1
+tct (alcatel),Telsa,TCL 6110A,3,-24,1
+tct (alcatel),x1_plus,TCL 750,3,-24,1
+tct (alcatel),idol4s_cn,TCL 950,3,-24,1
+tct (alcatel),TCL_A506,TCL A506,3,-24,1
+tct (alcatel),TCL_A510,TCL A510,3,-24,1
+tct (alcatel),TCL_A865,TCL A865,3,-24,1
+tct (alcatel),TCL_890D_gsm,TCL A890 2SIM,3,-24,1
+tct (alcatel),TCL-A909_A909_gsm,TCL A909,3,-24,1
+tct (alcatel),A919_gsm,TCL A919,3,-24,1
+tct (alcatel),TCL_A919_umts,TCL A919,3,-24,1
+tct (alcatel),TCL_A966_gsm,TCL A966,3,-24,1
+tct (alcatel),TCL_A968,TCL A968,3,-24,1
+tct (alcatel),TCL_A980_gsm,TCL A980,3,-24,1
+tct (alcatel),TCL_A986_gsm,TCL A986,3,-24,1
+tct (alcatel),one_touch_990_gsm,TCL A990,3,-24,1
+tct (alcatel),TCL_A998_gsm,TCL A998,3,-24,1
+tct (alcatel),TCL_C990_Plus_cdma,TCL C990+,3,-24,1
+tct (alcatel),TCL_C995_cdma,TCL C995,3,-24,1
+tct (alcatel),SOUL35,TCL D35,3,-24,1
+tct (alcatel),D40,TCL D40 DUAL,3,-24,1
+tct (alcatel),TCL_D515_cdma,TCL D515,3,-24,1
+tct (alcatel),YARIS_55,TCL D55,3,-24,1
+tct (alcatel),TCL_D662_cdma,TCL D662,3,-24,1
+tct (alcatel),DANIEL,TCL D668,3,-24,1
+tct (alcatel),EG502,TCL D706,3,-24,1
+tct (alcatel),EG501,TCL D768,3,-24,1
+tct (alcatel),TCL_D920,TCL D920,3,-24,1
+tct (alcatel),E928_TD,TCL E928,3,-24,1
+tct (alcatel),Griffin_TD,TCL E928,3,-24,1
+tct (alcatel),HERO2,TCL H900M,3,-24,1
+tct (alcatel),TCL_J210C_cdma,TCL J210C,3,-24,1
+tct (alcatel),Megane,TCL J300,3,-24,1
+tct (alcatel),MeganeB,TCL J310,3,-24,1
+tct (alcatel),Iris,TCL J320,3,-24,1
+tct (alcatel),Daniel_lite,TCL J320C,3,-24,1
+tct (alcatel),IrisTD,TCL J320T,3,-24,1
+tct (alcatel),Iris2TD,TCL J600T,3,-24,1
+tct (alcatel),Camry_GSM,TCL J610,3,-24,1
+tct (alcatel),md501,TCL J620,3,-24,1
+tct (alcatel),Iris2PlusTD,TCL J630T,3,-24,1
+tct (alcatel),YARISXL,TCL J720,3,-24,1
+tct (alcatel),YARISXL,TCL J726T,3,-24,1
+tct (alcatel),Rio5C,TCL J738M,3,-24,1
+tct (alcatel),Camry2,TCL J900,3,-24,1
+tct (alcatel),Camry2_TD,TCL J900T,3,-24,1
+tct (alcatel),YARIS_55,TCL J920,3,-24,1
+tct (alcatel),YARIS_55,TCL J926T,3,-24,1
+tct (alcatel),Prius,TCL J928,3,-24,1
+tct (alcatel),RIO55_LTE,TCL J938M,3,-24,1
+tct (alcatel),CROSS2,TCL M2M,3,-24,1
+tct (alcatel),CROSS2,TCL M2U,3,-24,1
+tct (alcatel),one_touch_990_gsm,TCL ONE TOUCH 990,3,-24,1
+tct (alcatel),Cooper_40,TCL P301C,3,-24,1
+tct (alcatel),TCL_P301M,TCL P301M,3,-24,1
+tct (alcatel),Cooper40,TCL P302C,3,-24,1
+tct (alcatel),Festa5_CT,TCL P316L,3,-24,1
+tct (alcatel),TCL_P331M,TCL P331M,3,-24,1
+tct (alcatel),TCL_P332U,TCL P332U,3,-24,1
+tct (alcatel),Focus5_CU,TCL P360W,3,-24,1
+tct (alcatel),Festa_L,TCL P500M,3,-24,1
+tct (alcatel),Festa5_CU,TCL P502U,3,-24,1
+tct (alcatel),Bora5_CT,TCL P520L,3,-24,1
+tct (alcatel),Rav4_GSM,TCL P600,3,-24,1
+tct (alcatel),Rav4_GSM,TCL P606,3,-24,1
+tct (alcatel),Rav4_GSM,TCL P606T,3,-24,1
+tct (alcatel),HUMMER5_CT,TCL P618L,3,-24,1
+tct (alcatel),Civic_X,TCL P631M,3,-24,1
+tct (alcatel),CROSS_LTE,TCL P728M,3,-24,1
+tct (alcatel),TCLS300T,TCL S300T,3,-24,1
+tct (alcatel),Martell_lite_GSM,TCL S500,3,-24,1
+tct (alcatel),TCL_S500_GSM,TCL S500,3,-24,1
+tct (alcatel),Telsa,TCL S520,3,-24,1
+tct (alcatel),TCL_S520_GSM,TCL S520,3,-24,1
+tct (alcatel),California,TCL S530T,3,-24,1
+tct (alcatel),Martell_lite_GSM,TCL S600,3,-24,1
+tct (alcatel),TCL_S600_GSM,TCL S600,3,-24,1
+tct (alcatel),TCLS700,TCL S700,3,-24,1
+tct (alcatel),TCLS700T,TCL S700T,3,-24,1
+tct (alcatel),Martell_GSM,TCL S710,3,-24,1
+tct (alcatel),Cross55,TCL S720,3,-24,1
+tct (alcatel),Cross55,TCL S720T,3,-24,1
+tct (alcatel),TCL_S800_GSM,TCL S800,3,-24,1
+tct (alcatel),Martell_GSM,TCL S800,3,-24,1
+tct (alcatel),Camry_GSM,TCL S810,3,-24,1
+tct (alcatel),Diablo,TCL S820,3,-24,1
+tct (alcatel),EOS_lte,TCL S830U,3,-24,1
+tct (alcatel),EOS_lte,TCL S838M,3,-24,1
+tct (alcatel),DiabloHD,TCL S850,3,-24,1
+tct (alcatel),Alpha,TCL S860,3,-24,1
+tct (alcatel),S900,TCL S900,3,-24,1
+tct (alcatel),DIABLOX,TCL S950,3,-24,1
+tct (alcatel),DIABLOX,TCL S950T,3,-24,1
+tct (alcatel),DIABLOXPLUS,TCL S960,3,-24,1
+tct (alcatel),DIABLOXPLUS,TCL S960T,3,-24,1
+tct (alcatel),evoque_cn,TCL T500L,3,-24,1
+tct (alcatel),T011,TCL TAB 7,3,-24,1
+tct (alcatel),A3A_PLUS,TCL V760,3,-24,1
+tct (alcatel),TCL_W969_gsm,TCL W969,3,-24,1
+tct (alcatel),Xess-mini,TCL Xess C15BA,3,-24,1
+tct (alcatel),Xess,TCL Xess P17AA,3,-24,1
+tct (alcatel),Xess-mini,TCL Xess miniC15BA,3,-24,1
+tct (alcatel),A3A_PLUS,TCL Y660,3,-24,1
+tct (alcatel),Scribe5_gsm,TCL Y710,3,-24,1
+tct (alcatel),Scribe5HD_GSM,TCL Y900,3,-24,1
+tct (alcatel),SCRIBEPRO,TCL Y910,3,-24,1
+tct (alcatel),SCRIBEPRO,TCL Y910T,3,-24,1
+tct (alcatel),EOS_MACAN,TCL i708U,3,-24,1
+tct (alcatel),EOS_Plus,TCL i709M,3,-24,1
+tct (alcatel),EOS2,TCL i718M,3,-24,1
+tct (alcatel),idol3,TCL i806,3,-24,1
+tct (alcatel),shine_plus,TCL-550,3,-24,1
+tct (alcatel),DANIEL,TCL-D668,3,-24,1
+tct (alcatel),TCL_D920,TCL-D920,3,-24,1
+tct (alcatel),TCL_J210C_cdma,TCL-J210C,3,-24,1
+tct (alcatel),Daniel_lite_2S,TCL-J320D,3,-24,1
+tct (alcatel),Rio5C,TCL-J736L,3,-24,1
+tct (alcatel),TCL_J900C,TCL-J900C,3,-24,1
+tct (alcatel),Diablo_LTE,TCL-J929L,3,-24,1
+tct (alcatel),Ford50,TCL-P306C,3,-24,1
+tct (alcatel),Rio5C,TCL-P688L,3,-24,1
+tct (alcatel),TCL-S806,TCL-S806,3,-24,1
+tct (alcatel),Diablo_LTE,TCL-S850L,3,-24,1
+tct (alcatel),PIXI5-6_4G,TCLGalaG60(9108A),3,-24,1
+tct (alcatel),Yaris_M_GSM,TCLJ330,3,-24,1
+tct (alcatel),Telsa,TCL_6110A,3,-24,1
+tct (alcatel),TCL_A510,TCL_A510,3,-24,1
+tct (alcatel),TCL_A988_gsm,TCL_A988,3,-24,1
+tct (alcatel),Beetle_Lite_GSM,TCL_J210,3,-24,1
+tct (alcatel),msm7627a_a5y_j636d,TCL_J636D,3,-24,1
+tct (alcatel),Focus_L,TCL_J706T,3,-24,1
+tct (alcatel),Fit55_CU,TCL_P561U,3,-24,1
+tct (alcatel),POLO55,TCL_P689L,3,-24,1
+tct (alcatel),Cross55_TD_Plus,TCL_S725T,3,-24,1
+tct (alcatel),TCL_U980,TCL_U980,3,-24,1
+tct (alcatel),TCL_W939_gsm,TCL_W939,3,-24,1
+tct (alcatel),TCL_A919_umts,TCL_W969,3,-24,1
+tct (alcatel),Rio5C,TOM007,3,-24,1
+tct (alcatel),one_touch_985_gsm,Telenor Smart,3,-24,1
+tct (alcatel),Beetle_Lite_GSM,Telenor Smart 2,3,-24,1
+tct (alcatel),SOUL4,Telenor Smart Mini,3,-24,1
+tct (alcatel),Megane_GSM,Telenor Smart Pro 2,3,-24,1
+tct (alcatel),one_touch_990_gsm,Telenor_OneTouch,3,-24,1
+tct (alcatel),one_touch_985_gsm,Telenor_One_Touch_C,3,-24,1
+tct (alcatel),one_touch_995_gsm,Telenor_One_Touch_S,3,-24,1
+tct (alcatel),one_touch_985_gsm,Telenor_Smart,3,-24,1
+tct (alcatel),one_touch_995_gsm,Telenor_Smart_HD,3,-24,1
+tct (alcatel),ONE_TOUCH_991_gsm,Telenor_Smart_Pro,3,-24,1
+tct (alcatel),one_touch_909B_cdma,USCC_ALCATEL_one_touch_909B,3,-24,1
+tct (alcatel),one_touch_988_cdma,USCC_ALCATEL_one_touch_988,3,-24,1
+tct (alcatel),ONE_TOUCH_983_gsm,VALENCIA,3,-24,1
+tct (alcatel),VFD500,VFD 500,3,-24,1
+tct (alcatel),VFD700,VFD 700,3,-24,1
+tct (alcatel),VFD700,VFD700,3,-24,1
+tct (alcatel),Vancouver_gsm,Vancouver_Orange,3,-24,1
+tct (alcatel),one_touch_890_gsm,Vip_MiniDroid,3,-24,1
+tct (alcatel),one_touch_922_gsm,Vodafone 861,3,-24,1
+tct (alcatel),one_touch_990_gsm,Vodafone 958,3,-24,1
+tct (alcatel),Vodafone_975,Vodafone 975,3,-24,1
+tct (alcatel),SmartIII4,Vodafone 975N,3,-24,1
+tct (alcatel),Vodafone_975N,Vodafone 975N,3,-24,1
+tct (alcatel),Vodafone985N,Vodafone 985N,3,-24,1
+tct (alcatel),Vodafone_Smart_II_gsm,Vodafone Smart II,3,-24,1
+tct (alcatel),X35E,X35E,3,-24,1
+tct (alcatel),X50D,X50D,3,-24,1
+tct (alcatel),Pixi4-6_4G_CKT,alcatel_5098O,3,-24,1
+tct (alcatel),YARIS_55,freebit PandA_m14,3,-24,1
+tct (alcatel),ONE_TOUCH_991D_gsm,moche smart a8,3,-24,1
+tct (alcatel),move_2_gsm,move 2,3,-24,1
+tct (alcatel),Martini,one touch 906,3,-24,1
+tct (alcatel),one_touch_995C_cdma,one touch 995C+,3,-24,1
+tct (alcatel),one_touch_D920,one touch D920,3,-24,1
+tct (alcatel),T10,one touch T10,3,-24,1
+tct (alcatel),T20,one touch T20,3,-24,1
+tct (alcatel),EVO7,onetouch EVO7,3,-24,1
+tct (alcatel),T60,onetouch T60,3,-24,1
+tct (alcatel),POLO55,onetouch_P689L,3,-24,1
+tct (alcatel),EVO7,starTIM tab 7,3,-24,1
+tct (alcatel),ONE_TOUCH_991D_gsm,tmn smart a8,3,-24,1
+vivo,I1928,I1927,5,-23,1
+vivo,I1928,I1928,5,-23,1
+vivo,PD1730E,V1730EA,5,-23,1
+vivo,PD1731C,V1731CA,5,-23,1
+vivo,PD1732,V1732A,5,-23,1
+vivo,PD1809,V1809A,5,-23,1
+vivo,PD1813C,V1813A,5,-23,1
+vivo,PD1813,V1813A,5,-23,1
+vivo,PD1813E,V1813A,5,-23,1
+vivo,PD1813B,V1813BA,5,-23,1
+vivo,PD1813D,V1813BT,5,-23,1
+vivo,PD1814,V1814A,5,-23,1
+vivo,PD1816,V1816A,5,-23,1
+vivo,PD1818G,V1818A,5,-23,1
+vivo,PD1818,V1818A,5,-23,1
+vivo,PD1818B,V1818BA,5,-23,1
+vivo,PD1818E,V1818CA,5,-23,1
+vivo,PD1818B,V1818CA,5,-23,1
+vivo,PD1818C,V1818CA,5,-23,1
+vivo,PD1821,V1821A,5,-23,1
+vivo,PD1824,V1824A,5,-23,1
+vivo,PD1829,V1829A,5,-23,1
+vivo,PD1831,V1831A,5,-23,1
+vivo,PD1832,V1832A,5,-23,1
+vivo,PD1836,V1836A,5,-23,1
+vivo,PD1838,V1838A,5,-23,1
+vivo,PD1901,V1901A,5,-23,1
+vivo,PD1911,V1911A,5,-23,1
+vivo,PD1913,V1913A,5,-23,1
+vivo,PD1914,V1914A,5,-23,1
+vivo,PD1916,V1916A,5,-23,1
+vivo,PD1921,V1921A,5,-23,1
+vivo,PD1922,V1922A,5,-23,1
+vivo,PD1923,V1923A,5,-23,1
+vivo,PD1924,V1924A,5,-23,1
+vivo,1926,V1926,5,-23,1
+vivo,PD1928,V1928A,5,-23,1
+vivo,PD1930,V1930A,5,-23,1
+vivo,PD1932,V1932A,5,-23,1
+vivo,PD1934,V1934A,5,-23,1
+vivo,PD1936,V1936A,5,-23,1
+vivo,PD1936G,V1936AL,5,-23,1
+vivo,PD1938,V1938CT,5,-23,1
+vivo,PD1938,V1938T,5,-23,1
+vivo,PD1941,V1941A,5,-23,1
+vivo,PD1945,V1945A,5,-23,1
+vivo,PD1950,V1950A,5,-23,1
+vivo,PD1955,V1955A,5,-23,1
+vivo,PD1962,V1962A,5,-23,1
+vivo,PD1963,V1963A,5,-23,1
+vivo,PD1965,V1965A,5,-23,1
+vivo,PD1981,V1981A,5,-23,1
+vivo,PD1990,V1990A,5,-23,1
+vivo,1601,vivo 1601,5,-23,1
+vivo,1603,vivo 1603,5,-23,1
+vivo,1606,vivo 1606,5,-23,1
+vivo,1609,vivo 1609,5,-23,1
+vivo,1610,vivo 1610,5,-23,1
+vivo,1611,vivo 1611,5,-23,1
+vivo,Y31i,vivo 1707,5,-23,1
+vivo,1601,vivo 1713,5,-23,1
+vivo,1714,vivo 1714,5,-23,1
+vivo,1716,vivo 1716,5,-23,1
+vivo,1718,vivo 1718,5,-23,1
+vivo,1719,vivo 1719,5,-23,1
+vivo,PD1710F_EX,vivo 1720,5,-23,1
+vivo,PD1709F_EX,vivo 1721,5,-23,1
+vivo,1723CF,vivo 1723,5,-23,1
+vivo,1723,vivo 1723,4,-20,3
+vivo,1724,vivo 1724,5,-23,1
+vivo,1725,vivo 1725,5,-23,1
+vivo,1726,vivo 1726,5,-23,1
+vivo,1727ID,vivo 1727,5,-23,1
+vivo,1727,vivo 1727,5,-23,1
+vivo,1801,vivo 1801,5,-23,1
+vivo,1802,vivo 1802,5,-23,1
+vivo,1803,vivo 1803,5,-23,1
+vivo,1804,vivo 1804,5,-26,3
+vivo,1805,vivo 1805,5,-23,1
+vivo,1806,vivo 1806,5,-23,1
+vivo,1807,vivo 1807,5,-23,1
+vivo,1807N,vivo 1807,5,-23,1
+vivo,1808,vivo 1808,5,-23,1
+vivo,1811,vivo 1811,5,-23,1
+vivo,1812,vivo 1812,5,-23,1
+vivo,1813,vivo 1813,5,-23,1
+vivo,1814,vivo 1814,5,-23,1
+vivo,1815,vivo 1815,5,-23,1
+vivo,1816,vivo 1816,5,-23,1
+vivo,1817,vivo 1817,5,-23,1
+vivo,1818N,vivo 1818,5,-23,1
+vivo,1818,vivo 1818,5,-23,1
+vivo,1819,vivo 1819,5,-23,1
+vivo,1819N,vivo 1819,5,-23,1
+vivo,1820,vivo 1820,5,-23,1
+vivo,1851,vivo 1851,5,-23,1
+vivo,1901,vivo 1901,5,-23,1
+vivo,1902,vivo 1902,5,-23,1
+vivo,1902D,vivo 1902,5,-23,1
+vivo,1904,vivo 1904,5,-23,1
+vivo,1906,vivo 1906,5,-23,1
+vivo,1907N,vivo 1907,5,-23,1
+vivo,1907,vivo 1907,5,-23,1
+vivo,1909,vivo 1909,5,-23,1
+vivo,1910,vivo 1910,5,-23,1
+vivo,1910N,vivo 1910,5,-23,1
+vivo,1912,vivo 1912,5,-23,1
+vivo,1913,vivo 1913,5,-23,1
+vivo,1811,vivo 1914,5,-23,1
+vivo,1915,vivo 1915,5,-23,1
+vivo,1916,vivo 1916,5,-23,1
+vivo,1917,vivo 1917,5,-23,1
+vivo,1919,vivo 1919,5,-23,1
+vivo,1920,vivo 1920,5,-23,1
+vivo,1921,vivo 1921,5,-23,1
+vivo,1933,vivo 1933,5,-23,1
+vivo,1935,vivo 1935,5,-23,1
+vivo,1937,vivo 1937,5,-23,1
+vivo,1951,vivo 1951,5,-23,1
+vivo,1902,vivo 2010,5,-23,1
+vivo,PD1806B,vivo NEX A,5,-23,1
+vivo,PD1806,vivo NEX A,5,-23,1
+vivo,PD1805,vivo NEX S,5,-23,1
+vivo,PD1415A,vivo PD1415A,5,-23,1
+vivo,PD1501D,vivo PD1501D,5,-23,1
+vivo,PD1515A,vivo PD1515A,5,-23,1
+vivo,PD1515BA,vivo PD1515BA,5,-23,1
+vivo,PD1522A,vivo PD1522A,5,-23,1
+vivo,PD1523,vivo PD1523A,5,-23,1
+vivo,PD1524B,vivo PD1524B,5,-23,1
+vivo,PD1612,vivo PD1612,5,-23,1
+vivo,PD1616B,vivo PD1616B,5,-23,1
+vivo,PD1628,vivo PD1628,5,-23,1
+vivo,PD1635,vivo PD1635,5,-23,1
+vivo,PD1708,vivo PD1708,5,-23,1
+vivo,PD1709,vivo PD1709,5,-23,1
+vivo,PD1710,vivo PD1710,5,-23,1
+vivo,PD1721,vivo PD1721,5,-23,1
+vivo,V1,vivo V1,5,-23,1
+vivo,V3,vivo V3,5,-23,1
+vivo,PD1524,vivo V3,5,-23,1
+vivo,V3Lite,vivo V3Lite,5,-23,1
+vivo,V3Max,vivo V3Max,5,-23,1
+vivo,PD1523B,vivo V3Max+ A,5,-23,1
+vivo,V5Plus,vivo V5Plus,5,-23,1
+vivo,PD1709,vivo X20A,5,-23,1
+vivo,PD1710,vivo X20Plus A,5,-23,1
+vivo,PD1721,vivo X20Plus UD,5,-23,1
+vivo,PD1728,vivo X21A,5,-23,1
+vivo,PD1728UD,vivo X21UD A,5,-23,1
+vivo,PD1801,vivo X21i A,5,-23,1
+vivo,X5,vivo X5,5,-23,1
+vivo,PD1401CL,vivo X5M,5,-23,1
+vivo,X5Max,vivo X5Max,5,-23,1
+vivo,bbk6752_lwt_kk,vivo X5Max S,5,-23,1
+vivo,msm8916_32,vivo X5MaxV,5,-23,1
+vivo,X5Pro,vivo X5Pro,5,-23,1
+vivo,bbk6752_lwt_l,vivo X5Pro D,5,-23,1
+vivo,PD1421V,vivo X5Pro V,5,-23,1
+vivo,PD1415D,vivo X6D,5,-23,1
+vivo,PD1415BA,vivo X6S A,5,-23,1
+vivo,PD1602,vivo X7,5,-23,1
+vivo,PD1603,vivo X7Plus,5,-23,1
+vivo,PD1616,vivo X9,5,-23,1
+vivo,PD1619,vivo X9Plus,5,-23,1
+vivo,PD1624,vivo X9i,5,-23,1
+vivo,PD1616B,vivo X9s,5,-23,1
+vivo,PD1635,vivo X9s Plus,5,-23,1
+vivo,PD1522A,vivo Xplay5A,5,-23,1
+vivo,PD1610,vivo Xplay6,5,-23,1
+vivo,Y11,vivo Y11,5,-23,1
+vivo,PD1304DL,vivo Y13iL,5,-23,1
+vivo,Y15,vivo Y15,5,-23,1
+vivo,Y15S,vivo Y15S,5,-23,1
+vivo,Y21,vivo Y21,5,-23,1
+vivo,Y21L,vivo Y21L,5,-23,1
+vivo,Y22,vivo Y22,5,-23,1
+vivo,Y27,vivo Y27,5,-23,1
+vivo,Y28,vivo Y28,5,-23,1
+vivo,PD1505,vivo Y31,5,-23,1
+vivo,Y31,vivo Y31,5,-23,1
+vivo,Y31i,vivo Y31,5,-23,1
+vivo,Y31L,vivo Y31L,5,-23,1
+vivo,Y31i,vivo Y31i,5,-23,1
+vivo,bbk6735_65c_l,vivo Y33,5,-23,1
+vivo,PD1502L,vivo Y35,5,-23,1
+vivo,PD1502A,vivo Y35A,5,-23,1
+vivo,Y37,vivo Y37,5,-23,1
+vivo,Y51,vivo Y51,5,-23,1
+vivo,PD1510,vivo Y51A,5,-23,1
+vivo,PD1613,vivo Y55,5,-23,1
+vivo,PD1621,vivo Y66,5,-23,1
+vivo,PD1621B,vivo Y66i A,5,-23,1
+vivo,PD1612,vivo Y67,5,-23,1
+vivo,PD1705,vivo Y69A,5,-23,1
+vivo,PD1731D,vivo Y71A,5,-23,1
+vivo,PD1731,vivo Y71A,5,-23,1
+vivo,PD1718,vivo Y75A,5,-23,1
+vivo,PD1708C,vivo Y75s,5,-23,1
+vivo,PD1708,vivo Y79A,5,-23,1
+vivo,PD1803,vivo Y83A,5,-23,1
+vivo,PD1730,vivo Y85A,5,-23,1
+vivo,PD1730D,vivo Y89,5,-23,1
+vivo,PD1419V,vivo Y923,5,-23,1
+vivo,PD1503,vivo Y937,5,-23,1
+vivo,PD1730C,vivo Z1,5,-23,1
+vivo,PD1730D,vivo Z1i,5,-23,1
+vivo,PD1730G,vivo Z3x,5,-23,1
+xiaomi,HM2013022,2013022,1,-23,1
+xiaomi,HM2013023,2013023,1,-23,1
+xiaomi,HM2014011,2014011,1,-23,1
+xiaomi,HM2014501,2014501,1,-23,1
+xiaomi,lte26007,2014502,1,-23,1
+xiaomi,HM2014811,2014811,1,-23,1
+xiaomi,HM2014812,2014812,1,-23,1
+xiaomi,HM2014813,2014813,1,-23,1
+xiaomi,HM2014817,2014817,1,-23,1
+xiaomi,HM2014818,2014818,1,-23,1
+xiaomi,HM2014819,2014819,1,-23,1
+xiaomi,cmi,Cmi,1,-23,1
+xiaomi,armani,HM 1AC,1,-23,1
+xiaomi,armani,HM 1S,1,-23,1
+xiaomi,armani,HM 1SC,1,-23,1
+xiaomi,armani,HM 1SW,1,-23,1
+xiaomi,lte26007,HM 2A,1,-23,1
+xiaomi,dior,HM NOTE 1LTE,1,-23,1
+xiaomi,dior,HM NOTE 1LTETD,1,-23,1
+xiaomi,dior,HM NOTE 1LTEW,1,-23,1
+xiaomi,gucci,HM NOTE 1S,1,-23,1
+xiaomi,lcsh92_wet_tdd,HM NOTE 1TD,1,-23,1
+xiaomi,lcsh92_wet_jb9,HM NOTE 1W,1,-23,1
+xiaomi,vangogh,M2002J9E,1,-23,1
+xiaomi,monet,M2002J9G,1,-23,1
+xiaomi,aries,MI 2,1,-23,1
+xiaomi,taurus,MI 2A,1,-23,1
+xiaomi,aries,MI 2S,1,-23,1
+xiaomi,pisces,MI 3,1,-23,1
+xiaomi,cancro,MI 3W,4,-21,1
+xiaomi,cancro,MI 4C,4,-21,1
+xiaomi,cancro,MI 4LTE,4,-21,1
+xiaomi,aqua,MI 4S,1,-23,1
+xiaomi,cancro,MI 4W,4,-21,3
+xiaomi,gemini,MI 5,-2,-27,3
+xiaomi,meri,MI 5C,1,-23,1
+xiaomi,tiffany,MI 5X,1,-23,1
+xiaomi,capricorn,MI 5s,-4,-26,3
+xiaomi,natrium,MI 5s Plus,-3,-23,3
+xiaomi,sagit,MI 6,2,-22,3
+xiaomi,wayne,MI 6X,1,-23,1
+xiaomi,dipper,MI 8,1,-22,3
+xiaomi,ursa,MI 8 Explorer Edition,1,-23,1
+xiaomi,platina,MI 8 Lite,1,-21,3
+xiaomi,equuleus,MI 8 Pro,1,-30,3
+xiaomi,sirius,MI 8 SE,1,-23,1
+xiaomi,equuleus,MI 8 UD,1,-30,1
+xiaomi,cepheus,MI 9,1,-23,1
+xiaomi,grus,MI 9 SE,1,-23,1
+xiaomi,tissot_sprout,MI A1,1,-17,1
+xiaomi,pyxis,MI CC 9,1,-23,1
+xiaomi,laurus,MI CC 9e,1,-23,1
+xiaomi,tucana,MI CC9 Pro,1,-23,1
+xiaomi,hydrogen,MI MAX,1,-23,1
+xiaomi,helium,MI MAX,1,-23,1
+xiaomi,oxygen,MI MAX 2,1,-23,1
+xiaomi,nitrogen,MI MAX 3,3,-24,3
+xiaomi,virgo,MI NOTE LTE,9,-23,3
+xiaomi,leo,MI NOTE Pro,1,-23,1
+xiaomi,mocha,MI PAD,1,-23,1
+xiaomi,latte,MI PAD 2,1,-23,1
+xiaomi,cappu,MI PAD 3,1,-23,1
+xiaomi,clover,MI PAD 4,1,-23,1
+xiaomi,lotus,MI PLAY,1,-23,1
+xiaomi,once,MIBOX3,1,-23,1
+xiaomi,oneday,MIBOX4,1,-23,1
+xiaomi,lithium,MIX,-2,-27,3
+xiaomi,chiron,MIX 2,6,-24,1
+xiaomi,polaris,MIX 2S,1,-19,1
+xiaomi,perseus,MIX 3,1,-23,1
+xiaomi,meri,Meri,1,-23,1
+xiaomi,umi,Mi 10,1,-23,1
+xiaomi,cmi,Mi 10 Pro,1,-23,1
+xiaomi,ferrari,Mi 4i,1,-23,1
+xiaomi,pyxis,Mi 9 Lite,1,-23,1
+xiaomi,grus,Mi 9 SE,1,-23,1
+xiaomi,davinci,Mi 9T,1,-23,1
+xiaomi,raphael,Mi 9T Pro,1,-23,1
+xiaomi,tissot_sprout,Mi A1,1,-17,3
+xiaomi,jasmine_sprout,Mi A2,0,-23,3
+xiaomi,daisy_sprout,Mi A2 Lite,2,-19,3
+xiaomi,laurel_sprout,Mi A3,1,-19,3
+xiaomi,chiron,Mi MIX 2,6,-24,3
+xiaomi,polaris,Mi MIX 2S,1,-19,3
+xiaomi,perseus,Mi MIX 3,1,-23,1
+xiaomi,andromeda,Mi MIX 3 5G,1,-23,1
+xiaomi,tucana,Mi Note 10,1,-23,1
+xiaomi,toco,Mi Note 10 Lite,1,-23,1
+xiaomi,scorpio,Mi Note 2,-2,-25,3
+xiaomi,jason,Mi Note 3,1,-23,1
+xiaomi,baiji,Mi Watch,1,-23,1
+xiaomi,libra,Mi-4c,1,-23,1
+xiaomi,crux,Mi9 Pro 5G,1,-23,1
+xiaomi,casablanca,MiBOX1S,1,-23,1
+xiaomi,dredd,MiBOX2,1,-23,1
+xiaomi,queenchristina,MiBOX3S,1,-23,1
+xiaomi,kungfupanda,MiBOX_PRO,1,-23,1
+xiaomi,forrestgump,MiBOX_mini,1,-23,1
+xiaomi,anglee,MiProjA1,1,-23,1
+xiaomi,eva,MiProjM05,1,-23,1
+xiaomi,braveheart,MiTV,1,-23,1
+xiaomi,dangal,MiTV-AXSO0,1,-23,1
+xiaomi,dangalFHD,MiTV-AXSO1,1,-23,1
+xiaomi,dangalUHD,MiTV-AXSO2,1,-23,1
+xiaomi,amelie,MiTV-MSSP0,1,-23,1
+xiaomi,nino,MiTV-MSSP1,1,-23,1
+xiaomi,volver,MiTV-MSSP2,1,-23,1
+xiaomi,machuca,MiTV-MSSP3,1,-23,1
+xiaomi,entrapment,MiTV2,1,-23,1
+xiaomi,missionimpossible,MiTV3S,1,-23,1
+xiaomi,pulpfiction,MiTV3S,1,-23,1
+xiaomi,pulpfiction,MiTV4,1,-23,1
+xiaomi,matrix,MiTV4C,1,-23,1
+xiaomi,magnolia,MiTV4I,1,-23,1
+xiaomi,onc,ONC,1,-23,1
+xiaomi,lmi,POCO F2 Pro,1,-23,1
+xiaomi,beryllium,POCOPHONE F1,1,-23,1
+xiaomi,platina,Platina,1,-21,1
+xiaomi,pyxis,Pyxis,1,-23,1
+xiaomi,ido,Redmi 3,3,-21,3
+xiaomi,land,Redmi 3S,-1,-25,3
+xiaomi,markw,Redmi 4,1,-23,1
+xiaomi,prada,Redmi 4,1,-23,1
+xiaomi,rolex,Redmi 4A,1,-23,1
+xiaomi,santoni,Redmi 4X,-1,-23,3
+xiaomi,rosy,Redmi 5,1,-23,1
+xiaomi,vince,Redmi 5 Plus,1,-23,1
+xiaomi,riva,Redmi 5A,3,-28,3
+xiaomi,cereus,Redmi 6,1,-23,1
+xiaomi,sakura,Redmi 6 Pro,1,-23,1
+xiaomi,sakura_india,Redmi 6 Pro,5,-21,3
+xiaomi,cactus,Redmi 6A,1,-23,1
+xiaomi,onc,Redmi 7,1,-23,1
+xiaomi,pine,Redmi 7A,1,-23,1
+xiaomi,olive,Redmi 8,1,-23,1
+xiaomi,tiare,Redmi Go,1,-23,1
+xiaomi,lmiin,Redmi K30 Pro 5G,1,-23,1
+xiaomi,lmiinpro,Redmi K30 Pro 5G Zoom Edition,1,-23,1
+xiaomi,lmipro,Redmi K30 Pro Zoom Edition,1,-23,1
+xiaomi,hermes,Redmi Note 2,1,-23,1
+xiaomi,kenzo,Redmi Note 3,5,-22,3
+xiaomi,hennessy,Redmi Note 3,5,-22,1
+xiaomi,kate,Redmi Note 3,5,-22,1
+xiaomi,nikel,Redmi Note 4,1,-23,1
+xiaomi,mido,Redmi Note 4,1,-23,1
+xiaomi,mido,Redmi Note 4X,1,-23,1
+xiaomi,vince,Redmi Note 5,1,-23,1
+xiaomi,whyred,Redmi Note 5,-1,-19,3
+xiaomi,whyred,Redmi Note 5 Pro,-1,-19,1
+xiaomi,ugglite,Redmi Note 5A,1,-23,1
+xiaomi,ugg,Redmi Note 5A,1,-23,1
+xiaomi,tulip,Redmi Note 6 Pro,3,-28,3
+xiaomi,violet,Redmi Note 7 Pro,1,-23,1
+xiaomi,omega,Redmi Pro,1,-23,1
+xiaomi,ysl,Redmi S2,4,-27,3
+xiaomi,ugg,Redmi Y1,1,-23,1
+xiaomi,umi,Umi,1,-23,1
+xiaomi,equuleus,equuleus,1,-30,1
+xiaomi,gucci,gucci,1,-23,1
+xiaomi,ido,ido,3,-21,1
+xiaomi,laurus,laurus,1,-23,1
+xiaomi,lithium,lithium,-2,-27,1
+xiaomi,lotus,lotus,1,-23,1
+xiaomi,santoni,santoni,-1,-23,1
+xiaomi,sirius,sirius,1,-23,1
+xiaomi,toco,toco,1,-23,1
+zte,blade,003Z,5,-25,1
+zte,bladeplus,008Z,5,-25,1
+zte,bladeplus,009Z,5,-25,1
+zte,ZTE-402ZT,402ZT,5,-25,1
+zte,msm8974,502ZT,5,-25,1
+zte,P450A01,901ZT,5,-25,1
+zte,billy,A1,5,-25,1
+zte,P963F01D,A1 Alpha,5,-25,1
+zte,v9,A100,5,-25,1
+zte,ailsa,A1P,5,-25,1
+zte,billy,A1R,5,-25,1
+zte,A2,A2,5,-25,1
+zte,Z8850K,A2020N3,5,-25,1
+zte,nice,A21plus,5,-25,1
+zte,P809A20,A460-T,5,-25,1
+zte,P172G10,A4C,5,-25,1
+zte,racer2,ARIZONA,5,-25,1
+zte,blade2,ATLAS W,5,-25,1
+zte,B800S2_V1,AV-ATB100,5,-25,1
+zte,msm8952_64,AXON 7 mini,5,-25,1
+zte,rolex,AXON WATCH,5,-25,1
+zte,atlas40,Acqua,5,-25,1
+zte,roamer2,Amazing A1,5,-25,1
+zte,P175A60,Amazing A3,5,-25,1
+zte,P809F20,Amazing A30,5,-25,1
+zte,P177E01,Amazing A4,5,-25,1
+zte,P172G10,Amazing A4C,5,-25,1
+zte,P172R10,Amazing A4S,5,-25,1
+zte,P637F02,Amazing A50,5,-25,1
+zte,P731A10,Amazing A5S,5,-25,1
+zte,P188F07,Amazing A6,5,-25,1
+zte,P682F06,Amazing A7,5,-25,1
+zte,msm8226,Amazing P6,5,-25,1
+zte,msm8226,Amazing X1,5,-25,1
+zte,msm8226,Amazing X2,5,-25,1
+zte,P632T31,Amazing X5,5,-25,1
+zte,ZTE_T620,Amazing X5s,5,-25,1
+zte,P839F30,Amazing X6,5,-25,1
+zte,P839V56,Amazing X7,5,-25,1
+zte,V77,Amazing p5_Lite,5,-25,1
+zte,K78,Amazing_P5,5,-25,1
+zte,K83,Amazing_P8,5,-25,1
+zte,Amazing_X3s,Amazing_X3s,5,-25,1
+zte,Amazing_X3s,Amazing_X3s_16G,5,-25,1
+zte,turies,Android Edition StarText,5,-25,1
+zte,blade,Android Edition StarTrail,5,-25,1
+zte,amigo,Android Edition Starnaute,5,-25,1
+zte,skate,Android edition by sfr STARADDICT,5,-25,1
+zte,Andromax_G46D1Z,Andromax G46D1Z,5,-25,1
+zte,atlas40,Avea inTouch 2,5,-25,1
+zte,P172E10,Avea inTouch 3,5,-25,1
+zte,P172D10,Avea inTouch 3 Large,5,-25,1
+zte,msm8916_32,Avea inTouch 4,5,-25,1
+zte,ztemt85_bx_kk,B760E,5,-25,1
+zte,ztemt85_bx_kk,B760H,5,-25,1
+zte,P172R10,B8405,5,-25,1
+zte,p200_2G,B860AV2,5,-25,1
+zte,B860H_V1,B860H,5,-25,1
+zte,B860H_V1,B860H V1.0,5,-25,1
+zte,B860H_V1,B860H V1.1,5,-25,1
+zte,B866_ZTE,B866,5,-25,1
+zte,skate,BASE Lutea 2,5,-25,1
+zte,v9,BASE Tab,5,-25,1
+zte,v9plus,BASE Tab 7.1,5,-25,1
+zte,blade,BASE lutea,5,-25,1
+zte,ZTE_Blade_A475,BGH JOY X2,5,-25,1
+zte,P172D01,BGH Joy Smart A1,5,-25,1
+zte,P172A10,BGH Joy Smart A2,5,-25,1
+zte,P172A30,BGH Joy Smart A3,5,-25,1
+zte,P172R10,BGH Joy Smart A5C,5,-25,1
+zte,P172R10,BGH Joy Smart A5d,5,-25,1
+zte,P172F10,BGH Joy Smart A6,5,-25,1
+zte,P172F10,BGH Joy Smart A6d,5,-25,1
+zte,P632A10,BGH Joy Smart A7G,5,-25,1
+zte,P182A10,BGH Joy Smart AXS,5,-25,1
+zte,P182A10,BGH Joy Smart AXS D,5,-25,1
+zte,N918St,BGH Joy Smart AXS II,5,-25,1
+zte,NX521J,BGH Joy Smart AXS II,5,-25,1
+zte,N918St,BGH Joy Smart AXS II D,5,-25,1
+zte,P635A20,BGH Joy V6,5,-25,1
+zte,ZTE_Blade_V580,BGH Joy X5,5,-25,1
+zte,v9,BLACK 03,5,-25,1
+zte,ZTE_BLADE_A110,BLADE A110,5,-25,1
+zte,P809F40,BLADE A3,5,-25,1
+zte,P809F20,BLADE A320,5,-25,1
+zte,P635A50,BLADE A510,5,-25,1
+zte,P637F10,BLADE A520,5,-25,1
+zte,P809F10,BLADE A521,5,-25,1
+zte,P639F10L,BLADE A530,5,-25,1
+zte,P639F10,BLADE A530,5,-25,1
+zte,P840F13,BLADE A6,5,-25,1
+zte,P809F15,BLADE A6 MAX,5,-25,1
+zte,P637F02,BLADE A602,5,-25,1
+zte,ZTE_BLADE_A610,BLADE A610,5,-25,1
+zte,P635A31,BLADE A910,5,-25,1
+zte,ZTE_Blade_A476,BLADE E01,5,-25,1
+zte,atlas40,BLADE III,5,-25,1
+zte,atlas40,BLADE III_IL,5,-25,1
+zte,P731F10,BLADE L7,5,-25,1
+zte,P731F12,BLADE L7A,5,-25,1
+zte,P840T22,BLADE V Ultra,5,-25,1
+zte,P653A10,BLADE V7,5,-25,1
+zte,ZTE_BLADE_V0800,BLADE V8,5,-25,1
+zte,ZTE_BLADE_V0850,BLADE V8 MINI,5,-25,1
+zte,ZTE_BLADE_V0820,BLADE V8 SE,5,-25,1
+zte,ZTE_BLADE_V0850,BLADE V8 mini,5,-25,1
+zte,P817F01,BLADE V8Q,5,-25,1
+zte,P450L10,BLADE V9,5,-25,1
+zte,P840F03,BLADE V9 VITA,5,-25,1
+zte,blade2,BLADEII,5,-25,1
+zte,blade,BLADE_N880,5,-25,1
+zte,ZTE-Baker,Baker,5,-25,1
+zte,blade,Beeline E400,5,-25,1
+zte,roamer2,Beeline E600,5,-25,1
+zte,P177E01,Beeline E700,5,-25,1
+zte,v9,Beeline M2,5,-25,1
+zte,P632A10,Beeline Pro,5,-25,1
+zte,P172R10,Beeline Smart 2,5,-25,1
+zte,ZTE-V811,Beeline Smart2,5,-25,1
+zte,Z3051T,Blade A3 2019,5,-25,1
+zte,Z3051T,Blade A3 2019-T,5,-25,1
+zte,P809A50,Blade A310,5,-25,1
+zte,P635E40,Blade A410,5,-25,1
+zte,P809A20,Blade A460,5,-25,1
+zte,ZTE_Blade_A465,Blade A465,5,-25,1
+zte,ZTE_Blade_A475,Blade A475,5,-25,1
+zte,Z5155T,Blade A5 2019-T,5,-25,1
+zte,P963F50,Blade A5 2020-T,5,-25,1
+zte,P635A50,Blade A510,5,-25,1
+zte,ZTE_Blade_A511,Blade A511,5,-25,1
+zte,Z6100T,Blade A7 2019-T,5,-25,1
+zte,coeus,Blade Apex,5,-25,1
+zte,msm8226,Blade Apex2,5,-25,1
+zte,P731A20,Blade C341,5,-25,1
+zte,oceanus,Blade G LTE,5,-25,1
+zte,P172F10,Blade G Lux,5,-25,1
+zte,P172A30,Blade G Pro,5,-25,1
+zte,atlas40,Blade III,5,-25,1
+zte,ZTE_BLADE_L110,Blade L110,5,-25,1
+zte,P182A10,Blade L2,5,-25,1
+zte,ZTE_Blade_L2_PLUS,Blade L2 Plus,5,-25,1
+zte,P182A20,Blade L3,5,-25,1
+zte,P172A50,Blade L3 Lite,5,-25,1
+zte,Blade_L3_Plus,Blade L3 Plus,5,-25,1
+zte,P172A40,Blade L5,5,-25,1
+zte,P680A20,Blade L5 Plus,5,-25,1
+zte,P816A12,Blade Q Lux,5,-25,1
+zte,P172D10,Blade Q Maxi,5,-25,1
+zte,P172A12,Blade Q2,5,-25,1
+zte,blade2,Blade S,5,-25,1
+zte,P839F30,Blade S,5,-25,1
+zte,P839F30,Blade S Lite,5,-25,1
+zte,P839F30,Blade S6,5,-25,1
+zte,P839F30,Blade S6 Lite,5,-25,1
+zte,P839F50,Blade S6 Plus,5,-25,1
+zte,P177A20,Blade Super,5,-25,1
+zte,P816A12,Blade V+,5,-25,1
+zte,ZTE_Blade_V580,Blade V580,5,-25,1
+zte,P635A20,Blade V6,5,-25,1
+zte,ZTE_BLADE_A610,Blade V6 Max,5,-25,1
+zte,ZTE_BLADE_V0720,Blade V6 Plus,5,-25,1
+zte,P692S20_Q82,Blade Vec,5,-25,1
+zte,nice,Bouygues Telecom Bs 351,5,-25,1
+zte,P172G10,Bouygues Telecom Bs 402,5,-25,1
+zte,P635F50,CELL C EMPIRE E8,5,-25,1
+zte,P855A23,CMCC M970,5,-25,1
+zte,mooncake,Carl,5,-25,1
+zte,P175A60,Cellcom 4G,5,-25,1
+zte,ZTE_BLADE_L110,ConeXis A1,5,-25,1
+zte,P809F52,ConeXis X1,5,-25,1
+zte,ZTE_BLADE_V0850,ConeXis X2,5,-25,1
+zte,nice,Cosmote Smart Share,5,-25,1
+zte,Cosmote-Xplore,Cosmote Xplore,5,-25,1
+zte,Cosmote,Cosmote Xplore,5,-25,1
+zte,D930,D930,5,-25,1
+zte,P731A20,DIGICEL DL755,5,-25,1
+zte,P172F10,DIGICEL DL800,5,-25,1
+zte,P182A20,DIGICEL DL910,5,-25,1
+zte,P637F02,DL2 PLUS,5,-25,1
+zte,frosty,Dialog Q143L,5,-25,1
+zte,P637F02,Digicel DL2 XL,5,-25,1
+zte,roamer2,Dubai,5,-25,1
+zte,roamer2,Dublin,5,-25,1
+zte,V6500,Etisalat Smartphone,5,-25,1
+zte,P635A31,Extreme E8,5,-25,1
+zte,msm8226,FT142D,5,-25,1
+zte,prindle,Grand Memo,5,-25,1
+zte,iris,Grand S Flex,5,-25,1
+zte,P189S10,Grand S Lite,5,-25,1
+zte,P175A20,Grand X,5,-25,1
+zte,mfld_pr2,Grand X In,5,-25,1
+zte,P177A20,Grand X Pro,5,-25,1
+zte,P175A20,Grand X(M),5,-25,1
+zte,redhookbay,Grand X2 In,5,-25,1
+zte,P809A01,Helios X1,5,-25,1
+zte,nice,ICE,5,-25,1
+zte,msm8226,Infinity X^2 mini,5,-25,1
+zte,crane-zte7,K75,5,-25,1
+zte,helen,K81,5,-25,1
+zte,K83,K83,5,-25,1
+zte,K83CA,K83CA,5,-25,1
+zte,K83,K83V,5,-25,1
+zte,K85,K85,5,-25,1
+zte,jasmine,K88,5,-25,1
+zte,gevjon,K90U,5,-25,1
+zte,primrose,K92,5,-25,1
+zte,K97,K97,5,-25,1
+zte,roamer2,KIS,5,-25,1
+zte,P731A20,KIS C341,5,-25,1
+zte,nice,KIS II,5,-25,1
+zte,P172R10,KIS II Max,5,-25,1
+zte,roamer2,KIS PLUS,5,-25,1
+zte,skate,KPN Smart 200,5,-25,1
+zte,P177A20,KPN Smart 300,5,-25,1
+zte,msm8226,KPN Smart 400,5,-25,1
+zte,N721,Karbonn_A1,5,-25,1
+zte,roamer2,Kis T3,5,-25,1
+zte,racer2,Kyivstar Shine,5,-25,1
+zte,blade,Kyivstar Spark,5,-25,1
+zte,P172D04,L8301,5,-25,1
+zte,P839F30,LS-5008,5,-25,1
+zte,P839F50,LS-5503,5,-25,1
+zte,roamer2,Leopard MF800,5,-25,1
+zte,P177E01,Leopard MF900,5,-25,1
+zte,v9,Light,5,-25,1
+zte,v9,Light Tab,5,-25,1
+zte,v9plus,Light Tab 2,5,-25,1
+zte,v9plus,Light Tab 2W,5,-25,1
+zte,roamer2,M8402,5,-25,1
+zte,P175A60,M9000,5,-25,1
+zte,ztenj73_gb,MD Smart,5,-25,1
+zte,atlas40,MEDION LIFE P4012,5,-25,1
+zte,skate,MEDION LIFE P4310,5,-25,1
+zte,roamer2,MEDION Smartphone LIFE E3501,5,-25,1
+zte,ZTE-P821E10,MEO SMART A16,5,-25,1
+zte,ZTE-P821E10,MEO Smart A16,5,-25,1
+zte,P172F10,MEO Smart A40,5,-25,1
+zte,P182A10,MEO Smart A75,5,-25,1
+zte,P182A20,MEO Smart A80,5,-25,1
+zte,blade,MF8604,5,-25,1
+zte,MF97A,MF97A,5,-25,1
+zte,msm8974,MF97B,5,-25,1
+zte,msm8974,MF97B_ROGERS,5,-25,1
+zte,msm8974,MF97B_T,5,-25,1
+zte,msm8974,MF97E,5,-25,1
+zte,msm8974,MF97G,5,-25,1
+zte,msm8974,MF97V,5,-25,1
+zte,MF97W,MF97W,5,-25,1
+zte,MO-01J,MO-01J,5,-25,1
+zte,MO-01K,MO-01K,5,-25,1
+zte,ZTE-P821E10,MOCHE SMART A16,5,-25,1
+zte,roundtop,MS4A,5,-25,1
+zte,kiska,MS4A,5,-25,1
+zte,V72,MT7A,5,-25,1
+zte,v9,MTC 1055,5,-25,1
+zte,mooncake,MTC 916,5,-25,1
+zte,P632T31,MTC SMART Run 4G,5,-25,1
+zte,mooncake,MTS-SP100,5,-25,1
+zte,mooncake2,MTS-SP102,5,-25,1
+zte,blade,MegaFon SP-A5,5,-25,1
+zte,v9plus,MegaFon V9+,5,-25,1
+zte,N720_Micromax,Micromax A60,5,-25,1
+zte,atlas40,Momodesign MD Droid,5,-25,1
+zte,skate,Monte Carlo,5,-25,1
+zte,QB7211,Movistar Express,5,-25,1
+zte,mooncake,Movistar Link,5,-25,1
+zte,roamer2,Movistar Motion,5,-25,1
+zte,blade,Movistar Prime,5,-25,1
+zte,P172D04,Movitel M8410,5,-25,1
+zte,mooncake2,Mtag 281,5,-25,1
+zte,N720,N720,5,-25,1
+zte,N721,N721,5,-25,1
+zte,roamer,N762,5,-25,1
+zte,N765,N765_APT,5,-25,1
+zte,roamer2,N788_BASHA,5,-25,1
+zte,deepblue,N790,5,-25,1
+zte,ZTE-N799D,N799D,5,-25,1
+zte,nex,N800,5,-25,1
+zte,N8000,N8000_USA_Cricket,5,-25,1
+zte,N8000,N8000_USA_RS,5,-25,1
+zte,N8000,N8000_WHTE_CKT,5,-25,1
+zte,N8010_APT,N8010_APT,5,-25,1
+zte,fluid,N810,5,-25,1
+zte,wellington,N817,5,-25,1
+zte,ZTE-N818,N818,5,-25,1
+zte,sapphire,N818S,5,-25,1
+zte,N8300_Reliance,N8300_Reliance,5,-25,1
+zte,roamer2,N8303,5,-25,1
+zte,sean,N850,5,-25,1
+zte,seanplus,N850L,5,-25,1
+zte,hope,N855D,5,-25,1
+zte,hope,N855D_PERFECTUM,5,-25,1
+zte,hope,N855D_YM,5,-25,1
+zte,arthur,N860,5,-25,1
+zte,warp2,N861,5,-25,1
+zte,blade,N880,5,-25,1
+zte,atlas40,N880E,5,-25,1
+zte,hayes,N9100,5,-25,1
+zte,apollo,N9101,5,-25,1
+zte,speed,N9130,5,-25,1
+zte,xray45,N9131,5,-25,1
+zte,cinco,N9132,5,-25,1
+zte,grayjoy,N9136,5,-25,1
+zte,msm8909go,N9137,5,-25,1
+zte,grayjoylite,N9137,5,-25,1
+zte,N9180,N9180,5,-25,1
+zte,N918St,N918St,5,-25,1
+zte,ZTE-N919D,N919D,5,-25,1
+zte,N940Sc,N940Sc,5,-25,1
+zte,gordon,N9500,5,-25,1
+zte,warplte,N9510,5,-25,1
+zte,warp4,N9515,5,-25,1
+zte,eridani,N9516,5,-25,1
+zte,warp8,N9517,5,-25,1
+zte,warp6,N9518,5,-25,1
+zte,beam,N9519,5,-25,1
+zte,stormer,N9520,5,-25,1
+zte,max,N9521,5,-25,1
+zte,bolton,N9560,5,-25,1
+zte,N958St,N958St,5,-25,1
+zte,quantum,N9810,5,-25,1
+zte,chovar,N9835,5,-25,1
+zte,P188F02,N986,5,-25,1
+zte,P188F10,N986+,5,-25,1
+zte,P188F10,N986D,5,-25,1
+zte,NE501J,NE501J,5,-25,1
+zte,P635F33,NOS FIVE,5,-25,1
+zte,P852F52,NOS NEVA 80,5,-25,1
+zte,ZTE_Blade_C370,NOS NOVU,5,-25,1
+zte,P680A20,NOS NOVU II,5,-25,1
+zte,P637F10,NOS NOVU III,5,-25,1
+zte,P839F30,NOS SLIM,5,-25,1
+zte,NX402,NX402,5,-25,1
+zte,NX40X,NX402,5,-25,1
+zte,NX403A,NX403A,5,-25,1
+zte,NX404H,NX404H,5,-25,1
+zte,NX405H,NX405H,5,-25,1
+zte,NX406E,NX406E,5,-25,1
+zte,NX40X,NX40X,5,-25,1
+zte,NX40X,NX40X_APT,5,-25,1
+zte,NX501,NX501,5,-25,1
+zte,NX501,NX501_APT,5,-25,1
+zte,NX503A_Z4,NX503A_Z4,5,-25,1
+zte,NX503J,NX503J,5,-25,1
+zte,NX505J,NX505J,5,-25,1
+zte,NX506J,NX506J,5,-25,1
+zte,NX507J,NX507H,5,-25,1
+zte,NX507J,NX507J,5,-25,1
+zte,NX508J,NX508J,5,-25,1
+zte,NX510J,NX510J,5,-25,1
+zte,NX511J,NX511J,5,-25,1
+zte,NX511J_V3,NX511J_V3,5,-25,1
+zte,NX512J,NX512J,5,-25,1
+zte,NX513J,NX513J,5,-25,1
+zte,NX521J,NX521J,5,-25,1
+zte,NX523J_V1,NX523J_V1,5,-25,1
+zte,NX527J_V1,NX527J_V1,5,-25,1
+zte,NX529J,NX529J,5,-25,1
+zte,NX531J,NX531J,5,-25,1
+zte,NX535J,NX535J,5,-25,1
+zte,NX541J,NX541J,5,-25,1
+zte,NX549J,NX549J,5,-25,1
+zte,NX551J,NX551J,5,-25,1
+zte,NX563J,NX563J,5,-25,1
+zte,NX569J,NX569J,5,-25,1
+zte,NX573J,NX573J,5,-25,1
+zte,NX575J,NX575J,5,-25,1
+zte,NX589J,NX589J,5,-25,1
+zte,NX591J,NX591J,5,-25,1
+zte,NX595J,NX595J,5,-25,1
+zte,NX597J,NX597J,5,-25,1
+zte,NX601J,NX601J,5,-25,1
+zte,NX606J,NX606J,5,-25,1
+zte,NX609J,NX609J,5,-25,1
+zte,NX612J,NX612J,5,-25,1
+zte,NX619J-EEA,NX619J,5,-25,1
+zte,NX619J,NX619J,5,-25,1
+zte,NX627J,NX627J,5,-25,1
+zte,NX627J-EEA,NX627J,5,-25,1
+zte,NX629J-EEA,NX629J,5,-25,1
+zte,NX629J,NX629J,5,-25,1
+zte,NX659J,NX659J,5,-25,1
+zte,NX907J,NX907J,5,-25,1
+zte,blade,Netphone 701,5,-25,1
+zte,VFD511,OWN FUN 5(4G),5,-25,1
+zte,ZTE_Blade_V580,OWN One Plus,5,-25,1
+zte,v9,One Pad,5,-25,1
+zte,blade2,Optimus Barcelona,5,-25,1
+zte,skate,Optimus Monte Carlo,5,-25,1
+zte,blade,Optimus San Francisco,5,-25,1
+zte,nice,Optimus Zali,5,-25,1
+zte,roamer2,Orange Dublin,5,-25,1
+zte,msm8226,Orange Hi 4G,5,-25,1
+zte,Orange_Hi_4G,Orange Hi 4G,5,-25,1
+zte,skate,Orange Monte Carlo,5,-25,1
+zte,Neva_jet,Orange Neva jet,5,-25,1
+zte,oceanus,Orange Novi,5,-25,1
+zte,P172D10,Orange Reyo,5,-25,1
+zte,msm8226,Orange Rono,5,-25,1
+zte,Vec4G,Orange Rono,5,-25,1
+zte,blade,Orange San Francisco,5,-25,1
+zte,blade,Orange Tactile internet 2,5,-25,1
+zte,P729B,Orange Tactile internet 2,5,-25,1
+zte,P172F10,Orange Tado,5,-25,1
+zte,nice,Orange Zali,5,-25,1
+zte,P635A20,Own One,5,-25,1
+zte,P932F20,P500,5,-25,1
+zte,P545,P545,5,-25,1
+zte,P609,P609,5,-25,1
+zte,msm8916_32,Preo Teknosa P1,5,-25,1
+zte,QB7211,QB7211,5,-25,1
+zte,platy,Quartz,5,-25,1
+zte,roamer2,RACER III mini,5,-25,1
+zte,racer2,RACERII,5,-25,1
+zte,mooncake,RTK D1,5,-25,1
+zte,blade,RTK V8,5,-25,1
+zte,v9,RTK V9,5,-25,1
+zte,mooncake,Racer,5,-25,1
+zte,racer2,RacerII,5,-25,1
+zte,P635E40,Rook from EE,5,-25,1
+zte,MT8123,S8Q,5,-25,1
+zte,P172R10,SMART Start,5,-25,1
+zte,ZTE_BLADE_L110,SMART Start 3,5,-25,1
+zte,whistler,STARADDICT II,5,-25,1
+zte,mfld_pr2,STARADDICT II Plus,5,-25,1
+zte,V6600,STARNAUTE II,5,-25,1
+zte,V71A,STARTAB,5,-25,1
+zte,QB7211,STARTEXT II,5,-25,1
+zte,P172E10,STARTRAIL 4,5,-25,1
+zte,prindle,STARXTREM,5,-25,1
+zte,msm8916_32,STARXTREM 4,5,-25,1
+zte,blade,San Francisco,5,-25,1
+zte,blade2,San Francisco II,5,-25,1
+zte,atlas40,Skate Pro,5,-25,1
+zte,skateplus,Skate4.3 H,5,-25,1
+zte,V11A,SmartTab10,5,-25,1
+zte,V71A,SmartTab7,5,-25,1
+zte,SoshPhone_3,SoshPhone 3,5,-25,1
+zte,Vec4G,Soshphone 4G,5,-25,1
+zte,msm8226,Soshphone 4G,5,-25,1
+zte,msm8974,Spro 2,5,-25,1
+zte,msm8974,Spro 2 LTE,5,-25,1
+zte,msm8974,Spro2,5,-25,1
+zte,blade2,T-Mobile Vivacity,5,-25,1
+zte,skate,T3,5,-25,1
+zte,P809A01,T57,5,-25,1
+zte,T77,T77,5,-25,1
+zte,P840F20,T85,5,-25,1
+zte,T86,T86,5,-25,1
+zte,primrose,T98,5,-25,1
+zte,v9,TO101,5,-25,1
+zte,QB7211,TQ150,5,-25,1
+zte,v9,TT101,5,-25,1
+zte,v9plus,TT102,5,-25,1
+zte,TURKCELL-T40,TURKCELL T40,5,-25,1
+zte,msm8226,TURKCELL T50,5,-25,1
+zte,P839T60,TURKCELL T60,5,-25,1
+zte,msm8916_32,TURKCELL T60,5,-25,1
+zte,P809T70,TURKCELL T70,5,-25,1
+zte,P840F14,TURKCELL T80,5,-25,1
+zte,msm8226,TURKCELL TURBO T50,5,-25,1
+zte,mooncake,TaiWan Mobile T2,5,-25,1
+zte,TWM_P726G,Taiwan Mobile T2,5,-25,1
+zte,P175A60,Telcel T20,5,-25,1
+zte,ztenj73_gb,Telenor Touch Mini,5,-25,1
+zte,v9plus,Telenor Touch Pad,5,-25,1
+zte,blade2,Telenor Touch Plus,5,-25,1
+zte,ZTE_Blade_V580,Turk Telekom TT175,5,-25,1
+zte,nice,Turkcell Maxi Plus 5,5,-25,1
+zte,racer2,Turkcell T11,5,-25,1
+zte,U9180,U9180,5,-25,1
+zte,P632A10,UZTE Blade Q Lux,5,-25,1
+zte,P731A10,UZTE Blade Q Pro,5,-25,1
+zte,P172R10,UZTE GRAND V7,5,-25,1
+zte,P188F04,UZTE GRAND X Quad,5,-25,1
+zte,roamer2,UZTE V790,5,-25,1
+zte,P177E01,UZTE V807,5,-25,1
+zte,P172E01,UZTE V808,5,-25,1
+zte,ZTE-V956,UZTE V817,5,-25,1
+zte,P175A10,UZTE V889M,5,-25,1
+zte,whistler,UZTE V970,5,-25,1
+zte,msm8916_32,Ultym 5.2,5,-25,1
+zte,NE501J,V5,5,-25,1
+zte,V55,V55,5,-25,1
+zte,V6020_Claro,V6020_Claro,5,-25,1
+zte,V66,V66,5,-25,1
+zte,V68,V68,5,-25,1
+zte,V71A,V71B,5,-25,1
+zte,ZTE-V72A,V72A,5,-25,1
+zte,v72c,V72C,5,-25,1
+zte,eos,V72M,5,-25,1
+zte,hct72_wet_jb3,V765M,5,-25,1
+zte,V769M,V769M,5,-25,1
+zte,roamer2,V788D,5,-25,1
+zte,P175A40,V791,5,-25,1
+zte,P172D01,V795(A3S),5,-25,1
+zte,V8000,V8000_USA_Cricket,5,-25,1
+zte,V8100_Z55,V8100_Z55,5,-25,1
+zte,V8110,V8110,5,-25,1
+zte,ZTE-V817,V817,5,-25,1
+zte,V8200_OSK,V8200-Memphis-orange-Slovakia,5,-25,1
+zte,V8200_EE_UK,V8200_EE_UK,5,-25,1
+zte,V8200plus,V8200plus,5,-25,1
+zte,MT8382,V8285,5,-25,1
+zte,V8300_Z39,V8300_Z39,5,-25,1
+zte,mooncake,V8402,5,-25,1
+zte,roamer2,V8403,5,-25,1
+zte,P177E01,V8501,5,-25,1
+zte,blade,V8502,5,-25,1
+zte,P172A30,V8507,5,-25,1
+zte,P821E10,V8514,5,-25,1
+zte,P188F07,V8602,5,-25,1
+zte,hct77_jb,V865M,5,-25,1
+zte,hct77_ics2,V865M,5,-25,1
+zte,joe,V871,5,-25,1
+zte,blade,V880,5,-25,1
+zte,nice,V880S,5,-25,1
+zte,bladeplus,V881,5,-25,1
+zte,V883M,V883M,5,-25,1
+zte,v9,V9,5,-25,1
+zte,v9plus,V9+,5,-25,1
+zte,V9180,V9180,5,-25,1
+zte,whistler,V961,5,-25,1
+zte,V96A,V96A,5,-25,1
+zte,V972M,V972M,5,-25,1
+zte,redhookbay,V975,5,-25,1
+zte,v9plus,V9A,5,-25,1
+zte,v9,V9C,5,-25,1
+zte,V9S,V9S,5,-25,1
+zte,v9,V9c,5,-25,1
+zte,v9,V9e,5,-25,1
+zte,v9plus,V9e+,5,-25,1
+zte,ZTE_BLADE_L110,VERGATARIO 5,5,-25,1
+zte,ZTE_BLADE_L110,VERGATARIO5PLUS,5,-25,1
+zte,P727A,VF945,5,-25,1
+zte,VFD520,VFD 520,5,-25,1
+zte,VFD822,VFD 822,5,-25,1
+zte,P172D03,VIETTEL V8411,5,-25,1
+zte,mooncake,Vip Droid,5,-25,1
+zte,atlas40,Vip Racer III,5,-25,1
+zte,joe,Vodafone 945,5,-25,1
+zte,ZTE-Blade-V,Vodafone Blade V,5,-25,1
+zte,turies,Vodafone Smart Chat,5,-25,1
+zte,msm8916_32,Vodafone Smart ultra 6,5,-25,1
+zte,arthur,Warp,5,-25,1
+zte,blade,WayteQ Libra,5,-25,1
+zte,X500,X500,5,-25,1
+zte,X500,X500_USA_General,5,-25,1
+zte,X501,X501_USA_Cricket,5,-25,1
+zte,X501,X501_USA_OM,5,-25,1
+zte,X501,X501_USA_RS,5,-25,1
+zte,P182A20,X8607,5,-25,1
+zte,X9180,X9180,5,-25,1
+zte,mooncake,XCD 28,5,-25,1
+zte,blade,XCD35,5,-25,1
+zte,Z-01K,Z-01K,5,-25,1
+zte,P963F30P,Z3,5,-25,1
+zte,sapphire4g,Z3001S,5,-25,1
+zte,Z3153,Z3153V,5,-25,1
+zte,Z3351,Z3351S,5,-25,1
+zte,oldman,Z353VL,5,-25,1
+zte,Z5031O,Z5031O,5,-25,1
+zte,Z5151,Z5151V,5,-25,1
+zte,msm8909,Z557BL,5,-25,1
+zte,lewis,Z557BL,5,-25,1
+zte,Z557,Z557BL,5,-25,1
+zte,msm8909,Z558VL,5,-25,1
+zte,Z559DL,Z559DL,5,-25,1
+zte,msm8937,Z610DL,5,-25,1
+zte,Z6201,Z6201V,5,-25,1
+zte,Z6400,Z6400C,5,-25,1
+zte,Z6410,Z6410S,5,-25,1
+zte,Z6530,Z6530M,5,-25,1
+zte,Z6530,Z6530V,5,-25,1
+zte,nice,Z660G,5,-25,1
+zte,Z6621O,Z6621O,5,-25,1
+zte,seanplus,Z665C,5,-25,1
+zte,demi,Z667,5,-25,1
+zte,bonnie,Z667T,5,-25,1
+zte,demi,Z669,5,-25,1
+zte,baffin,Z716BL,5,-25,1
+zte,lavender,Z717VL,5,-25,1
+zte,lemon,Z718TL,5,-25,1
+zte,msm8909,Z719DL,5,-25,1
+zte,ada,Z730,5,-25,1
+zte,metis,Z740,5,-25,1
+zte,metis,Z740G,5,-25,1
+zte,Z750C,Z750C,5,-25,1
+zte,eros,Z752C,5,-25,1
+zte,faerie,Z753G,5,-25,1
+zte,iris,Z755,5,-25,1
+zte,Z768G,Z768G,5,-25,1
+zte,betty,Z777,5,-25,1
+zte,apus,Z787,5,-25,1
+zte,giant,Z791G,5,-25,1
+zte,giant,Z792,5,-25,1
+zte,hera,Z793C,5,-25,1
+zte,ZTE-Z795G,Z795G,5,-25,1
+zte,Z796C,Z796C,5,-25,1
+zte,carol,Z797C,5,-25,1
+zte,stark,Z798BL,5,-25,1
+zte,martell,Z799VL,5,-25,1
+zte,xuantan,Z812,5,-25,1
+zte,xuantan,Z813,5,-25,1
+zte,sheen,Z815,5,-25,1
+zte,sunny,Z818L,5,-25,1
+zte,sungod,Z819L,5,-25,1
+zte,P675T07,Z820,5,-25,1
+zte,herculis,Z826,5,-25,1
+zte,achill,Z828,5,-25,1
+zte,achill,Z828TL,5,-25,1
+zte,gruis,Z830,5,-25,1
+zte,chapel,Z831,5,-25,1
+zte,mimir,Z832,5,-25,1
+zte,camellia,Z833,3,-25,3
+zte,draco,Z835,5,-25,1
+zte,guardian,Z836BL,5,-25,1
+zte,guardian,Z836F,5,-25,1
+zte,breaker,Z837VL,5,-25,1
+zte,sweet,Z839,5,-25,1
+zte,sweet,Z839V,5,-25,1
+zte,sif,Z850,5,-25,1
+zte,jeff,Z851,5,-25,1
+zte,jeff,Z851M,5,-25,1
+zte,kelly,Z852,5,-25,1
+zte,calbee,Z855,5,-25,1
+zte,benz,Z861BL,5,-25,1
+zte,captain,Z862VL,5,-25,1
+zte,weeper,Z863DL,5,-25,1
+zte,msm8909,Z899VL,5,-25,1
+zte,red,Z916BL,5,-25,1
+zte,fortune,Z917VL,5,-25,1
+zte,coeus,Z930L,5,-25,1
+zte,warplte,Z932L,5,-25,1
+zte,glaucus,Z933,5,-25,1
+zte,gift,Z936L,5,-25,1
+zte,leo,Z955A,5,-25,1
+zte,leo,Z955L,5,-25,1
+zte,financier,Z956,5,-25,1
+zte,financier,Z957,5,-25,1
+zte,lol,Z958,5,-25,1
+zte,abby,Z959,5,-25,1
+zte,tom,Z962BL,5,-25,1
+zte,lily,Z963U,5,-25,1
+zte,nancy,Z963VL,5,-25,1
+zte,proline,Z965,5,-25,1
+zte,noah,Z968,5,-25,1
+zte,draconis,Z970,5,-25,1
+zte,peony,Z971,5,-25,1
+zte,dandelion,Z978,5,-25,1
+zte,cygni,Z980L,5,-25,1
+zte,urd,Z981,5,-25,1
+zte,crocus,Z982,5,-25,1
+zte,stollen,Z983,5,-25,1
+zte,florist,Z986DL,5,-25,1
+zte,cynthia,Z986U,5,-25,1
+zte,cygni,Z987,5,-25,1
+zte,jerry,Z988,5,-25,1
+zte,aviva,Z992,5,-25,1
+zte,aviva,Z993,5,-25,1
+zte,becky,Z995,5,-25,1
+zte,coeus,Z998,5,-25,1
+zte,fujisan,Z999,5,-25,1
+zte,msm8974,ZKB2A,5,-25,1
+zte,P671F50,ZTE 2050,5,-25,1
+zte,P671F50_D,ZTE 2050,5,-25,1
+zte,P671S50,ZTE 2050,5,-25,1
+zte,P671F50_D,ZTE 2050RU,5,-25,1
+zte,P671F60,ZTE 9000,5,-25,1
+zte,P637S15,ZTE A0616,5,-25,1
+zte,P840S13,ZTE A0620,5,-25,1
+zte,P817S13,ZTE A0622,5,-25,1
+zte,P840S18,ZTE A0722,5,-25,1
+zte,msm8994,ZTE A2015,5,-25,1
+zte,msm8994,ZTE A2016,5,-25,1
+zte,msm8996,ZTE A2017,5,-25,1
+zte,ailsa_ii,ZTE A2017,5,-25,1
+zte,ailsa_ii,ZTE A2017G,5,-25,1
+zte,ailsa_ii,ZTE A2017U,5,-25,1
+zte,candice,ZTE A2018,5,-25,1
+zte,P845A02,ZTE A2019 Pro,5,-25,1
+zte,P845A01,ZTE A2019G Pro,5,-25,1
+zte,P855A02,ZTE A2020 Pro,6,-26,1
+zte,P855A01,ZTE A2020G Pro,6,-26,1
+zte,P855A21,ZTE A2020N2 Pro,5,-25,1
+zte,P855A21,ZTE A2020N3 Pro,6,-26,1
+zte,P855A01,ZTE A2020RU Pro,6,-26,1
+zte,P855A03_NA,ZTE A2020U Pro,6,-26,3
+zte,P725A12,ZTE A2021,5,-25,1
+zte,P809S10,ZTE A520S,5,-25,1
+zte,P639T10,ZTE A530,5,-25,1
+zte,P639S10,ZTE A606,5,-25,1
+zte,P671S02,ZTE A7000,5,-25,1
+zte,P662S02,ZTE A7010,5,-25,1
+zte,ZTE-A880,ZTE A880,5,-25,1
+zte,P855A03,ZTE Axon 10 Pro,6,-26,1
+zte,msm8916_64,ZTE B2015,5,-25,1
+zte,msm8916_64,ZTE B2016,5,-25,1
+zte,msm8952_64,ZTE B2017G,5,-25,1
+zte,tulip,ZTE B2017G,5,-25,1
+zte,verdandi,ZTE B2017G,5,-25,1
+zte,roamer2,ZTE B790,5,-25,1
+zte,ZTE-T792,ZTE B792,5,-25,1
+zte,P172D01,ZTE B795,5,-25,1
+zte,P172R10,ZTE B815,5,-25,1
+zte,P172R10,ZTE B816,5,-25,1
+zte,P635N30,ZTE B880,5,-25,1
+zte,S_P635N30,ZTE B880,5,-25,1
+zte,P635T39,ZTE BA510,5,-25,1
+zte,P637T10,ZTE BA520,5,-25,1
+zte,ZTE_BA601,ZTE BA601,5,-25,1
+zte,P637S02,ZTE BA602,5,-25,1
+zte,P637T02,ZTE BA602T,5,-25,1
+zte,P809S10,ZTE BA603,5,-25,1
+zte,P635N36,ZTE BA610C,5,-25,1
+zte,V_P635T36,ZTE BA610T,5,-25,1
+zte,P635T36,ZTE BA610T,5,-25,1
+zte,P635N40,ZTE BA611C,5,-25,1
+zte,V_P635T40,ZTE BA611T,5,-25,1
+zte,P635T40,ZTE BA611T,5,-25,1
+zte,V_P653N31,ZTE BA910,5,-25,1
+zte,P653N31,ZTE BA910,5,-25,1
+zte,T_P653N31,ZTE BA910T,5,-25,1
+zte,P809F15,ZTE BLADE A0605,5,-25,1
+zte,P840F12,ZTE BLADE A0620,5,-25,1
+zte,P840F13,ZTE BLADE A0621,5,-25,1
+zte,P809F12,ZTE BLADE A0622,5,-25,1
+zte,ZTE_BLADE_A110,ZTE BLADE A110,5,-25,1
+zte,P635A60,ZTE BLADE A112,5,-25,1
+zte,P809F01,ZTE BLADE A125,5,-25,1
+zte,ZTE_Blade_A210,ZTE BLADE A210,5,-25,1
+zte,P809F40,ZTE BLADE A3,5,-25,1
+zte,P809A50,ZTE BLADE A310,5,-25,1
+zte,P809F20,ZTE BLADE A320,5,-25,1
+zte,VFD511,ZTE BLADE A321,5,-25,1
+zte,P809F30,ZTE BLADE A330,5,-25,1
+zte,P809A20,ZTE BLADE A460,5,-25,1
+zte,P809T70,ZTE BLADE A506,5,-25,1
+zte,P809F52,ZTE BLADE A506,5,-25,1
+zte,P635A50,ZTE BLADE A510,5,-25,1
+zte,P817E52,ZTE BLADE A512,5,-25,1
+zte,P637F10,ZTE BLADE A520,5,-25,1
+zte,P809F10,ZTE BLADE A520C,5,-25,1
+zte,P809F10,ZTE BLADE A521,5,-25,1
+zte,P817E53,ZTE BLADE A522,5,-25,1
+zte,P639F10,ZTE BLADE A530,5,-25,1
+zte,P639F10L,ZTE BLADE A530,5,-25,1
+zte,P840F13,ZTE BLADE A6,5,-25,1
+zte,P809F15,ZTE BLADE A6 MAX,5,-25,1
+zte,ZTE_BLADE_A601,ZTE BLADE A601,5,-25,1
+zte,P637F02,ZTE BLADE A602,5,-25,1
+zte,ZTE_BLADE_A610,ZTE BLADE A610,5,-25,1
+zte,P635F50,ZTE BLADE A610C,5,-25,1
+zte,P635F50,ZTE BLADE A612,5,-25,1
+zte,P635A31,ZTE BLADE A910,5,-25,1
+zte,ZTE_BLADE_L110,ZTE BLADE B111,5,-25,1
+zte,P635A60,ZTE BLADE B112,5,-25,1
+zte,P809F01,ZTE BLADE B125,5,-25,1
+zte,P177E01,ZTE BLADE C,5,-25,1
+zte,ZTE_Blade_C370,ZTE BLADE C370,5,-25,1
+zte,atlas40,ZTE BLADE III,5,-25,1
+zte,P680A20,ZTE BLADE L0510,5,-25,1
+zte,ZTE_BLADE_L110,ZTE BLADE L110,5,-25,1
+zte,ZTE_BLADE_L110,ZTE BLADE L111,5,-25,1
+zte,P680A20,ZTE BLADE L5 PLUS,5,-25,1
+zte,P731F10,ZTE BLADE L7,5,-25,1
+zte,P731F12,ZTE BLADE L7A,5,-25,1
+zte,P731F12,ZTE BLADE L8,5,-25,1
+zte,crocus,ZTE BLADE V Ultra Z982,5,-25,1
+zte,ZTE_BLADE_V0710,ZTE BLADE V0710,5,-25,1
+zte,ZTE_BLADE_V0720,ZTE BLADE V0720,5,-25,1
+zte,ZTE_BLADE_V0730,ZTE BLADE V0730,5,-25,1
+zte,ZTE_BLADE_V0800,ZTE BLADE V0800,5,-25,1
+zte,ZTE_BLADE_V0820,ZTE BLADE V0820,5,-25,1
+zte,P817F01,ZTE BLADE V0840,5,-25,1
+zte,ZTE_BLADE_V0850,ZTE BLADE V0850,5,-25,1
+zte,P450F10,ZTE BLADE V0900,5,-25,1
+zte,P840F03,ZTE BLADE V0920,5,-25,1
+zte,P653A10,ZTE BLADE V7,5,-25,1
+zte,ZTE_BLADE_V0720,ZTE BLADE V7 LITE,5,-25,1
+zte,P653A11,ZTE BLADE V7 PLUS,5,-25,1
+zte,ZTE_BLADE_V0850,ZTE BLADE V8 MINI,5,-25,1
+zte,P450F10,ZTE BLADE V9,5,-25,1
+zte,P450L10,ZTE BLADE V9,5,-25,1
+zte,P840F03,ZTE BLADE V9 VITA,5,-25,1
+zte,P653N11,ZTE BV0701,5,-25,1
+zte,P655A30,ZTE BV0710,5,-25,1
+zte,P655A30,ZTE BV0710T,5,-25,1
+zte,P650A30,ZTE BV0720,5,-25,1
+zte,P650A30,ZTE BV0720T,5,-25,1
+zte,P650A31,ZTE BV0730,5,-25,1
+zte,P840S10,ZTE BV0800,5,-25,1
+zte,P840S01,ZTE BV0850,5,-25,1
+zte,P840V71,ZTE BV0870,5,-25,1
+zte,P963F01,ZTE Blade 10 Vita,5,-25,1
+zte,P172F01,ZTE Blade 2,5,-25,1
+zte,P817F18,ZTE Blade A0722,5,-25,1
+zte,ZTE_Blade_A210,ZTE Blade A210,5,-25,1
+zte,P932K20,ZTE Blade A3 2019,5,-25,1
+zte,P932F20,ZTE Blade A3 2019,5,-25,1
+zte,P932F20,ZTE Blade A3 2019RU,5,-25,1
+zte,P932F50,ZTE Blade A3 2020,5,-25,1
+zte,P932F50,ZTE Blade A3 2020RU,5,-25,1
+zte,P932F20,ZTE Blade A3 Lite,5,-25,1
+zte,ZTE_Blade_A315,ZTE Blade A315,5,-25,1
+zte,P635E40,ZTE Blade A410,5,-25,1
+zte,P632A10,ZTE Blade A430,5,-25,1
+zte,P632T31,ZTE Blade A450,5,-25,1
+zte,P635F33,ZTE Blade A452,5,-25,1
+zte,P809A20,ZTE Blade A460,5,-25,1
+zte,P809A50,ZTE Blade A462,5,-25,1
+zte,ZTE_Blade_A465,ZTE Blade A465,5,-25,1
+zte,P809A40,ZTE Blade A470,5,-25,1
+zte,ZTE_Blade_A475,ZTE Blade A475,5,-25,1
+zte,ZTE_Blade_A476,ZTE Blade A476,5,-25,1
+zte,P731A20,ZTE Blade A5,5,-25,1
+zte,P963F30P,ZTE Blade A5 2019,5,-25,1
+zte,P963F30,ZTE Blade A5 2019,5,-25,1
+zte,P963F30P,ZTE Blade A5 2019RU,5,-25,1
+zte,P963F50,ZTE Blade A5 2020,5,-25,1
+zte,P963F50,ZTE Blade A5 2020RU,5,-25,1
+zte,ZTE_Blade_A511,ZTE Blade A511,5,-25,1
+zte,ZTE_Blade_A511,ZTE Blade A515,5,-25,1
+zte,P817E53,ZTE Blade A522,5,-25,1
+zte,P932F10,ZTE Blade A531,5,-25,1
+zte,ZTE_T617,ZTE Blade A570,5,-25,1
+zte,ZTE_BLADE_A610,ZTE Blade A610,5,-25,1
+zte,P963F02,ZTE Blade A7 2019,5,-25,1
+zte,P963F02,ZTE Blade A7 2019RU,5,-25,1
+zte,P662F02D,ZTE Blade A7 2020,5,-25,1
+zte,P662F02_D1,ZTE Blade A7 2020,5,-25,1
+zte,P662F02D,ZTE Blade A7 2020RU,5,-25,1
+zte,P662F02_D1,ZTE Blade A7 2020RU,5,-25,1
+zte,P662F02,ZTE Blade A7s,5,-25,1
+zte,P731A20,ZTE Blade AF5,5,-25,1
+zte,oceanus,ZTE Blade Apex,5,-25,1
+zte,msm8226,ZTE Blade Apex2,5,-25,1
+zte,msm8916_32,ZTE Blade Apex3,5,-25,1
+zte,P172R10,ZTE Blade Buzz,5,-25,1
+zte,P172A10,ZTE Blade C2,5,-25,1
+zte,P172B20,ZTE Blade C2 Plus,5,-25,1
+zte,P172D04,ZTE Blade C310,5,-25,1
+zte,P715A20,ZTE Blade C312,5,-25,1
+zte,P172R10,ZTE Blade C320,5,-25,1
+zte,P172R12,ZTE Blade C340,5,-25,1
+zte,P731A20,ZTE Blade C341,5,-25,1
+zte,P731A20,ZTE Blade C342,5,-25,1
+zte,ZTE_Blade_C370,ZTE Blade C370,5,-25,1
+zte,P658A10,ZTE Blade D6 Lite 3G,5,-25,1
+zte,P635A30,ZTE Blade D6 Lite 4G,5,-25,1
+zte,ZTE-Blade-G,ZTE Blade G,5,-25,1
+zte,coeus,ZTE Blade G LTE,5,-25,1
+zte,P172F10,ZTE Blade G Lux,5,-25,1
+zte,P172A30,ZTE Blade G Plus,5,-25,1
+zte,P172A30,ZTE Blade G Pro,5,-25,1
+zte,P188F03,ZTE Blade G2,5,-25,1
+zte,ZTE_Blade_HN,ZTE Blade HN,5,-25,1
+zte,atlas40,ZTE Blade III,5,-25,1
+zte,Blade-III-Pro,ZTE Blade III Pro,5,-25,1
+zte,P177A10,ZTE Blade L,5,-25,1
+zte,ZTE_BLADE_L110,ZTE Blade L110,5,-25,1
+zte,P731F30,ZTE Blade L130,5,-25,1
+zte,P731K30,ZTE Blade L130,5,-25,1
+zte,P731F30,ZTE Blade L130RU,5,-25,1
+zte,P182A10,ZTE Blade L2,5,-25,1
+zte,P182A20,ZTE Blade L3,5,-25,1
+zte,ZTE_Blade_L3_Apex,ZTE Blade L3 Apex,5,-25,1
+zte,P172A50,ZTE Blade L3 Lite,5,-25,1
+zte,ZTE_Blade_L3_Plus,ZTE Blade L3 Plus,5,-25,1
+zte,ZTE_Blade_L315,ZTE Blade L315,5,-25,1
+zte,ZTE_Blade_C370,ZTE Blade L370,5,-25,1
+zte,ZTE_Blade_A475,ZTE Blade L4 Pro,5,-25,1
+zte,P172A40,ZTE Blade L5,5,-25,1
+zte,P680A20,ZTE Blade L5 Plus,5,-25,1
+zte,P680A10,ZTE Blade L6,5,-25,1
+zte,P731F20,ZTE Blade L8,5,-25,1
+zte,P731F20,ZTE Blade L8RU,5,-25,1
+zte,P172E10,ZTE Blade Q,5,-25,1
+zte,P816A12,ZTE Blade Q Lux,5,-25,1
+zte,P632A10,ZTE Blade Q Lux,5,-25,1
+zte,P632A10,ZTE Blade Q Lux 3G,5,-25,1
+zte,P172D10,ZTE Blade Q Maxi,5,-25,1
+zte,P172G10,ZTE Blade Q Mini,5,-25,1
+zte,P172G10_UK_VIRGIN,ZTE Blade Q Mini,5,-25,1
+zte,P172R10,ZTE Blade Q1,5,-25,1
+zte,P731A30,ZTE Blade Q3,5,-25,1
+zte,P839T60,ZTE Blade S6 Flex,5,-25,1
+zte,P839F50,ZTE Blade S6 Plus,5,-25,1
+zte,ZTE-Blade-V,ZTE Blade V,5,-25,1
+zte,P671F20,ZTE Blade V10,5,-25,1
+zte,P963F01,ZTE Blade V10 Vita,5,-25,1
+zte,P963F01,ZTE Blade V10 Vita RU,5,-25,1
+zte,P963F01D,ZTE Blade V10 Vita RU,5,-25,1
+zte,P671F20,ZTE Blade V1000,5,-25,1
+zte,P671F20D,ZTE Blade V1000RU,5,-25,1
+zte,msm8916_32,ZTE Blade V2,5,-25,1
+zte,P632T31,ZTE Blade V2 Lite,5,-25,1
+zte,msm8916_32,ZTE Blade V220,5,-25,1
+zte,ZTE_Blade_V580,ZTE Blade V580,5,-25,1
+zte,P635A20,ZTE Blade V6,5,-25,1
+zte,P680A10,ZTE Blade V6 Lite,5,-25,1
+zte,ZTE_BLADE_V0720,ZTE Blade V6 Plus,5,-25,1
+zte,P852F52,ZTE Blade V770,5,-25,1
+zte,P840V80,ZTE Blade V8 Arc,5,-25,1
+zte,P692S20_Q82,ZTE Blade VEC,5,-25,1
+zte,P692S20_Q82,ZTE Blade Vec,5,-25,1
+zte,msm8226,ZTE Blade Vec 4G,5,-25,1
+zte,P692S20_M92,ZTE Blade Vec Pro,5,-25,1
+zte,orchid,ZTE C2016,5,-25,1
+zte,alice,ZTE C2017,5,-25,1
+zte,P172D04,ZTE C310,5,-25,1
+zte,P635N32,ZTE C880,5,-25,1
+zte,P635B32,ZTE C880A,5,-25,1
+zte,P635D32,ZTE C880D,5,-25,1
+zte,V_P635N34,ZTE C880S,5,-25,1
+zte,P635N34,ZTE C880S,5,-25,1
+zte,S_P635N34,ZTE C880S,5,-25,1
+zte,T_P635N34,ZTE C880S,5,-25,1
+zte,P635V32,ZTE C880U,5,-25,1
+zte,P632A10,ZTE Fit 4G Smart,5,-25,1
+zte,P172E02,ZTE G601U,5,-25,1
+zte,P692N30,ZTE G717C,5,-25,1
+zte,ZTE-G718C,ZTE G718C,5,-25,1
+zte,ZTE-G719C,ZTE G719C,5,-25,1
+zte,ZTE-G720C,ZTE G720C,5,-25,1
+zte,P839T30,ZTE G720T,5,-25,1
+zte,V_P839T30,ZTE G720T,5,-25,1
+zte,atlas40,ZTE G882,5,-25,1
+zte,msm8226,ZTE GEEK II 4G,5,-25,1
+zte,ztexasp92_wet_jb9,ZTE GEEK II Pro,5,-25,1
+zte,msm8226,ZTE GEEK II Pro 4G,5,-25,1
+zte,redhookbay,ZTE Geek,5,-25,1
+zte,P692S20_Q82,ZTE Geek 2,5,-25,1
+zte,msm8226,ZTE Geek 2 LTE,5,-25,1
+zte,P692S20_M92,ZTE Geek 2 pro,5,-25,1
+zte,enterprise_RU,ZTE Grand Era,5,-25,1
+zte,enterprise_HK,ZTE Grand Era,5,-25,1
+zte,Grand-Memo,ZTE Grand Memo,5,-25,1
+zte,Grand-Memo,ZTE Grand Memo LTE,5,-25,1
+zte,P189F13,ZTE Grand Memo lite,5,-25,1
+zte,ZTE-V988,ZTE Grand S,5,-25,1
+zte,Grand-S,ZTE Grand S,5,-25,1
+zte,ZTE-Grand-S,ZTE Grand S,5,-25,1
+zte,iris,ZTE Grand S Flex,5,-25,1
+zte,P897A21,ZTE Grand S II,5,-25,1
+zte,P541T50,ZTE Grand S II,5,-25,1
+zte,msm8974,ZTE Grand S II LTE,5,-25,1
+zte,P188F04,ZTE Grand X,5,-25,1
+zte,whistler,ZTE Grand X,5,-25,1
+zte,P682F06,ZTE Grand X 2,5,-25,1
+zte,P175A20,ZTE Grand X Classic,5,-25,1
+zte,mfld_pr2,ZTE Grand X In,5,-25,1
+zte,P188F07,ZTE Grand X Quad Lite,5,-25,1
+zte,P188F07,ZTE Grand X2,5,-25,1
+zte,redhookbay,ZTE Grand X2 In,5,-25,1
+zte,K97,ZTE K97,5,-25,1
+zte,P175A60,ZTE KIS Flex,5,-25,1
+zte,P172D01,ZTE KIS II,5,-25,1
+zte,P172D01,ZTE KIS II PRO,5,-25,1
+zte,ZTE-P821E10,ZTE Kis 3,5,-25,1
+zte,P172D01,ZTE Kis II,5,-25,1
+zte,P172R10,ZTE Kis II Max,5,-25,1
+zte,P172R10,ZTE Kis II Max Plus,5,-25,1
+zte,P172R10,ZTE Kis II Max plus,5,-25,1
+zte,roamer2,ZTE Kis Lite,5,-25,1
+zte,nice,ZTE Kis Pro,5,-25,1
+zte,P172D02,ZTE Kis Q,5,-25,1
+zte,P172F10,ZTE Kis3 max,5,-25,1
+zte,V883M,ZTE LEO M1,5,-25,1
+zte,hct72_wet_jb3,ZTE LEO Q1,5,-25,1
+zte,V769M,ZTE LEO Q2,5,-25,1
+zte,V972M,ZTE LEO S1,5,-25,1
+zte,V982M_Z64,ZTE LEO S2,5,-25,1
+zte,blade,ZTE Libra,5,-25,1
+zte,ztexasp92_wet_jb9,ZTE M1001,5,-25,1
+zte,P692N60,ZTE M901C,5,-25,1
+zte,P172R10,ZTE Maxx,5,-25,1
+zte,ZTE-N5,ZTE N5,5,-25,1
+zte,prmthus,ZTE N5L,5,-25,1
+zte,P189F10,ZTE N5S,5,-25,1
+zte,mooncake2,ZTE N660,5,-25,1
+zte,roamer2,ZTE N788,5,-25,1
+zte,roamer2,ZTE N789,5,-25,1
+zte,deepblue,ZTE N790,5,-25,1
+zte,deepblue,ZTE N790S,5,-25,1
+zte,deepblue,ZTE N795,5,-25,1
+zte,atlas40,ZTE N798,5,-25,1
+zte,ZTE_N798,ZTE N798+,5,-25,1
+zte,ZTE_N798P,ZTE N798+,5,-25,1
+zte,ZTE-N799D,ZTE N799D,5,-25,1
+zte,ZTE-N807,ZTE N807,5,-25,1
+zte,ZTE-N818,ZTE N818,5,-25,1
+zte,hope,ZTE N855,5,-25,1
+zte,hope,ZTE N855D,5,-25,1
+zte,hope,ZTE N855D+,5,-25,1
+zte,atlas40,ZTE N880E,5,-25,1
+zte,msm7627a,ZTE N880F,5,-25,1
+zte,ZTE-N880F,ZTE N880F,5,-25,1
+zte,ZTE-N880G,ZTE N880G,5,-25,1
+zte,atlas40,ZTE N881D,5,-25,1
+zte,ZTE-N881E,ZTE N881E,5,-25,1
+zte,ZTE-N881F,ZTE N881F,5,-25,1
+zte,atlas40,ZTE N882E,5,-25,1
+zte,ZTE-N900,ZTE N900,5,-25,1
+zte,ZTE-N900D,ZTE N900D,5,-25,1
+zte,ZTE-N909,ZTE N909,5,-25,1
+zte,ZTE-N909D,ZTE N909D,5,-25,1
+zte,elden,ZTE N9120,5,-25,1
+zte,N918St,ZTE N918St,5,-25,1
+zte,ZTE-N919,ZTE N919,5,-25,1
+zte,ZTE-N919D,ZTE N919D,5,-25,1
+zte,N928Dt,ZTE N928Dt,5,-25,1
+zte,skate,ZTE N960,5,-25,1
+zte,dana,ZTE N970,5,-25,1
+zte,ZTE-N980,ZTE N980,5,-25,1
+zte,P177F03,ZTE N983,5,-25,1
+zte,chovar,ZTE N9835,5,-25,1
+zte,P188F02,ZTE N986,5,-25,1
+zte,ZTE-N988,ZTE N988,5,-25,1
+zte,P_P635N34,ZTE P_C880S,5,-25,1
+zte,P810T10,ZTE Q101T,5,-25,1
+zte,P172T24,ZTE Q201T,5,-25,1
+zte,P826N50,ZTE Q2S-C,5,-25,1
+zte,P826T50,ZTE Q2S-T,5,-25,1
+zte,APT_TW_P810N30,ZTE Q301C,5,-25,1
+zte,P810N30,ZTE Q301C,5,-25,1
+zte,P172T33,ZTE Q301T,5,-25,1
+zte,P809N20,ZTE Q302C,5,-25,1
+zte,P816N34,ZTE Q5-C,5,-25,1
+zte,P816T32,ZTE Q5-T,5,-25,1
+zte,CU_P816T32,ZTE Q5-T,5,-25,1
+zte,P172T31,ZTE Q501T,5,-25,1
+zte,P172F04,ZTE Q501U,5,-25,1
+zte,P682V53,ZTE Q503U,5,-25,1
+zte,P826T20,ZTE Q505T,5,-25,1
+zte,P682T20,ZTE Q507T,5,-25,1
+zte,P816V50,ZTE Q508U,5,-25,1
+zte,P632T31,ZTE Q509T,5,-25,1
+zte,ZTE_Q519T,ZTE Q519T,5,-25,1
+zte,V_P635N33,ZTE Q529C,5,-25,1
+zte,P635N33,ZTE Q529C,5,-25,1
+zte,P635T35,ZTE Q529E,5,-25,1
+zte,P635T33,ZTE Q529T,5,-25,1
+zte,CMCC_P839V50,ZTE Q7,5,-25,1
+zte,CU_P839V50,ZTE Q7,5,-25,1
+zte,P839V50,ZTE Q7,5,-25,1
+zte,P839N50,ZTE Q7-C,5,-25,1
+zte,ZTE-Q701C,ZTE Q701C,5,-25,1
+zte,P682V60,ZTE Q705U,5,-25,1
+zte,ZTE-Q801C,ZTE Q801C,5,-25,1
+zte,ZTE-Q801L,ZTE Q801L,5,-25,1
+zte,P181L30,ZTE Q801T,5,-25,1
+zte,P826V30,ZTE Q801U,5,-25,1
+zte,ZTE-Q802C,ZTE Q802C,5,-25,1
+zte,ZTE-Q802D,ZTE Q802D,5,-25,1
+zte,P826T30,ZTE Q802T,5,-25,1
+zte,P120T55,ZTE Q805T,5,-25,1
+zte,V_P635T30,ZTE Q806T,5,-25,1
+zte,atlas40,ZTE R22,5,-25,1
+zte,demeter,ZTE R83,5,-25,1
+zte,P816A20,ZTE R84,5,-25,1
+zte,P188F03,ZTE R880H,5,-25,1
+zte,roamer,ZTE Roamer,5,-25,1
+zte,P189S10,ZTE S118,5,-25,1
+zte,msm8226,ZTE S2002,5,-25,1
+zte,msm8974,ZTE S2004,5,-25,1
+zte,msm8974,ZTE S2005,5,-25,1
+zte,msm8974,ZTE S2007,5,-25,1
+zte,P_P653S10,ZTE S2010,5,-25,1
+zte,V_P653S10,ZTE S2010,5,-25,1
+zte,ZTE_S2010,ZTE S2010,5,-25,1
+zte,P653S10,ZTE S2010,5,-25,1
+zte,ZTE-S2014,ZTE S2014,5,-25,1
+zte,ZTE-S2015,ZTE S2015,5,-25,1
+zte,P541T50,ZTE S221,5,-25,1
+zte,msm8226,ZTE STAR,5,-25,1
+zte,skate,ZTE Skate,5,-25,1
+zte,P188F07,ZTE Skate 2,5,-25,1
+zte,msm8226,ZTE Star 1,5,-25,1
+zte,deepblue,ZTE Switch X1,5,-25,1
+zte,P173A30T,ZTE T12,5,-25,1
+zte,atlas40,ZTE T22,5,-25,1
+zte,P172R12,ZTE T220,5,-25,1
+zte,P731A20,ZTE T221,5,-25,1
+zte,P731A30,ZTE T230,5,-25,1
+zte,P731A20,ZTE T230,5,-25,1
+zte,bluetick,ZTE T28,5,-25,1
+zte,bluetick,ZTE T28 Prepaid,5,-25,1
+zte,P632A10,ZTE T311,5,-25,1
+zte,P731A10,ZTE T320,5,-25,1
+zte,ZTE_T325,ZTE T325,5,-25,1
+zte,P172A40,ZTE T520,5,-25,1
+zte,P809A01,ZTE T57,5,-25,1
+zte,turies,ZTE T60,5,-25,1
+zte,P809A20,ZTE T610,5,-25,1
+zte,ZTE_T617,ZTE T617,5,-25,1
+zte,ZTE_T620,ZTE T620,5,-25,1
+zte,P635T30,ZTE T630,5,-25,1
+zte,P635A20,ZTE T660,5,-25,1
+zte,P635A20,ZTE T663,5,-25,1
+zte,P173A10T,ZTE T760,5,-25,1
+zte,roamer2,ZTE T790,5,-25,1
+zte,ZTE-T792,ZTE T792,5,-25,1
+zte,msm8226,ZTE T80,5,-25,1
+zte,P172A10,ZTE T809,5,-25,1
+zte,iliamna,ZTE T81,5,-25,1
+zte,P172R10,ZTE T815,5,-25,1
+zte,P172R10,ZTE T816,5,-25,1
+zte,frosty,ZTE T82,5,-25,1
+zte,demeter,ZTE T83,5,-25,1
+zte,P816A20,ZTE T84,5,-25,1
+zte,msm8226,ZTE T86,5,-25,1
+zte,msm8226,ZTE T88,5,-25,1
+zte,P839F30,ZTE T911,5,-25,1
+zte,P839F30,ZTE T912,5,-25,1
+zte,ZTE_T920,ZTE T920,5,-25,1
+zte,enterprise,ZTE U5,5,-25,1
+zte,P188T51,ZTE U5S,5,-25,1
+zte,U788,ZTE U788,5,-25,1
+zte,z788,ZTE U788+,5,-25,1
+zte,U790,ZTE U790,5,-25,1
+zte,P810T01,ZTE U791,5,-25,1
+zte,P810T01,ZTE U791(OPEN),5,-25,1
+zte,P810T02,ZTE U793,5,-25,1
+zte,U795,ZTE U795,5,-25,1
+zte,z795,ZTE U795+,5,-25,1
+zte,P117A11,ZTE U807,5,-25,1
+zte,P117A13,ZTE U807N,5,-25,1
+zte,P825T10,ZTE U808,5,-25,1
+zte,P825T10,ZTE U808(OPEN),5,-25,1
+zte,P172T11,ZTE U809,5,-25,1
+zte,P988T20,ZTE U816,5,-25,1
+zte,P117A20,ZTE U817,5,-25,1
+zte,P117A20qHD,ZTE U817,5,-25,1
+zte,P172T21,ZTE U818,5,-25,1
+zte,P188T20,ZTE U819,5,-25,1
+zte,P172T30,ZTE U879,5,-25,1
+zte,U880E,ZTE U880E,5,-25,1
+zte,ventana_U880F,ZTE U880F,5,-25,1
+zte,U880F1,ZTE U880F1,5,-25,1
+zte,U880s,ZTE U880s,5,-25,1
+zte,P810A10,ZTE U880s2,5,-25,1
+zte,U885,ZTE U885,5,-25,1
+zte,P810A20,ZTE U887,5,-25,1
+zte,P183T30,ZTE U889,5,-25,1
+zte,U9180,ZTE U9180,5,-25,1
+zte,ventana_U930,ZTE U930,5,-25,1
+zte,U930HD,ZTE U930HD,5,-25,1
+zte,P117A30,ZTE U935,5,-25,1
+zte,enterprise_U950,ZTE U950,5,-25,1
+zte,P188T10,ZTE U956,5,-25,1
+zte,msm7630_zteu960,ZTE U960D,5,-25,1
+zte,P117T21,ZTE U960E,5,-25,1
+zte,U960s2,ZTE U960s2,5,-25,1
+zte,U960s3,ZTE U960s3,5,-25,1
+zte,P682T51,ZTE U968,5,-25,1
+zte,P682T50,ZTE U969,5,-25,1
+zte,ventana,ZTE U970,5,-25,1
+zte,P945T20,ZTE U9815,5,-25,1
+zte,enterprise_U985,ZTE U985,5,-25,1
+zte,pluto,ZTE U988S,5,-25,1
+zte,P653N11,ZTE V0721,5,-25,1
+zte,P817S01,ZTE V0840,5,-25,1
+zte,P450S10,ZTE V0900,5,-25,1
+zte,P840S03,ZTE V0920,5,-25,1
+zte,v9plus,ZTE V10,5,-25,1
+zte,P671S20,ZTE V1000,5,-25,1
+zte,P671S50,ZTE V1050,5,-25,1
+zte,P189F13,ZTE V5S,5,-25,1
+zte,V6700,ZTE V6700,5,-25,1
+zte,ZTE-V70,ZTE V70,5,-25,1
+zte,V7073,ZTE V7073,5,-25,1
+zte,V72,ZTE V72,5,-25,1
+zte,hct72_wet_jb3,ZTE V765M,5,-25,1
+zte,V768,ZTE V768,5,-25,1
+zte,P253A20,ZTE V768,5,-25,1
+zte,V769M,ZTE V769M,5,-25,1
+zte,ZTEV779M,ZTE V779M,5,-25,1
+zte,roamer2,ZTE V788D,5,-25,1
+zte,roamer2,ZTE V790,5,-25,1
+zte,P175A40,ZTE V791,5,-25,1
+zte,P810D01,ZTE V792C,5,-25,1
+zte,P175A60,ZTE V793,5,-25,1
+zte,P172D01,ZTE V795,5,-25,1
+zte,deepblue,ZTE V796,5,-25,1
+zte,P172D03,ZTE V797,5,-25,1
+zte,P177E01,ZTE V807,5,-25,1
+zte,P172E01,ZTE V808,5,-25,1
+zte,P172A10,ZTE V809,5,-25,1
+zte,P821E10,ZTE V811,5,-25,1
+zte,ZTE-V811,ZTE V811,5,-25,1
+zte,ZTE-P821E10,ZTE V811,5,-25,1
+zte,P810E01,ZTE V811C,5,-25,1
+zte,P821E10,ZTE V811W,5,-25,1
+zte,P172R12,ZTE V812,5,-25,1
+zte,P172B20,ZTE V813W,5,-25,1
+zte,P172R10,ZTE V815W,5,-25,1
+zte,P172R10,ZTE V816W,5,-25,1
+zte,ZTE-V817,ZTE V817,5,-25,1
+zte,ZTE-V956,ZTE V817,5,-25,1
+zte,P172F01,ZTE V818,5,-25,1
+zte,P172A30,ZTE V829,5,-25,1
+zte,P172F10,ZTE V830W,5,-25,1
+zte,P731A10,ZTE V831W,5,-25,1
+zte,sailboat,ZTE V875,5,-25,1
+zte,P172F02,ZTE V879,5,-25,1
+zte,blade,ZTE V880,5,-25,1
+zte,atlas40,ZTE V880E,5,-25,1
+zte,ZTE-V880G,ZTE V880G,5,-25,1
+zte,P188F03,ZTE V880H,5,-25,1
+zte,bladeplus,ZTE V881,5,-25,1
+zte,bladeplus,ZTE V882,5,-25,1
+zte,bladeplus,ZTE V886J,5,-25,1
+zte,P177A10,ZTE V887,5,-25,1
+zte,atlas40,ZTE V889D,5,-25,1
+zte,ZTE-V889F,ZTE V889F,5,-25,1
+zte,msm7627a,ZTE V889F,5,-25,1
+zte,P175A10,ZTE V889M,5,-25,1
+zte,P177E01,ZTE V889S,5,-25,1
+zte,sdm660_64,ZTE V890,5,-25,1
+zte,P986E01,ZTE V891,5,-25,1
+zte,okmok,ZTE V9500,5,-25,1
+zte,ZTE-V955,ZTE V955,5,-25,1
+zte,ZTE-V956,ZTE V956,5,-25,1
+zte,skate,ZTE V960,5,-25,1
+zte,P188F03,ZTE V965,5,-25,1
+zte,P188F07,ZTE V967S,5,-25,1
+zte,P682F06,ZTE V968,5,-25,1
+zte,P682F06,ZTE V969,5,-25,1
+zte,P682F01,ZTE V969,5,-25,1
+zte,whistler,ZTE V970,5,-25,1
+zte,P175A20,ZTE V970,5,-25,1
+zte,P175A20,ZTE V970M,5,-25,1
+zte,whistler,ZTE V970T,5,-25,1
+zte,redhookbay,ZTE V975,5,-25,1
+zte,roundtop,ZTE V9800,5,-25,1
+zte,kiska,ZTE V9800,5,-25,1
+zte,ZTE-V9820,ZTE V9820,5,-25,1
+zte,P177A30,ZTE V983,5,-25,1
+zte,enterprise_V985,ZTE V985,5,-25,1
+zte,P188F04,ZTE V987,5,-25,1
+zte,ZTE-V988,ZTE V988,5,-25,1
+zte,ZTE_V993W,ZTE V993W,5,-25,1
+zte,v9plus,ZTE V9A,5,-25,1
+zte,rolex,ZTE W1010,5,-25,1
+zte,mooncake,ZTE X850,5,-25,1
+zte,P817E52,ZTE Z10,5,-25,1
+zte,warplte,ZTE Z932L,5,-25,1
+zte,roamer,ZTE roamer,5,-25,1
+zte,blade,ZTE-BLADE,5,-25,1
+zte,P729C,ZTE-BLADE,5,-25,1
+zte,mooncake,ZTE-C N600,5,-25,1
+zte,mooncake,ZTE-C N600+,5,-25,1
+zte,roamer,ZTE-C N760,5,-25,1
+zte,banana,ZTE-C N780,5,-25,1
+zte,blade,ZTE-C N880S,5,-25,1
+zte,r750,ZTE-C R750,5,-25,1
+zte,X500MMB,ZTE-C X500,5,-25,1
+zte,P809K50,ZTE-K813,5,-25,1
+zte,blade,ZTE-LIBRA,5,-25,1
+zte,mooncake,ZTE-LINK,5,-25,1
+zte,P726G,ZTE-LINK,5,-25,1
+zte,blade,ZTE-Libra,5,-25,1
+zte,whistler,ZTE-Mimosa X,5,-25,1
+zte,arthur4g,ZTE-N910,5,-25,1
+zte,mooncake,ZTE-RACER,5,-25,1
+zte,BUL_P726G,ZTE-RACER,5,-25,1
+zte,P726G,ZTE-RACER,5,-25,1
+zte,skate,ZTE-SKATE,5,-25,1
+zte,skate,ZTE-Skate,5,-25,1
+zte,T9,ZTE-T T9,5,-25,1
+zte,cardhu,ZTE-T T98,5,-25,1
+zte,U805,ZTE-T U805,5,-25,1
+zte,U812,ZTE-T U812,5,-25,1
+zte,U830,ZTE-T U830,5,-25,1
+zte,U880,ZTE-T U880,5,-25,1
+zte,msm7630_zteu960,ZTE-T U960,5,-25,1
+zte,U960s,ZTE-T U960s,5,-25,1
+zte,turies,ZTE-Tureis,5,-25,1
+zte,N720,ZTE-U N720,5,-25,1
+zte,N721,ZTE-U N721,5,-25,1
+zte,ztenj73_gb,ZTE-U V760,5,-25,1
+zte,p173a10,ZTE-U V760,5,-25,1
+zte,mooncake,ZTE-U V852,5,-25,1
+zte,ztenj73_gb,ZTE-U V856,5,-25,1
+zte,zte_v857,ZTE-U V857,5,-25,1
+zte,ztenj73_gb,ZTE-U V857,5,-25,1
+zte,V857,ZTE-U V857,5,-25,1
+zte,racer2,ZTE-U V859,5,-25,1
+zte,V875m,ZTE-U V875m,5,-25,1
+zte,blade,ZTE-U V880,5,-25,1
+zte,bladeplus,ZTE-U V881,5,-25,1
+zte,ZTE-U-V889F,ZTE-U V889F,5,-25,1
+zte,msm7627a,ZTE-U V889F,5,-25,1
+zte,skate,ZTE-U V960,5,-25,1
+zte,P175A20,ZTE-U V970M,5,-25,1
+zte,mooncake,ZTE-U X850,5,-25,1
+zte,P726VV,ZTE-U X850,5,-25,1
+zte,P726CU,ZTE-U X850,5,-25,1
+zte,P722G,ZTE-U X876,5,-25,1
+zte,V6500,ZTE-V6500,5,-25,1
+zte,zte_v856,ZTE-V856,5,-25,1
+zte,P840F03,ZTE-V9VITA,5,-25,1
+zte,P726G,ZTE-WAVE,5,-25,1
+zte,X500,ZTE-X500,5,-25,1
+zte,roamer,ZTE-Z990,5,-25,1
+zte,roamer,ZTE-Z990G,5,-25,1
+zte,hct72_wet_jb3,ZTE_CLARO_Q1,5,-25,1
+zte,hct72_wet_jb3,ZTE_LEO_Q1,5,-25,1
+zte,hera,ZTE_N9511,5,-25,1
+zte,N720,ZTE_U N720,5,-25,1
+zte,N721,ZTE_U N721,5,-25,1
+zte,NE501J,ZTE_V5,5,-25,1
+zte,ZTE_V971LM,ZTE_V971LM,5,-25,1
+zte,ZTE_V97L,ZTE_V97L,5,-25,1
+zte,P852F52,ZTU31,5,-25,1
+zte,platy,ZW10,5,-25,1
+zte,N8300_CT,ZXY-ZTE N8300,5,-25,1
+zte,N8010_CT,ZXY-ZTE_N8010,5,-25,1
+zte,N8010_YM,ZXY-ZTE_N8010,5,-25,1
+zte,N8010_CT_BL,ZXY-ZTE_N8010,5,-25,1
+zte,V6700,ZXY-ZTE_V6700,5,-25,1
+zte,blade,a5,5,-25,1
+zte,P635A50,dtac phone M1,5,-25,1
+zte,P172A10,meo smart a12,5,-25,1
+zte,hct72_wet_jb3,mobifone M9001,5,-25,1
+zte,ztenj73_gb,moii E598,5,-25,1
+zte,v9plus,my Pad P3,5,-25,1
+zte,v9,myPad P2,5,-25,1
+zte,v9plus,myPad P3,5,-25,1
+zte,V72,myPad P4 Lite,5,-25,1
+zte,K78,myPad P5,5,-25,1
+zte,V9S,myPadP4,5,-25,1
+zte,NX501,nubia Z5,5,-25,1
+zte,P726N,soft stone,5,-25,1
+zte,P726N,soft-stone,5,-25,1
+zte,atlas40,tmn smart a15,5,-25,1
+zte,P175A20,tmn smart a18,5,-25,1
+zte,P177A10,tmn smart a20,5,-25,1
+zte,P175A60,tmn smart a6,5,-25,1
+zte,kiska,tmn smart a60,5,-25,1
+zte,sailboat,tmn smart a7,5,-25,1


### PR DESCRIPTION
Adds rssi/tx device list

- [x] find out how to handle that LineageOS, etc. `android.os.Build.MANUFACTURER/DEVICE/MODEL` differs from Verndor image.
- [x] update to current list


![shhhhh](https://user-images.githubusercontent.com/1891273/91646217-345b4700-ea4d-11ea-885e-5e78ae217593.png)

