### PR TITLE
Log (sensitive) information only on debug builds

### DIFF
--- a/sdk/src/main/java/org/coralibre/android/sdk/internal/TracingService.java
+++ b/sdk/src/main/java/org/coralibre/android/sdk/internal/TracingService.java
@@ -28,6 +28,7 @@ import androidx.core.app.NotificationCompat;
 
 import java.util.Collection;
 
+import org.coralibre.android.sdk.BuildConfig;
 import org.coralibre.android.sdk.PPCP;
 import org.coralibre.android.sdk.R;
 import org.coralibre.android.sdk.TracingStatus;
@@ -70,7 +71,9 @@ public class TracingService extends Service {
             if (BluetoothAdapter.ACTION_STATE_CHANGED.equals(intent.getAction())) {
                 int state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, -1);
                 if (state == BluetoothAdapter.STATE_OFF || state == BluetoothAdapter.STATE_ON) {
-                    Log.w(TAG, BluetoothAdapter.ACTION_STATE_CHANGED);
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, BluetoothAdapter.ACTION_STATE_CHANGED);
+                    }
                     BluetoothServiceStatus.resetInstance();
                     BroadcastHelper.sendErrorUpdateBroadcast(context);
                 }
@@ -82,7 +85,9 @@ public class TracingService extends Service {
         @Override
         public void onReceive(Context context, Intent intent) {
             if (LocationManager.MODE_CHANGED_ACTION.equals(intent.getAction())) {
-                Log.w(TAG, LocationManager.MODE_CHANGED_ACTION);
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, LocationManager.MODE_CHANGED_ACTION);
+                }
                 BroadcastHelper.sendErrorUpdateBroadcast(context);
             }
         }
@@ -108,7 +113,9 @@ public class TracingService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
-        Log.d(TAG, "onCreate()");
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "onCreate()");
+        }
 
         isFinishing = false;
 
@@ -142,7 +149,9 @@ public class TracingService extends Service {
             wl.acquire();
         }
 
-        Log.i(TAG, "onStartCommand() with " + intent.getAction());
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "onStartCommand() with " + intent.getAction());
+        }
 
         startAdvertising = intent.getBooleanExtra(EXTRA_ADVERTISE, true);
         startReceiving = intent.getBooleanExtra(EXTRA_RECEIVE, true);
@@ -318,7 +327,9 @@ public class TracingService extends Service {
     }
 
     private BluetoothState startClient() {
-        Log.d(TAG, "request to restart client");
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "request to restart client");
+        }
         stopClient();
 
         if (startReceiving) {
@@ -349,7 +360,9 @@ public class TracingService extends Service {
 
     @Override
     public void onDestroy() {
-        Log.i(TAG, "onDestroy()");
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "onDestroy()");
+        }
 
         unregisterReceiver(errorsUpdateReceiver);
         unregisterReceiver(bluetoothStateChangeReceiver);

--- a/sdk/src/main/java/org/coralibre/android/sdk/internal/TracingServiceBroadcastReceiver.java
+++ b/sdk/src/main/java/org/coralibre/android/sdk/internal/TracingServiceBroadcastReceiver.java
@@ -16,14 +16,18 @@ import android.util.Log;
 
 import androidx.core.content.ContextCompat;
 
+import org.coralibre.android.sdk.BuildConfig;
+
 
 public class TracingServiceBroadcastReceiver extends BroadcastReceiver {
 
-    public static final String TAG = "TS BroadcastReceiver";
+    public static final String TAG = "TS BroadcastReceiver"; // 23 chars is the maximum length
 
     @Override
     public void onReceive(Context context, Intent i) {
-        Log.d(TAG, "received broadcast to start service");
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "received broadcast to start service");
+        }
         Intent intent = new Intent(context, TracingService.class).setAction(i.getAction());
         intent.putExtra(TracingService.EXTRA_ADVERTISE, true);
         intent.putExtra(TracingService.EXTRA_RECEIVE, true);

--- a/sdk/src/main/java/org/coralibre/android/sdk/internal/bluetooth/BleClient.java
+++ b/sdk/src/main/java/org/coralibre/android/sdk/internal/bluetooth/BleClient.java
@@ -124,7 +124,9 @@ public class BleClient {
             @Override
             public void onBatchScanResults(List<ScanResult> results) {
                 bluetoothServiceStatus.updateScanStatus(BluetoothServiceStatus.SCAN_OK);
-                if (BuildConfig.DEBUG) Log.d(TAG, "Batch size " + results.size());
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Batch size " + results.size());
+                }
                 for (ScanResult result : results) {
                     onScanResult(0, result);
                 }
@@ -132,12 +134,15 @@ public class BleClient {
 
             public void onScanFailed(int errorCode) {
                 bluetoothServiceStatus.updateScanStatus(errorCode);
-                Log.e(TAG, "error: " + errorCode);
+                Log.e(TAG, "onScanFailed(), errorCode: " + errorCode);
             }
         };
 
         bleScanner.startScan(scanFilters, scanSettings, bleScanCallback);
-        Log.i(TAG, "started BLE scanner, scanMode: " + scanSettings.getScanMode() + " scanFilters: " + scanFilters.size());
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "started BLE scanner, scanMode: " + scanSettings.getScanMode()
+                    + " scanFilters: " + scanFilters.size());
+        }
 
         return BluetoothState.ENABLED;
     }
@@ -164,7 +169,7 @@ public class BleClient {
             // risk calculation later
             collectedData.add(new CollectedDatumInstance(payload, rssi, now));
         } catch (Exception e) {
-            Log.e(TAG, e.toString());
+            e.printStackTrace();
         }
     }
 
@@ -176,7 +181,9 @@ public class BleClient {
             return;
         }
         if (bleScanner != null) {
-            Log.i(TAG, "stopping BLE scanner");
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "stopping BLE scanner");
+            }
             bleScanner.stopScan(bleScanCallback);
             bleScanner = null;
         }

--- a/sdk/src/main/java/org/coralibre/android/sdk/internal/bluetooth/BleServer.java
+++ b/sdk/src/main/java/org/coralibre/android/sdk/internal/bluetooth/BleServer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 
 import java.util.UUID;
 
+import org.coralibre.android.sdk.BuildConfig;
 import org.coralibre.android.sdk.internal.AppConfigManager;
 import org.coralibre.android.sdk.internal.crypto.ppcp.AssociatedMetadata;
 import org.coralibre.android.sdk.internal.crypto.ppcp.CryptoModule;
@@ -51,13 +52,15 @@ public class BleServer {
 	private final AdvertiseCallback advertiseCallback = new AdvertiseCallback() {
 		@Override
 		public void onStartFailure(int errorCode) {
-			Log.e(TAG, "advertise onStartFailure: " + errorCode);
+			Log.e(TAG, "advertise onStartFailure(), errorCode: " + errorCode);
 			BluetoothServiceStatus.getInstance(context).updateAdvertiseStatus(errorCode);
 		}
 
 		@Override
 		public void onStartSuccess(AdvertiseSettings settingsInEffect) {
-			Log.i(TAG, "advertise onStartSuccess: " + settingsInEffect.toString());
+			if (BuildConfig.DEBUG) {
+				Log.d(TAG, "advertise onStartSuccess(), settingsInEffect: " + settingsInEffect.toString());
+			}
 			BluetoothServiceStatus.getInstance(context).updateAdvertiseStatus(BluetoothServiceStatus.ADVERTISE_OK);
 		}
 	};
@@ -126,8 +129,10 @@ public class BleServer {
 				.build();
 
 		mLeAdvertiser.startAdvertising(advSettings, advData, advertiseCallback);
-		Log.d(TAG, "started advertising (only advertiseData), powerLevel (CAUTION THIS IS A MOCK): "
-				+ ((int) mockTXPowerlevel));
+		if (BuildConfig.DEBUG) {
+			Log.d(TAG, "started advertising (only advertiseData),"
+					+ "powerLevel (CAUTION THIS IS A MOCK): " + ((int) mockTXPowerlevel));
+		}
 
 		return BluetoothState.ENABLED;
 	}


### PR DESCRIPTION
This PR wraps logging calls into `if (BuildConfig.DEBUG)` statements, since debug logs are unneded in release builds and so as to prevent disclosing sensitive information.

All calls to `Log.i` and `Log.w` were converted to `Log.d` and wrapped with the `if`, since they were used only for debugging. `Log.e(TAG, e.toString())` calls were converted to a `e.printStackTrace()`, as that provides more information. We should make sure, though, that the error messages in those exceptions do not reveal any sensitive information.

Fixes #37